### PR TITLE
Policy#authorized_users method

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -37,7 +37,7 @@ class Institution < ActiveRecord::Base
   private
 
   def update_owner_policies
-    self.user.update_computed_policies
+    self.user.try(:update_computed_policies)
   end
 
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -115,6 +115,10 @@ class Policy < ActiveRecord::Base
     ComputedPolicy.condition_resources_for(action, resource, user)
   end
 
+  def self.authorized_users(action, resource)
+    ComputedPolicy.authorized_users(action, resource)
+  end
+
   def implicit?
     self.granter_id == nil
   end


### PR DESCRIPTION
Added Policy#authorized_users method to get all users with access to a specific resource. Fixes #510.