### PR TITLE
#412 edit encounters. fix test_result search

### DIFF
--- a/app/assets/javascripts/components/encounter_form.js.jsx
+++ b/app/assets/javascripts/components/encounter_form.js.jsx
@@ -1,0 +1,222 @@
+var EncounterForm = React.createClass({
+  getDefaultProps: function() {
+    return {
+      assayResultOptions: _.map(['positive', 'negative', 'indeterminate'], function(v){return {value: v, label: _.capitalize(v)};})
+    }
+  },
+
+  getInitialState: function() {
+    return {encounter: this.props.encounter};
+  },
+
+  save: function() {
+    var callback = function() {
+      window.location.href = '/encounters/' + this.state.encounter.id;
+    };
+
+    if (this.state.encounter.id) {
+      this._ajax('PUT', '/encounters/' + this.state.encounter.id, callback);
+    } else {
+      this._ajax('POST', '/encounters', callback);
+    }
+  },
+
+  showSamplesModal: function(event) {
+    this.refs.samplesModal.show()
+    event.preventDefault()
+  },
+
+  closeSamplesModal: function (event) {
+    this.refs.samplesModal.hide();
+    event.preventDefault();
+  },
+
+  _ajax_put: function(url, success) {
+    this._ajax('PUT', url, success);
+  },
+
+  _ajax: function(method, url, success) {
+    var _this = this;
+    $.ajax({
+      url: url,
+      method: method,
+      data: { encounter: JSON.stringify(this.state.encounter) },
+      success: function (data) {
+        if (data.status == 'error') {
+          alert(data.message); //TODO show errors nicely
+        }
+
+        _this.setState(React.addons.update(_this.state, {
+          encounter: { $set: data.encounter }
+        }), function(){
+          if (data.status == 'ok' && success) {
+            success.call(_this);
+          }
+        });
+      }
+    });
+  },
+
+  appendSample: function(sample) {
+    this.setState(React.addons.update(this.state, {
+      encounter : { samples : {
+        $push : [sample]
+      }}
+    }));
+    this.refs.samplesModal.hide()
+    this._ajax_put("/encounters/add/sample/" + sample.uuid);
+  },
+
+  showTestsModal: function(event) {
+    this.refs.testsModal.show()
+    event.preventDefault()
+  },
+
+  closeTestsModal: function(event) {
+    this.refs.testsModal.hide()
+    event.preventDefault()
+  },
+
+  appendTest: function(test) {
+    this.setState(React.addons.update(this.state, {
+      encounter : { test_results : {
+        $push : [test]
+      }}
+    }));
+    this.refs.testsModal.hide()
+    this._ajax_put("/encounters/add/test/" + test.uuid);
+  },
+
+  encounterChanged: function(field){
+    return function(event) {
+      var newValue = event.target.value;
+      this.setState(React.addons.update(this.state, {
+        encounter : { [field] : { $set : newValue } }
+      }));
+    }.bind(this);
+  },
+
+  encounterAssayChanged: function(index, field){
+    return function(event) {
+      var newValue;
+
+      if (field == 'result') {
+        newValue = event;
+      } else if (field == 'quantitative') {
+        newValue = parseInt(event.target.value)
+        if (isNaN(newValue)) {
+          newValue = null;
+        }
+      } else {
+        newValue = event.target.value;
+      }
+
+      this.setState(React.addons.update(this.state, {
+        encounter : { assays : { [index] : { [field] : { $set : newValue } } } }
+      }));
+    }.bind(this);
+  },
+
+  render: function() {
+    var institutionSelect = <InstitutionSelect onChange={this.setInstitution} url="/encounters/institutions"/>;
+
+    if (this.state.encounter.institution == null)
+      return (<div>{institutionSelect}</div>);
+
+    var diagnosisEditor = null;
+
+    if (this.state.encounter.assays.length > 0) {
+      diagnosisEditor = (
+        <div className="col assays-editor">
+          {this.state.encounter.assays.map(function(assay, index){
+            return (
+              <div className="row" key={index}>
+                <div className="col pe-4">
+                  <div className="underline">
+                    <span>{assay.condition.toUpperCase()}</span>
+                  </div>
+                </div>
+                <div className="col pe-3">
+                  <Select value={assay.result} options={this.props.assayResultOptions} onChange={this.encounterAssayChanged(index, 'result')} />
+                </div>
+                <div className="col pe-1">
+                  <input type="text" className="quantitative" value={assay.quantitative} placeholder="Quant." onChange={this.encounterAssayChanged(index, 'quantitative')} />
+                </div>
+              </div>
+            );
+          }.bind(this))}
+
+          <textarea value={this.state.encounter.observations} placeholder="Observations" onChange={this.encounterChanged('observations')} />
+        </div>);
+    } else {
+      diagnosisEditor = (
+        <div className="col">
+          <i>
+            <a href="#" onClick={this.showSamplesModal}>Add samples</a> or <a href="#" onClick={this.showTestsModal}>tests</a> to edit the diagnosis associated with the encounter
+          </i>
+        </div>);
+    }
+
+
+    return (
+      <div>
+        <FlexFullRow>
+          <PatientCard patient={this.state.encounter.patient} />
+        </FlexFullRow>
+
+        <div className="row">
+          <div className="col pe-2">
+            <label>Diagnosis</label>
+          </div>
+          {diagnosisEditor}
+        </div>
+
+        <div className="row">
+          <div className="col pe-2">
+            <label>Samples</label>
+            <p>
+              <a className="btn-add btn-add-secondary" href='#' onClick={this.showSamplesModal}>+</a>
+            </p>
+          </div>
+          <div className="col">
+            <SamplesList samples={this.state.encounter.samples} />
+          </div>
+          <Modal ref="samplesModal">
+            <h1>
+              <a href="#" className="modal-back" onClick={this.closeSamplesModal}><img src="/assets/arrow-left.png"/></a>
+              Add sample
+            </h1>
+
+            <AddItemSearch callback={"/encounters/search_sample?institution_uuid=" + this.state.encounter.institution.uuid} onItemChosen={this.appendSample}
+              itemTemplate={AddItemSearchSampleTemplate}
+              itemKey="uuid" />
+          </Modal>
+        </div>
+
+        <div className="row">
+          <div className="col">
+            <TestResultsList testResults={this.state.encounter.test_results} /><br/>
+            <a className="btn-add btn-add-secondary" href='#' onClick={this.showTestsModal}>+</a>
+          </div>
+
+          <Modal ref="testsModal">
+            <h1>
+              <a href="#" className="modal-back" onClick={this.closeTestsModal}><img src="/assets/arrow-left.png"/></a>
+              Add test
+            </h1>
+
+            <AddItemSearch callback={"/encounters/search_test?institution_uuid=" + this.state.encounter.institution.uuid} onItemChosen={this.appendTest}
+              itemTemplate={AddItemSearchTestResultTemplate}
+              itemKey="uuid" />
+          </Modal>
+        </div>
+
+        <FlexFullRow>
+          <button type="button" className="btn-primary" onClick={this.save}>Save</button>
+        </FlexFullRow>
+
+      </div>
+    );
+  },
+
+});

--- a/app/assets/javascripts/components/encounter_new.js.jsx
+++ b/app/assets/javascripts/components/encounter_new.js.jsx
@@ -1,10 +1,4 @@
 var EncounterNew = React.createClass({
-  getDefaultProps: function() {
-    return {
-      assayResultOptions: _.map(['positive', 'negative', 'indeterminate'], function(v){return {value: v, label: _.capitalize(v)};})
-    }
-  },
-
   getInitialState: function() {
     return {encounter: {
       institution: null,
@@ -29,207 +23,17 @@ var EncounterNew = React.createClass({
     }));
   },
 
-  save: function() {
-    this._ajax('POST', '/encounters', function() {
-      window.location.href = '/encounters/' + this.state.encounter.id;
-    });
-  },
-
-  showSamplesModal: function(event) {
-    this.refs.samplesModal.show()
-    event.preventDefault()
-  },
-
-  closeSamplesModal: function (event) {
-    this.refs.samplesModal.hide();
-    event.preventDefault();
-  },
-
-  _ajax_put: function(url, success) {
-    this._ajax('PUT', url, success);
-  },
-
-  _ajax: function(method, url, success) {
-    var _this = this;
-    $.ajax({
-      url: url,
-      method: method,
-      data: { encounter: JSON.stringify(this.state.encounter) },
-      success: function (data) {
-        if (data.status == 'error') {
-          alert(data.message); //TODO show errors nicely
-        }
-
-        _this.setState(React.addons.update(_this.state, {
-          encounter: { $set: data.encounter }
-        }), function(){
-          if (data.status == 'ok' && success) {
-            success.call(_this);
-          }
-        });
-      }
-    });
-  },
-
-  appendSample: function(sample) {
-    this.setState(React.addons.update(this.state, {
-      encounter : { samples : {
-        $push : [sample]
-      }}
-    }));
-    this.refs.samplesModal.hide()
-    this._ajax_put("/encounters/new/sample/" + sample.uuid);
-  },
-
-  showTestsModal: function(event) {
-    this.refs.testsModal.show()
-    event.preventDefault()
-  },
-
-  closeTestsModal: function(event) {
-    this.refs.testsModal.hide()
-    event.preventDefault()
-  },
-
-  appendTest: function(test) {
-    this.setState(React.addons.update(this.state, {
-      encounter : { test_results : {
-        $push : [test]
-      }}
-    }));
-    this.refs.testsModal.hide()
-    this._ajax_put("/encounters/new/test/" + test.uuid);
-  },
-
-  encounterChanged: function(field){
-    return function(event) {
-      var newValue = event.target.value;
-      this.setState(React.addons.update(this.state, {
-        encounter : { [field] : { $set : newValue } }
-      }));
-    }.bind(this);
-  },
-
-  encounterAssayChanged: function(index, field){
-    return function(event) {
-      var newValue;
-
-      if (field == 'result') {
-        newValue = event;
-      } else if (field == 'quantitative') {
-        newValue = parseInt(event.target.value)
-        if (isNaN(newValue)) {
-          newValue = null;
-        }
-      } else {
-        newValue = event.target.value;
-      }
-
-      this.setState(React.addons.update(this.state, {
-        encounter : { assays : { [index] : { [field] : { $set : newValue } } } }
-      }));
-    }.bind(this);
-  },
-
   render: function() {
     var institutionSelect = <InstitutionSelect onChange={this.setInstitution} url="/encounters/institutions"/>;
 
     if (this.state.encounter.institution == null)
       return (<div>{institutionSelect}</div>);
 
-    var diagnosisEditor = null;
-
-    if (this.state.encounter.assays.length > 0) {
-      diagnosisEditor = (
-        <div className="col assays-editor">
-          {this.state.encounter.assays.map(function(assay, index){
-            return (
-              <div className="row" key={index}>
-                <div className="col pe-4">
-                  <div className="underline">
-                    <span>{assay.condition.toUpperCase()}</span>
-                  </div>
-                </div>
-                <div className="col pe-3">
-                  <Select value={assay.result} options={this.props.assayResultOptions} onChange={this.encounterAssayChanged(index, 'result')} />
-                </div>
-                <div className="col pe-1">
-                  <input type="text" className="quantitative" value={assay.quantitative} placeholder="Quant." onChange={this.encounterAssayChanged(index, 'quantitative')} />
-                </div>
-              </div>
-            );
-          }.bind(this))}
-
-          <textarea value={this.state.encounter.observations} placeholder="Observations" onChange={this.encounterChanged('observations')} />
-        </div>);
-    } else {
-      diagnosisEditor = (
-        <div className="col">
-          <i>
-            <a href="#" onClick={this.showSamplesModal}>Add samples</a> or <a href="#" onClick={this.showTestsModal}>tests</a> to edit the diagnosis associated with the encounter
-          </i>
-        </div>);
-    }
-
-
     return (
       <div>
         {institutionSelect}
-        <FlexFullRow>
-          <PatientCard patient={this.state.encounter.patient} />
-        </FlexFullRow>
 
-        <div className="row">
-          <div className="col pe-2">
-            <label>Diagnosis</label>
-          </div>
-          {diagnosisEditor}
-        </div>
-
-        <div className="row">
-          <div className="col pe-2">
-            <label>Samples</label>
-            <p>
-              <a className="btn-add btn-add-secondary" href='#' onClick={this.showSamplesModal}>+</a>
-            </p>
-          </div>
-          <div className="col">
-            <SamplesList samples={this.state.encounter.samples} />
-          </div>
-          <Modal ref="samplesModal">
-            <h1>
-              <a href="#" className="modal-back" onClick={this.closeSamplesModal}><img src="/assets/arrow-left.png"/></a>
-              Add sample
-            </h1>
-
-            <AddItemSearch callback={"/encounters/search_sample?institution_uuid=" + this.state.encounter.institution.uuid} onItemChosen={this.appendSample}
-              itemTemplate={AddItemSearchSampleTemplate}
-              itemKey="uuid" />
-          </Modal>
-        </div>
-
-        <div className="row">
-          <div className="col">
-            <TestResultsList testResults={this.state.encounter.test_results} /><br/>
-            <a className="btn-add btn-add-secondary" href='#' onClick={this.showTestsModal}>+</a>
-          </div>
-
-          <Modal ref="testsModal">
-            <h1>
-              <a href="#" className="modal-back" onClick={this.closeTestsModal}><img src="/assets/arrow-left.png"/></a>
-              Add test
-            </h1>
-
-            <AddItemSearch callback="/encounters/search_test" onItemChosen={this.appendTest}
-              itemTemplate={AddItemSearchTestResultTemplate}
-              itemKey="uuid" />
-          </Modal>
-        </div>
-
-        <FlexFullRow>
-          <button type="button" className="btn-primary" onClick={this.save}>Save</button>
-        </FlexFullRow>
-
+        <EncounterForm encounter={this.state.encounter} />
       </div>
     );
   },

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -22,11 +22,8 @@ class EncountersController < ApplicationController
   def show
     @encounter = Encounter.find(params[:id])
     return unless authorize_resource(@encounter, READ_ENCOUNTER)
-    if Policy.can?(UPDATE_ENCOUNTER, @encounter, current_user, @current_user_policies) && params[:mode] != 'show'
-      redirect_to edit_encounter_path(@encounter)
-      return
-    end
     @encounter_as_json = as_json_edit(@encounter).attributes!
+    @can_update = has_access?(@encounter, UPDATE_ENCOUNTER)
   end
 
   def edit

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -22,7 +22,7 @@ class EncountersController < ApplicationController
   def show
     @encounter = Encounter.find(params[:id])
     return unless authorize_resource(@encounter, READ_ENCOUNTER)
-    if Policy.can?(UPDATE_ENCOUNTER, @encounter, current_user, @current_user_policies)
+    if Policy.can?(UPDATE_ENCOUNTER, @encounter, current_user, @current_user_policies) && params[:mode] != 'show'
       redirect_to edit_encounter_path(@encounter)
       return
     end
@@ -33,6 +33,15 @@ class EncountersController < ApplicationController
     @encounter = Encounter.find(params[:id])
     return unless authorize_resource(@encounter, UPDATE_ENCOUNTER)
     @encounter_as_json = as_json_edit(@encounter).attributes!
+  end
+
+  def update
+    perform_encounter_action do
+      prepare_encounter_from_json
+      return unless authorize_resource(@encounter, UPDATE_ENCOUNTER)
+      raise "encounter.id does not match" if params[:id].to_i != @encounter.id
+      @encounter.save!
+    end
   end
 
   def search_sample
@@ -82,11 +91,16 @@ class EncountersController < ApplicationController
   end
 
   def prepare_encounter_from_json
-    @encounter = Encounter.new
-
     encounter_param = JSON.parse(params[:encounter])
-    @institution = institution_by_uuid(encounter_param['institution']['uuid'])
-    @encounter.institution = @institution
+    @encounter = encounter_param['id'] ? Encounter.find(encounter_param['id']) : Encounter.new
+
+    if @encounter.new_record?
+      @institution = institution_by_uuid(encounter_param['institution']['uuid'])
+      @encounter.institution = @institution
+    else
+      @institution = @encounter.institution
+    end
+
     encounter_param['samples'].each do |sample_param|
       add_sample_by_uuid sample_param['uuid']
     end

--- a/app/views/encounters/edit.html.haml
+++ b/app/views/encounters/edit.html.haml
@@ -5,4 +5,4 @@
         = image_tag "arrow-left.png"
       Encounter
 
-= react_component('EncounterShow', encounter: @encounter_as_json)
+= react_component('EncounterForm', encounter: @encounter_as_json)

--- a/app/views/encounters/show.html.haml
+++ b/app/views/encounters/show.html.haml
@@ -6,3 +6,8 @@
       Encounter
 
 = react_component('EncounterShow', encounter: @encounter_as_json)
+
+- if @can_update
+  .row
+    .col
+      = link_to 'Edit', edit_encounter_path(@encounter), class: 'btn-primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,13 +21,13 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :encounters, only: [:new, :create, :edit, :show] do
+  resources :encounters, only: [:new, :create, :edit, :update, :show] do
     collection do
       get :institutions
       get :search_sample
       get :search_test
-      put 'new/sample/:sample_uuid' => 'encounters#add_sample'
-      put 'new/test/:test_uuid' => 'encounters#add_test'
+      put 'add/sample/:sample_uuid' => 'encounters#add_sample'
+      put 'add/test/:test_uuid' => 'encounters#add_test'
     end
   end
   resources :locations, only: [:index, :show]

--- a/spec/controllers/encounters_controller_spec.rb
+++ b/spec/controllers/encounters_controller_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe EncountersController, type: :controller do
       encounter = Encounter.make institution: i1
       get :show, id: encounter.id
       expect(response).to have_http_status(:success)
+
+      expect(assigns[:can_update]).to be_falsy
     end
 
     it "returns http forbidden if not allowed" do
@@ -42,7 +44,8 @@ RSpec.describe EncountersController, type: :controller do
       encounter = Encounter.make institution: i1
       get :show, id: encounter.id
 
-      expect(response).to redirect_to(edit_encounter_path(encounter))
+      expect(response).to have_http_status(:success)
+      expect(assigns[:can_update]).to be_truthy
     end
   end
 

--- a/spec/controllers/encounters_controller_spec.rb
+++ b/spec/controllers/encounters_controller_spec.rb
@@ -132,6 +132,57 @@ RSpec.describe EncountersController, type: :controller do
     end
   end
 
+  describe "PUT update" do
+    let(:encounter) { Encounter.make institution: institution }
+
+    let(:sample) {
+      device = Device.make institution: institution
+      DeviceMessage.create_and_process device: device, plain_text_data: Oj.dump(test:{assays:[condition: "flu_a"]}, sample: {id: 'a'}, patient: {id: 'a'})
+      Sample.first
+    }
+
+    before(:each) {
+      put :update, id: encounter.id, encounter: {
+        id: encounter.id,
+        institution: { uuid: 'uuid-to-discard' },
+        samples: [{ uuid: sample.uuid }],
+        test_results: [],
+        assays: [{condition: 'mtb', result: 'positive', quantitative: 3}],
+        observations: 'Lorem ipsum',
+      }.to_json
+
+      sample.reload
+
+      encounter.reload
+    }
+
+    let(:json_response) { JSON.parse(response.body) }
+
+    it "succeed" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns samples" do
+      expect(sample.encounter).to eq(encounter)
+    end
+
+    it "assigns assays" do
+      expect(encounter.core_fields[Encounter::ASSAYS_FIELD]).to eq([{'condition' => 'mtb', 'result' => 'positive', 'quantitative' => 3}])
+    end
+
+    it "assigns observations" do
+      expect(encounter.core_fields[Encounter::OBSERVATIONS_FIELD]).to eq('Lorem ipsum')
+    end
+
+    it "assigns returns a json status ok" do
+      expect(json_response['status']).to eq('ok')
+    end
+
+    it "assigns returns a json status ok" do
+      expect(json_response['encounter']['id']).to eq(encounter.id)
+    end
+  end
+
   describe "GET #search_sample" do
     it "returns sample by entity id" do
       device = Device.make institution: institution
@@ -320,6 +371,30 @@ RSpec.describe EncountersController, type: :controller do
       expect(json_response['encounter']['samples'].count).to eq(1)
     end
 
+    it "can use existing encounter to add sample" do
+      encounter = Encounter.make institution: institution
+      device = Device.make institution: institution
+      DeviceMessage.create_and_process device: device, plain_text_data: Oj.dump(test:{assays:[condition: "flu_a"]}, sample: {id: 'a'})
+      DeviceMessage.create_and_process device: device, plain_text_data: Oj.dump(test:{assays:[condition: "flu_a"]}, sample: {id: 'b'})
+      sample_a, sample_b = Sample.all.to_a
+      encounter.add_sample_uniq sample_a
+      encounter.save!
+
+      put :add_sample, sample_uuid: sample_b.uuid, encounter: {
+        id: encounter.id,
+        institution: { uuid: institution.uuid },
+        samples: [{uuid: sample_a.uuid}],
+        test_results: [],
+      }.to_json
+
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body).with_indifferent_access
+
+      expect(json_response['status']).to eq('ok')
+      expect(json_response['encounter']['samples'].count).to eq(2)
+      expect(json_response['encounter']['samples'][0]).to include(sample_json(sample_a))
+      expect(json_response['encounter']['samples'][1]).to include(sample_json(sample_b))
+    end
   end
 
   describe "PUT #add_test" do


### PR DESCRIPTION
Refactor EncounterNew component to a EncounterForm component in order to allow edition and creation of encounters.

Fix test_results lookup (missing instituion_uuid param)

Since `GET encounter/:id` redirects to `GET encounter/:id/edit` if the user can edit it, a `GET encounter/:id?mode=show` will skip the redirection mainly for development issues.  