### PR TITLE
Fixes #394

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -19,6 +19,7 @@ class SitesController < ApplicationController
 
   def new
     @site = Site.new
+    @sites = check_access(Site, READ_SITE)
     prepare_for_institution_and_authorize(@site, CREATE_INSTITUTION_SITE)
   end
 
@@ -112,6 +113,6 @@ class SitesController < ApplicationController
     location_details = Location.details(params[:site][:location_geoid]).first
     params[:site][:lat] = location_details.lat
     params[:site][:lng] = location_details.lng
-    params.require(:site).permit(:name, :address, :city, :state, :zip_code, :country, :region, :lat, :lng, :location_geoid)
+    params.require(:site).permit(:name, :address, :city, :state, :zip_code, :country, :region, :lat, :lng, :location_geoid, :parent_id)
   end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -103,6 +103,14 @@ class SitesController < ApplicationController
     render layout: false
   end
 
+  def dependencies
+    site = Site.find(params[:id])
+    @sites = check_access(site.children, READ_SITE)
+    @sites_to_edit = check_access(site.children, UPDATE_SITE).pluck(:id)
+
+    render layout: false
+  end
+
   private
 
   def load_institutions

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -28,6 +28,7 @@ class Device < ActiveRecord::Base
   validate :unpublished_device_model_from_institution
 
   before_create :set_uuid
+  before_save :set_site_prefix
 
   delegate :current_manifest, to: :device_model
 
@@ -90,6 +91,10 @@ class Device < ActiveRecord::Base
 
   def set_uuid
     self.uuid = MessageEncryption.secure_random(9)
+  end
+
+  def set_site_prefix
+    self.site_prefix = site.try(:prefix)
   end
 
   def new_activation_token

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -7,6 +7,7 @@ class Site < ActiveRecord::Base
   has_many :devices
   has_many :test_results, through: :devices
   belongs_to :parent, class_name: "Site"
+  has_many :children, class_name: "Site", foreign_key: "parent_id"
 
   validates_presence_of :institution
   validates_presence_of :name

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -6,9 +6,12 @@ class Site < ActiveRecord::Base
   has_one :user, through: :institution
   has_many :devices
   has_many :test_results, through: :devices
+  belongs_to :parent, class_name: "Site"
 
   validates_presence_of :institution
   validates_presence_of :name
+
+  after_create :compute_prefix
 
   attr_writer :location
 
@@ -56,5 +59,16 @@ class Site < ActiveRecord::Base
 
   def to_s
     name
+  end
+
+  private
+
+  def compute_prefix
+    if parent
+      self.prefix = "#{parent.prefix}.#{id}"
+    else
+      self.prefix = id.to_s
+    end
+    self.save!
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -58,6 +58,10 @@ class Site < ActiveRecord::Base
     end
   end
 
+  def path
+    prefix.split(".")
+  end
+
   def to_s
     name
   end
@@ -70,9 +74,9 @@ class Site < ActiveRecord::Base
 
   def compute_prefix
     if parent
-      self.prefix = "#{parent.prefix}.#{id}"
+      self.prefix = "#{parent.prefix}.#{uuid}"
     else
-      self.prefix = id.to_s
+      self.prefix = uuid
     end
     self.save!
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -61,6 +61,10 @@ class Site < ActiveRecord::Base
     name
   end
 
+  def self.prefix(id)
+    Site.find(id).prefix
+  end
+
   private
 
   def compute_prefix

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -83,5 +83,6 @@ class TestResult < ActiveRecord::Base
   def set_foreign_keys
     self.site_id = device.try(:site_id)
     self.institution_id = device.try(:institution_id)
+    self.site_prefix = device.try(:site).try(:prefix)
   end
 end

--- a/app/models/test_result_indexer.rb
+++ b/app/models/test_result_indexer.rb
@@ -49,6 +49,7 @@ class TestResultIndexer
     site = device.site
     site_uuid = site.try &:uuid
     site_name = site.try &:name
+    site_path = site.try(&:path)
 
     location = site.try &:location
     location_id = location.try(:geo_id)
@@ -82,7 +83,8 @@ class TestResultIndexer
           "uuid" => device.institution.uuid
         },
         "site" => {
-          "uuid" => site_uuid
+          "uuid" => site_uuid,
+          "path" => site_path,
         }
       }).
       deep_merge(core_fields_from(test_result.sample)).

--- a/app/models/test_result_query.rb
+++ b/app/models/test_result_query.rb
@@ -68,7 +68,7 @@ class TestResultQuery < Cdx::Api::Elasticsearch::Query
 
   def conditions_for(computed_policy, preloaded_uuids)
     Hash[computed_policy.conditions.map do |field, value|
-      ["#{field}.uuid", preloaded_uuids[field][value]] unless value.nil?
+      ["#{field}.uuid", preloaded_uuids[field][value.to_i]] unless value.nil?
     end.compact]
   end
 
@@ -76,7 +76,7 @@ class TestResultQuery < Cdx::Api::Elasticsearch::Query
     resource_ids = Hash.new { |h,k| h[k] = Set.new }
     (policies + policies.map(&:exceptions).flatten).each do |policy|
       policy.conditions.each do |field, value|
-        resource_ids[field] << value
+        resource_ids[field] << value.to_i
       end
     end
 

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -18,6 +18,18 @@
       = f.label :location_geoid, "Location"
     .col
       = f.hidden_field :location_geoid, class: 'input-large'
+  - if @site.new_record?
+    .row
+      .col.pe-2
+        = f.label :parent_id, "Supervisor"
+      .col
+        = f.collection_select(:parent_id, @sites, :id, :name, {include_blank: "Choose one"}, class: 'ddown')
+  - elsif @site.parent
+    .row
+      .col.pe-2
+        = f.label :parent_id, "Supervisor"
+      .col
+        = @site.parent.name
 
   .row.button-actions
     .col

--- a/app/views/sites/dependencies.html.haml
+++ b/app/views/sites/dependencies.html.haml
@@ -1,0 +1,13 @@
+- if @sites.empty?
+  %span This site has no dependencies yet
+- else
+  = cdx_table title: 'Dependencies' do |t|
+    - t.thead do
+      %tr
+        %th Name
+        %th Location
+    - t.tbody do
+      - @sites.each do |site|
+        %tr{data: (@sites_to_edit.include?(site.id) ? {href: site_path(site) } : {})}
+          %td= site.name
+          %td= site.location.try(&:name)

--- a/app/views/sites/show.html.haml
+++ b/app/views/sites/show.html.haml
@@ -8,6 +8,9 @@
     = card image: map_url(@site.lat, @site.lng) do |c|
       - c.top do
         %b= @site.name
+        - if parent = @site.parent
+          %div
+            Site under #{link_to parent.name, site_path(parent)}
       - if @can_edit
         - c.actions do
           = link_to edit_site_path(@site), :title => 'Edit' do
@@ -20,3 +23,4 @@
     = cdx_tabs do |t|
       - t.tab title: 'Devices', url: devices_site_path(@site)
       - t.tab title: 'Tests', url: tests_site_path(@site)
+      - t.tab title: 'Dependencies', url: dependencies_site_path(@site)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     member do
       get :devices
       get :tests
+      get :dependencies
     end
   end
 

--- a/db/migrate/20151019202219_add_parent_id_and_prefix_to_sites.rb
+++ b/db/migrate/20151019202219_add_parent_id_and_prefix_to_sites.rb
@@ -1,0 +1,6 @@
+class AddParentIdAndPrefixToSites < ActiveRecord::Migration
+  def change
+    add_column :sites, :parent_id, :integer
+    add_column :sites, :prefix, :string
+  end
+end

--- a/db/migrate/20151020173442_change_resource_id_and_condition_site_id_to_string_in_computed_policies.rb
+++ b/db/migrate/20151020173442_change_resource_id_and_condition_site_id_to_string_in_computed_policies.rb
@@ -1,0 +1,6 @@
+class ChangeResourceIdAndConditionSiteIdToStringInComputedPolicies < ActiveRecord::Migration
+  def change
+    change_column :computed_policies, :resource_id, :string
+    change_column :computed_policies, :condition_site_id, :string
+  end
+end

--- a/db/migrate/20151026185300_change_resource_id_and_condition_site_id_to_string_in_computed_policy_exceptions.rb
+++ b/db/migrate/20151026185300_change_resource_id_and_condition_site_id_to_string_in_computed_policy_exceptions.rb
@@ -1,0 +1,6 @@
+class ChangeResourceIdAndConditionSiteIdToStringInComputedPolicyExceptions < ActiveRecord::Migration
+  def change
+    change_column :computed_policy_exceptions, :resource_id, :string
+    change_column :computed_policy_exceptions, :condition_site_id, :string
+  end
+end

--- a/db/migrate/20151026193558_add_site_prefix_to_devices_and_test_results.rb
+++ b/db/migrate/20151026193558_add_site_prefix_to_devices_and_test_results.rb
@@ -1,0 +1,6 @@
+class AddSitePrefixToDevicesAndTestResults < ActiveRecord::Migration
+  def change
+    add_column :devices, :site_prefix, :string
+    add_column :test_results, :site_prefix, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151019174509) do
+ActiveRecord::Schema.define(version: 20151026193558) do
 
   create_table "activation_tokens", force: :cascade do |t|
     t.string   "value",      limit: 255
@@ -36,9 +36,9 @@ ActiveRecord::Schema.define(version: 20151019174509) do
     t.integer "user_id",                  limit: 4
     t.string  "action",                   limit: 255
     t.string  "resource_type",            limit: 255
-    t.integer "resource_id",              limit: 4
+    t.string  "resource_id",              limit: 255
     t.integer "condition_institution_id", limit: 4
-    t.integer "condition_site_id",        limit: 4
+    t.string  "condition_site_id",        limit: 255
     t.boolean "delegable",                            default: false
     t.integer "condition_device_id",      limit: 4
   end
@@ -47,9 +47,9 @@ ActiveRecord::Schema.define(version: 20151019174509) do
     t.integer "computed_policy_id",       limit: 4
     t.string  "action",                   limit: 255
     t.string  "resource_type",            limit: 255
-    t.integer "resource_id",              limit: 4
+    t.string  "resource_id",              limit: 255
     t.integer "condition_institution_id", limit: 4
-    t.integer "condition_site_id",        limit: 4
+    t.string  "condition_site_id",        limit: 255
     t.integer "condition_device_id",      limit: 4
   end
 
@@ -104,8 +104,8 @@ ActiveRecord::Schema.define(version: 20151019174509) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "institution_id",      limit: 4
-    t.boolean  "supports_activation"
     t.datetime "published_at"
+    t.boolean  "supports_activation"
   end
 
   add_index "device_models", ["published_at"], name: "index_device_models_on_published_at", using: :btree
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 20151019174509) do
     t.text     "custom_mappings", limit: 65535
     t.integer  "site_id",         limit: 4
     t.string   "serial_number",   limit: 255
+    t.string   "site_prefix",     limit: 255
   end
 
   create_table "encounters", force: :cascade do |t|
@@ -245,6 +246,8 @@ ActiveRecord::Schema.define(version: 20151019174509) do
     t.datetime "updated_at"
     t.string   "location_geoid", limit: 60
     t.string   "uuid",           limit: 255
+    t.integer  "parent_id",      limit: 4
+    t.string   "prefix",         limit: 255
   end
 
   create_table "ssh_keys", force: :cascade do |t|
@@ -285,6 +288,7 @@ ActiveRecord::Schema.define(version: 20151019174509) do
     t.integer  "encounter_id",         limit: 4
     t.integer  "site_id",              limit: 4
     t.integer  "institution_id",       limit: 4
+    t.string   "site_prefix",          limit: 255
     t.integer  "sample_identifier_id", limit: 4
   end
 

--- a/deps/cdx_core/lib/config/fields.yml
+++ b/deps/cdx_core/lib/config/fields.yml
@@ -89,6 +89,8 @@ site:
     uuid:
       searchable: true
     name:
+    path:
+      searchable: true
 patient:
   allows_custom: true
   fields:

--- a/spec/models/cdx_api_elasticsearch_mapping_template_spec.rb
+++ b/spec/models/cdx_api_elasticsearch_mapping_template_spec.rb
@@ -179,6 +179,10 @@ describe "Cdx::Api::Elasticsearch::MappingTemplate" do
               "uuid" => {
                 "type" => "string",
                 "index" => "not_analyzed"
+              },
+              "path" => {
+                "type" => "string",
+                "index" => "not_analyzed"
               }
             }
           },

--- a/spec/models/cdx_spec.rb
+++ b/spec/models/cdx_spec.rb
@@ -12,6 +12,7 @@ describe Cdx do
       "institution.name",
       "site.uuid",
       "site.name",
+      "site.path",
       "location.admin_levels",
       "location.id",
       "location.lat",

--- a/spec/models/computed_policy_spec.rb
+++ b/spec/models/computed_policy_spec.rb
@@ -27,7 +27,7 @@ describe ComputedPolicy do
         expect(p.user).to eq(user)
         expect(p.action).to eq(READ_DEVICE)
         expect(p.resource_type).to eq('device')
-        expect(p.resource_id).to eq(device.id)
+        expect(p.resource_id).to eq(device.id.to_s)
         expect(p.condition_institution_id).to be_nil
         expect(p.condition_site_id).to be_nil
       end
@@ -92,7 +92,7 @@ describe ComputedPolicy do
       }.to change(user.computed_policies(:reload), :count).by(1)
 
       user.computed_policies.first.tap do |p|
-        expect(p.condition_site_id).to eq(device.site.id)
+        expect(p.condition_site_id).to eq(device.site.id.to_s)
       end
     end
 
@@ -124,7 +124,7 @@ describe ComputedPolicy do
         grant granter, user, Device, [READ_DEVICE]
       }.to change(user.computed_policies(:reload), :count).by(2)
 
-      expect(user.computed_policies.map(&:resource_id)).to match_array([device.id, device2.id])
+      expect(user.computed_policies.map(&:resource_id)).to match_array([device.id, device2.id].map(&:to_s))
     end
 
     it "should create intersection from delegable resources" do
@@ -135,7 +135,7 @@ describe ComputedPolicy do
         grant granter, user, Device, [READ_DEVICE]
       }.to change(user.computed_policies(:reload), :count).by(1)
 
-      expect(user.computed_policies.first.resource_id).to eq(device.id)
+      expect(user.computed_policies.first.resource_id).to eq(device.id.to_s)
     end
 
     it "should create intersection from resources with conditions" do
@@ -146,7 +146,7 @@ describe ComputedPolicy do
       }.to change(user.computed_policies(:reload), :count).by(1)
 
       user.computed_policies.first.tap do |p|
-        expect(p.condition_site_id).to eq(device.site.id)
+        expect(p.condition_site_id).to eq(device.site.id.to_s)
         expect(p.condition_institution_id).to eq(device.institution.id)
       end
     end
@@ -203,10 +203,10 @@ describe ComputedPolicy do
 
       p1, p2 = user.computed_policies(:reload).order(:id).all
 
-      expect(p1.resource_id).to eq(device.id)
+      expect(p1.resource_id).to eq(device.id.to_s)
       expect(p1.delegable).to be_truthy
 
-      expect(p2.resource_id).to eq(device2.id)
+      expect(p2.resource_id).to eq(device2.id.to_s)
       expect(p2.delegable).to be_falsey
     end
 
@@ -466,6 +466,78 @@ describe ComputedPolicy do
       expect(devices).to      match_array(Device.all)
     end
 
+  end
+
+  context "sites" do
+    let!(:site1) { Site.make }
+    let!(:site11) { Site.make parent_id: site1.id }
+    let!(:site111) { Site.make parent_id: site11.id }
+
+    let!(:device1) { Device.make site_id: site1.id }
+    let!(:device11) { Device.make site_id: site11.id }
+
+    let!(:granter)  { User.make }
+    let!(:granter2) { User.make }
+
+    it "grants access to same site" do
+      grant nil, granter, site1, [READ_SITE]
+
+      expect {
+        grant granter, granter2, site1, READ_SITE
+      }.to change(granter2.computed_policies(:reload), :count).by(1)
+
+      expect(granter2).to have(1).computed_policies
+      p = granter2.computed_policies.first
+      expect(p.resource_id).to eq(site1.prefix)
+    end
+
+    it "grants access to subsite" do
+      grant nil, granter, site1, [READ_SITE]
+
+      expect {
+        grant granter, granter2, site11, READ_SITE
+      }.to change(granter2.computed_policies(:reload), :count).by(1)
+
+      expect(granter2).to have(1).computed_policies
+      p = granter2.computed_policies.first
+      expect(p.resource_id).to eq(site11.prefix)
+    end
+
+    it "grants access to subsubsite" do
+      grant nil, granter, site1, [READ_SITE]
+
+      expect {
+        grant granter, granter2, site111, READ_SITE
+      }.to change(granter2.computed_policies(:reload), :count).by(1)
+
+      expect(granter2).to have(1).computed_policies
+      p = granter2.computed_policies.first
+      expect(p.resource_id).to eq(site111.prefix)
+    end
+
+    it "interesects no site condition with site condition" do
+      grant nil, granter, device11, [READ_DEVICE]
+
+      expect {
+        grant granter, granter2, "device?site=#{device11.site.id}", [READ_DEVICE]
+      }.to change(granter2.computed_policies(:reload), :count).by(1)
+
+      expect(granter2).to have(1).computed_policies
+      p = granter2.computed_policies.first
+      expect(p.condition_site_id).to eq(site11.prefix)
+    end
+
+    it "interesects two site conditions" do
+      grant nil, granter, "device?site=#{device1.site.id}", [READ_DEVICE]
+
+      expect {
+        grant granter, granter2, "device?site=#{device11.site.id}", [READ_DEVICE]
+      }.to change(granter2.computed_policies(:reload), :count).by(1)
+
+      expect(granter2).to have(1).computed_policies
+      p = granter2.computed_policies.first
+      expect(p.condition_site_id).to eq(site11.prefix)
+    end
   end
 
 end

--- a/spec/models/computed_policy_spec.rb
+++ b/spec/models/computed_policy_spec.rb
@@ -92,7 +92,7 @@ describe ComputedPolicy do
       }.to change(user.computed_policies(:reload), :count).by(1)
 
       user.computed_policies.first.tap do |p|
-        expect(p.condition_site_id).to eq(device.site.id.to_s)
+        expect(p.condition_site_id).to eq(device.site.prefix)
       end
     end
 
@@ -106,7 +106,7 @@ describe ComputedPolicy do
       expect(p.resource_id).to be_nil
 
       expect(p).to have(1).exceptions
-      expect(p.exceptions.first.resource_id).to eq(device.id)
+      expect(p.exceptions.first.resource_id).to eq(device.id.to_s)
     end
 
   end
@@ -146,7 +146,7 @@ describe ComputedPolicy do
       }.to change(user.computed_policies(:reload), :count).by(1)
 
       user.computed_policies.first.tap do |p|
-        expect(p.condition_site_id).to eq(device.site.id.to_s)
+        expect(p.condition_site_id).to eq(device.site.prefix)
         expect(p.condition_institution_id).to eq(device.institution.id)
       end
     end
@@ -252,7 +252,7 @@ describe ComputedPolicy do
       expect(user.computed_policies.first).to have(2).exceptions
       exceptions = user.computed_policies.first.exceptions
 
-      expect(exceptions.map(&:resource_id)).to match_array([device.id, device2.id])
+      expect(exceptions.map(&:resource_id)).to match_array([device.id.to_s, device2.id.to_s])
     end
 
     it "should not join exceptions when not applicable" do
@@ -271,7 +271,7 @@ describe ComputedPolicy do
 
       device_policies.each do |p|
         expect(p).to have(1).exceptions
-        expect(p.exceptions.first.resource_id).to eq(device.id)
+        expect(p.exceptions.first.resource_id).to eq(device.id.to_s)
       end
     end
 

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -91,4 +91,12 @@ describe Device do
       expect(commands[0].command).to be_nil
     end
   end
+
+  context 'site_prefix' do
+    let(:device) { Device.make }
+
+    it "has a site_prefix" do
+      expect(device.site_prefix).to eq(device.site.prefix)
+    end
+  end
 end

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -718,6 +718,14 @@ describe Policy do
       let!(:device2)      { Device.make institution_id: institution2.id, site: site2 }
       let!(:test_result2) { TestResult.make device_messages: [DeviceMessage.make(device: device2)]}
 
+      let!(:institution3) { user.institutions.make }
+      let!(:site3) { Site.make institution: institution3 }
+      let!(:device3) { Device.make institution_id: institution3.id, site: site3 }
+      let!(:site3_1) { Site.make institution: institution3, parent_id: site3.id }
+      let!(:device3_1) { Device.make institution_id: institution3.id, site: site3_1 }
+      let!(:test_result3) { TestResult.make device_messages: [DeviceMessage.make(device: device3)]}
+      let!(:test_result3_1) { TestResult.make device_messages: [DeviceMessage.make(device: device3_1)]}
+
       it "does not allow user to query test result" do
         assert_cannot user2, test_result, QUERY_TEST
       end
@@ -752,6 +760,11 @@ describe Policy do
         assert_can user2, TestResult, QUERY_TEST, [test_result]
       end
 
+      it "returns a scope with tests authorised by site and subsite" do
+        grant user, user2, {test_result: site3}, QUERY_TEST
+        assert_can user2, TestResult, QUERY_TEST, [test_result3, test_result3_1]
+      end
+
       it "returns a scope with tests authorised by device" do
         grant user, user2, {test_result: device}, QUERY_TEST
         assert_can user2, TestResult, QUERY_TEST, [test_result]
@@ -765,12 +778,12 @@ describe Policy do
 
       it "returns a scope with all tests" do
         grant user, user2, TestResult, QUERY_TEST
-        assert_can user2, TestResult, QUERY_TEST, [test_result, test_result2]
+        assert_can user2, TestResult, QUERY_TEST, [test_result, test_result2, test_result3, test_result3_1]
       end
 
       it "returns a scope with all tests minus exceptions" do
         grant user, user2, TestResult, QUERY_TEST, except: {test_result: site2}
-        assert_can user2, TestResult, QUERY_TEST, [test_result]
+        assert_can user2, TestResult, QUERY_TEST, [test_result, test_result3, test_result3_1]
       end
 
     end

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -487,6 +487,41 @@ describe Policy do
         assert_can user2, site, DELETE_SITE
       end
     end
+
+    context "with subsites" do
+      let!(:site1) { Site.make }
+      let!(:site11) { Site.make parent_id: site1.id }
+      let!(:site111) { Site.make parent_id: site11.id }
+
+      let!(:device1) { Device.make site_id: site1.id }
+      let!(:device11) { Device.make site_id: site11.id }
+
+      let!(:user2) { User.make }
+
+      it "can access sub-sites" do
+        grant nil, user, site1, READ_SITE
+
+        assert_can user, site1, READ_SITE
+        assert_can user, site11, READ_SITE
+        assert_can user, site111, READ_SITE
+      end
+
+      it "can access sub-sites related to another site" do
+        grant nil, user, site1, READ_SITE
+        grant user, user2, site11, READ_SITE
+
+        assert_cannot user2, site1, READ_SITE
+        assert_can user2, site11, READ_SITE
+        assert_can user2, site111, READ_SITE
+      end
+
+      it "can access sub-site with condition" do
+        grant nil, user, "device?site=#{site1.id}", READ_DEVICE
+
+        assert_can user, device1, READ_DEVICE
+        assert_can user, device11, READ_DEVICE
+      end
+    end
   end
 
   context "Device Model" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Site do
+  it "computes prefix for self" do
+    site = Site.make
+    expect(site.prefix).to eq(site.id.to_s)
+  end
+
+  it "computes prefix for self with parent" do
+    site1 = Site.make
+    site2 = Site.make parent_id: site1.id
+    expect(site2.prefix).to eq("#{site1.id}.#{site2.id}")
+  end
+
+  it "computes prefix for self with parent and grandparent" do
+    site1 = Site.make
+    site2 = Site.make parent_id: site1.id
+    site3 = Site.make parent_id: site2.id
+    expect(site3.prefix).to eq("#{site1.id}.#{site2.id}.#{site3.id}")
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -3,19 +3,21 @@ require 'spec_helper'
 describe Site do
   it "computes prefix for self" do
     site = Site.make
-    expect(site.prefix).to eq(site.id.to_s)
+    expect(site.prefix).to eq(site.uuid.to_s)
   end
 
   it "computes prefix for self with parent" do
     site1 = Site.make
     site2 = Site.make parent_id: site1.id
-    expect(site2.prefix).to eq("#{site1.id}.#{site2.id}")
+    expect(site2.prefix).to eq("#{site1.uuid}.#{site2.uuid}")
   end
 
   it "computes prefix for self with parent and grandparent" do
     site1 = Site.make
     site2 = Site.make parent_id: site1.id
     site3 = Site.make parent_id: site2.id
-    expect(site3.prefix).to eq("#{site1.id}.#{site2.id}.#{site3.id}")
+    expect(site3.prefix).to eq("#{site1.uuid}.#{site2.uuid}.#{site3.uuid}")
+
+    expect(site3.path).to eq([site1.uuid, site2.uuid, site3.uuid])
   end
 end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -72,7 +72,7 @@ describe Subscriber, elasticsearch: true do
       expect(response.keys).to match_array(["device", "encounter", "institution", "site", "location", "patient", "sample", "test"])
       expect(response["device"].keys).to match_array(["model", "uuid", "name", "serial_number"])
       expect(response["institution"].keys).to match_array(["uuid", "name"])
-      expect(response["site"].keys).to match_array(["uuid", "name"])
+      expect(response["site"].keys).to match_array(["uuid", "name", "path"])
       expect(response["location"].keys).to match_array(["id", "parents", "admin_levels", "lat", "lng"])
       expect(response["patient"].keys).to match_array(["gender"])
       expect(response["sample"].keys).to match_array(["uuid", "id", "type", "collection_date"])

--- a/spec/models/test_result_indexer_spec.rb
+++ b/spec/models/test_result_indexer_spec.rb
@@ -99,7 +99,8 @@ describe TestResultIndexer, elasticsearch: true do
           "serial_number" => test.device.serial_number
         },
         "site" => {
-          "uuid" => test.device.site.uuid
+          "uuid" => test.device.site.uuid,
+          "path" => [test.device.site.uuid],
         },
         "institution" => {
           "uuid" => test.device.institution.uuid

--- a/spec/models/test_result_query_spec.rb
+++ b/spec/models/test_result_query_spec.rb
@@ -15,11 +15,14 @@ describe TestResultQuery, elasticsearch: true do
   let(:site_3)    {Site.make institution: institution_3}
   let(:site_4)    {Site.make institution: institution}
 
+  let(:site_sub_1) { Site.make institution: institution, parent_id: site.id }
+
   let(:user_device)     {Device.make institution_id: institution.id, site: site}
   let(:user_device_2)   {Device.make institution_id: institution.id, site: site}
   let(:user_device_3)   {Device.make institution_id: institution_2.id, site: site_2}
   let(:user_device_4)   {Device.make institution_id: institution_3.id, site: site_3}
   let(:user_device_5)   {Device.make institution_id: institution.id, site: site_4}
+  let(:user_device_6)   {Device.make institution_id: institution.id, site: site_sub_1}
   let(:non_user_device) {Device.make}
 
   let(:core_fields) { {"test" => {"results" =>["condition" => "mtb", "result" => :positive]}} }
@@ -108,6 +111,18 @@ describe TestResultQuery, elasticsearch: true do
     it "have access with policy by site" do
       TestResult.create_and_index(core_fields: core_fields, device_messages:[DeviceMessage.make(device: user_device)])
       TestResult.create_and_index(core_fields: core_fields, device_messages:[DeviceMessage.make(device: user_device_5)])
+
+      refresh_index
+
+      grant(user, user_2, "testResult?site=#{site.id}", QUERY_TEST)
+
+      result = TestResultQuery.for({"condition" => 'mtb'}, user_2).execute
+      expect(result['total_count']).to eq(1)
+    end
+
+    it "have access with policy by site with children" do
+      TestResult.create_and_index(core_fields: core_fields, device_messages:[DeviceMessage.make(device: user_device_6)])
+      TestResult.create_and_index(core_fields: core_fields, device_messages:[DeviceMessage.make(device: user_device_3)])
 
       refresh_index
 

--- a/spec/models/test_result_spec.rb
+++ b/spec/models/test_result_spec.rb
@@ -22,4 +22,9 @@ describe TestResult do
     tests = TestResult.from_the_past_year(Time.now).all
     expect(tests).to eq([test2])
   end
+
+  it "sets the site_prefix" do
+    test = TestResult.make
+    expect(test.site_prefix).to eq(test.device.site.prefix)
+  end
 end


### PR DESCRIPTION
Changes summary:

* The UI for a site gets a list of site dependencies (the children). And when creating a site you can choose its supervisor (parent)
* Changed sites, devices, institutions, and policy tables and logic to support querying sites by prefix
* Added `site.path` to `fields.yml`