### PR TITLE
`data-auto-submit` attribute for html forms

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -52,6 +52,22 @@ $(document).ready(function(){
     window.location.href = $(this).data('href');
   });
 
+  $('form[data-auto-submit]').each(function(){
+    var form = $(this);
+    var payload = form.serialize();
+
+    var debouncedSubmit = _.debounce(function(){
+      form.submit();
+    }, 2000);
+
+    form.on('change', function(){
+      if (payload != form.serialize()) {
+        payload = form.serialize()
+        debouncedSubmit();
+      }
+    });
+  });
+
   $(document).on('click', '.tabs .tabs-header a:not(".selected")', function(event) {
     var target = $(event.target);
     var tabsHeader = target.closest('ul');

--- a/app/views/devices/index.haml
+++ b/app/views/devices/index.haml
@@ -2,7 +2,7 @@
   .row
     .col
       %h1 Filters
-  %form
+  %form(data-auto-submit)
     .row
       - if @institutions.size > 1
         .col.pe-2
@@ -16,8 +16,6 @@
           = cdx_select name: "site", value: params["site"] do |select|
             - select.item "", "(all)"
             - select.items @sites, :id, :name
-      .col
-        %input.btn-primary.pull-right{type: "submit", value: "Filter"}
 
 .row
   .col

--- a/app/views/sites/index.html.haml
+++ b/app/views/sites/index.html.haml
@@ -2,7 +2,7 @@
   .row
     .col
       %h1 Filters
-  %form
+  %form(data-auto-submit)
     .row
       .col
         %label.block Institution
@@ -10,8 +10,6 @@
         = cdx_select name: "institution", value: params["institution"] do |select|
           - select.item "", "(all)"
           - select.items @institutions, :id, :name
-
-        %input.btn-primary.pull-right{type: "submit", value: "Filter"}
 
 .row
   .col

--- a/app/views/test_results/index.haml
+++ b/app/views/test_results/index.haml
@@ -1,4 +1,4 @@
-%form
+%form(data-auto-submit)
   .row
     .col
       %h1 Filters
@@ -46,7 +46,6 @@
       %input{type: "text", name: "encounter.id", value: params["encounter.id"]}
   .row
     .col
-      %input.btn-primary.pull-right{type: "submit", value: "Filter"}
       = link_to "Add filter", new_filter_path(query: @filter), class: 'btn pull-right'
 
   .row


### PR DESCRIPTION
fix #444. form tags can have `data-auto-submit` attribute so the form will be submitted with a debounced logic of 2 sec. used ofr devices, sites, and test_results search