### PR TITLE
Generate shorter and easier to type activation tokens

### DIFF
--- a/app/controllers/api/activations_controller.rb
+++ b/app/controllers/api/activations_controller.rb
@@ -2,7 +2,7 @@ class Api::ActivationsController < ApiController
   skip_before_action :authenticate_user!
 
   def create
-    activation_token = ActivationToken.find_by(value: params[:token])
+    activation_token = ActivationToken.find_by(value: params[:token].delete("-"))
     response = if activation_token.nil?
       { status: :failure, message: 'Invalid activation token' }
     elsif activation_token.used?

--- a/app/models/activation_token.rb
+++ b/app/models/activation_token.rb
@@ -30,7 +30,9 @@ class ActivationToken < ActiveRecord::Base
     self.client_id = SyncHelpers.client_id(device) if device && !self.client_id
   end
 
+  TOKEN_CHARS = ('0'..'9').to_a + ('A'..'Z').to_a
+
   def set_value
-    self.value = Guid.new.to_s unless self.value
+    self.value ||= TOKEN_CHARS.sample(16, random: Random.new).join
   end
 end

--- a/app/views/devices/_activation_token.haml
+++ b/app/views/devices/_activation_token.haml
@@ -1,5 +1,5 @@
 - if @device.activation_token
-  .key= @device.activation_token.value
+  .key= @device.activation_token.value.scan(/.{4}/).join("-")
   %p= barcode(@device.activation_token.value)
 - else
   = link_to 'Reactivate',

--- a/spec/controllers/api/activations_controller_spec.rb
+++ b/spec/controllers/api/activations_controller_spec.rb
@@ -15,6 +15,15 @@ describe Api::ActivationsController do
       it { expect(response_json['message']).to eq('Device activated') }
     end
 
+    context 'when token exists and device secret key is valid ignoring case and dashes' do
+      let!(:activation_token) { ActivationToken.make(value: 'AAAABBBB') }
+      before { post :create, { token: 'aaaa-bbbb', public_key: SampleSshKey }, format: :json  }
+      let(:response_json) { JSON.parse(response.body) }
+
+      it { expect(response_json['status']).to eq('success') }
+      it { expect(response_json['message']).to eq('Device activated') }
+    end
+
     context 'when token exists but device uuid does not match' do
       let!(:activation_token) { ActivationToken.make(value: '12345') }
       before { activation_token.device.tap(&:set_key).save }

--- a/spec/models/activation_token_spec.rb
+++ b/spec/models/activation_token_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 describe ActivationToken do
   let!(:device) { Device.make }
-  let!(:token) { ActivationToken.create!(device: device, value: 'foobar') }
+  let!(:token) { ActivationToken.create!(device: device) }
+
+  describe 'new' do
+    it 'generates the token value' do
+      expect(token.value).to match /[A-Z0-9]{16}/
+    end
+  end
 
   describe '#used?' do
     context 'when there is no activation' do


### PR DESCRIPTION
Activation tokens are generated to be something like: `A4FC-NQOB-VFYZ-6EKM`
Case and dashes are ignored during activation.