### PR TITLE
rollback to phantom 1.9.8 due to lack of attachment and el capitan support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ bundler_args: --jobs=8 --without development
 services:
 - elasticsearch
 before_script:
-- mkdir travis-phantomjs
-- wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-- tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-- export PATH=$PWD/travis-phantomjs:$PATH
-
 - bundle exec rake db:setup
 - bundle exec rake db:test:prepare
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -113,4 +113,8 @@ group :test do
   gem 'site_prism'
   gem 'poltergeist'
   gem 'capybara-screenshot'
+
+  source 'https://rails-assets.org' do
+    gem 'rails-assets-es5-shim'
+  end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ PATH
 
 GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actionmailer (4.2.3)
       actionpack (= 4.2.3)
@@ -436,6 +437,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.3)
       sprockets-rails
+    rails-assets-es5-shim (4.3.1)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.7)
@@ -661,6 +663,7 @@ DEPENDENCIES
   puma
   quiet_assets
   rails (~> 4.2.0)
+  rails-assets-es5-shim!
   rails-i18n (~> 4.0.0)
   rchardet
   react-rails

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ To start developing:
 
 2. Install dependencies:
 	* `bundle install`.
-	* PhantomJS `>= 2.0` for [Poltergeist](https://github.com/teampoltergeist/poltergeist) (development and test only)
+	* PhantomJS 1.9.8 for [Poltergeist](https://github.com/teampoltergeist/poltergeist) (development and test only)
 	* ImageMagick for [Paperclip](https://github.com/thoughtbot/paperclip#image-processor).
-  
+
 3. Setup development database: `bundle exec rake db:setup`
 
 4. Setup test database: `bundle exec rake db:test:prepare`

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,7 @@
     %title Connected Diagnostics Platform
     = Gon::Base.render_data({})
     = stylesheet_link_tag "application", :media => "all"
+    = javascript_include_tag "es5-shim" if Rails.env.test?
     = javascript_include_tag "application"
     = csrf_meta_tags
   %body{class: @body_class}

--- a/app/views/layouts/clean.haml
+++ b/app/views/layouts/clean.haml
@@ -4,6 +4,7 @@
     %title Connected Diagnostics Platform
     = Gon::Base.render_data({})
     = stylesheet_link_tag "application", :media => "all"
+    = javascript_include_tag "es5-shim" if Rails.env.test?
     = javascript_include_tag "application"
     = csrf_meta_tags
   %body.devise{class: @body_class}
@@ -11,4 +12,3 @@
 
       .row.center
         = content_for?(:cdp_content) ? yield(:cdp_content) : yield
-

--- a/app/views/layouts/devise.haml
+++ b/app/views/layouts/devise.haml
@@ -4,6 +4,7 @@
     %title Connected Diagnostics Platform
     = Gon::Base.render_data({})
     = stylesheet_link_tag "application", :media => "all"
+    = javascript_include_tag "es5-shim" if Rails.env.test?
     = javascript_include_tag "application"
     = csrf_meta_tags
   %body.devise{class: @body_class}

--- a/app/views/layouts/messages.haml
+++ b/app/views/layouts/messages.haml
@@ -4,6 +4,7 @@
     %title Connected Diagnostics Platform
     = Gon::Base.render_data({})
     = stylesheet_link_tag "application", :media => "all"
+    = javascript_include_tag "es5-shim" if Rails.env.test?
     = javascript_include_tag "application"
     = csrf_meta_tags
   %body.devise{class: @body_class}

--- a/spec/features/device_model_spec.rb
+++ b/spec/features/device_model_spec.rb
@@ -4,9 +4,7 @@ describe "device model" do
   let(:user) { Institution.make(:manufacturer).user }
   before(:each) { sign_in(user) }
 
-  pending "can create model and access to it's details" do
-    # pending due to https://github.com/ariya/phantomjs/issues/12506
-
+  it "can create model and access to it's details" do
     goto_page NewDeviceModelPage do |page|
       page.name.set "MyModel"
       page.support_url.set "example.org/support"

--- a/spec/features/device_spec.rb
+++ b/spec/features/device_spec.rb
@@ -6,9 +6,7 @@ describe "device" do
       let(:user) { Institution.make(:manufacturer).user }
       before(:each) { sign_in(user) }
 
-      pending "can create model with activation and device get a token" do
-        # pending due to https://github.com/ariya/phantomjs/issues/12506
-
+      it "can create model with activation and device get a token" do
         goto_page NewDeviceModelPage do |page|
           page.name.set "MyModel"
           page.support_url.set "example.org/support"


### PR DESCRIPTION
To install PhantomJS 1.9.8 in OSX with homebrew

```
$ cd /usr/local/Library
$ git checkout 9089836d7539aa5530cbfc6cc3d9e3772ecc78b3 /usr/local/Library/Formula/phantomjs.rb
$ brew install phantomjs
```

Check
```
$ phantomjs --version
1.9.8
```

Travis already has Phantomjs 1.9.8