### PR TITLE
Added the controversial db per branch setting

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,3 +1,10 @@
+<%
+  require 'config'
+  branch = `git rev-parse --abbrev-ref HEAD`.strip rescue nil
+  use_single_db = !Settings.db_per_branch || !branch || branch == 'master'
+  branch_spec = (use_single_db ? "" : "_#{branch}").underscore.gsub(/[\.\/\-]/, '_')
+%>
+
 default: &default
   adapter: mysql2
   encoding: utf8
@@ -8,7 +15,7 @@ default: &default
 
 development:
   <<: *default
-  database: cdp_development
+  database: cdp_development<%= branch_spec %>
   reconnect: true
 
 test: &test

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,3 +7,4 @@ google_client_id:
 google_client_secret:
 google_maps_api_key:
 single_tenant: false
+db_per_branch: false

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,24 @@
+namespace :db do
+
+  desc "Copies master development database, or specified by SOURCE env param, into current branch name only if it does not exist"
+  task :clone do
+    config = Rails.application.config.database_configuration[Rails.env]
+    source_db = ENV['SOURCE'].presence || 'cdp_development'
+    target_db = config['database']
+    mysql_opts =  "-u #{config['username']} "
+    mysql_opts << "--password=\"#{config['password']}\" " if config['password'].presence
+
+    `mysqlshow #{mysql_opts} #{target_db.gsub('_', '\\\\\_')}`
+    raise "Target database #{target_db} already exists" if $?.to_i == 0
+
+    `mysqlshow #{mysql_opts} #{source_db.gsub('_', '\\\\\_')}`
+    raise "Source database #{source_db} not found" if $?.to_i != 0
+
+    puts "Creating empty database #{target_db}"
+    `mysql #{mysql_opts} -e "CREATE DATABASE #{target_db}"`
+
+    puts "Copying #{source_db} into #{target_db}"
+    `mysqldump #{mysql_opts} #{source_db} | mysql #{mysql_opts} #{target_db}`
+  end
+
+end


### PR DESCRIPTION
If `db_per_branch` setting is truthy, then the development database will be named `cdp_development_BRANCH`, where BRANCH is the current branch name. When switching to a new branch, running rake db:clone will copy the current cdp_development database to a new cdp_development_newbranch database. This allows to easily switch between different branches, without causing issues with migrations specific to a branch having been run on the development database, but that are not expected in another branch.