### PR TITLE
Sample lookup should be scoped by site for non-manufacturer institutions

### DIFF
--- a/app/models/blender.rb
+++ b/app/models/blender.rb
@@ -586,15 +586,17 @@ class Blender
     def before_save(entity)
       sample = @parents[Sample].try(:target)
       sample_id = @sample_id
+      site_id = entity.site_id
 
       existing_identifier = entity.sample_identifier
-      existing_identifier_does_not_match =  existing_identifier && (existing_identifier.sample != sample || existing_identifier.sample_id != sample_id)
+      existing_identifier_does_not_match =  existing_identifier && (existing_identifier.sample != sample || existing_identifier.sample_id != sample_id || existing_identifier.site_id != site_id)
 
       if sample.nil?
         entity.sample_identifier = nil
         @garbage << existing_identifier
       elsif existing_identifier.nil? || existing_identifier_does_not_match
-        entity.sample_identifier = sample.sample_identifiers.where(entity_id: sample_id).first || SampleIdentifier.new(entity_id: sample_id, sample: sample)
+        matching_sample_identifier = sample.sample_identifiers.all.find { |si| si.entity_id == sample_id && si.site_id == site_id }
+        entity.sample_identifier = matching_sample_identifier || sample.sample_identifiers.build(entity_id: sample_id, site_id: site_id)
         @garbage << existing_identifier
       end
     end

--- a/app/models/concerns/auto_id_hash.rb
+++ b/app/models/concerns/auto_id_hash.rb
@@ -11,8 +11,8 @@ module AutoIdHash
   end
 
   class_methods do
-    def find_by_entity_id(entity_id, institution_id)
-      find_by(entity_id_hash: MessageEncryption.hash(entity_id.to_s), institution_id: institution_id)
+    def find_by_entity_id(entity_id, opts={})
+      find_by(entity_id_hash: MessageEncryption.hash(entity_id.to_s), institution_id: opts.fetch(:institution_id))
     end
   end
 end

--- a/app/models/concerns/core_entity_id.rb
+++ b/app/models/concerns/core_entity_id.rb
@@ -16,8 +16,8 @@ module CoreEntityId
   end
 
   class_methods do
-    def find_by_entity_id(entity_id, institution_id)
-      find_by(entity_id: entity_id.to_s, institution_id: institution_id)
+    def find_by_entity_id(entity_id, opts)
+      find_by(entity_id: entity_id.to_s, institution_id: opts.fetch(:institution_id))
     end
   end
 end

--- a/app/models/device_message_processor.rb
+++ b/app/models/device_message_processor.rb
@@ -59,7 +59,7 @@ class DeviceMessageProcessor
         new_entity_id = parsed_message.get_in(klazz.entity_scope, (klazz == Patient ? 'pii' : 'core'), 'id').try(:to_s)
         entity_id_does_not_match = original_entity_id && new_entity_id && original_entity_id != new_entity_id
 
-        new_entity = find_entity_by_id(klazz, new_entity_id, (klazz != Patient))
+        new_entity = find_entity_by_id(klazz, new_entity_id)
         original_blender = test_blender.send(klazz.entity_scope)
 
         new_entity ||= klazz.new(institution: institution) if entity_id_does_not_match || original_blender.nil?
@@ -84,11 +84,13 @@ class DeviceMessageProcessor
 
     private
 
-    def find_entity_by_id(klass, entity_id, use_reset_policy = true)
+    def find_entity_by_id(klass, entity_id)
       return nil if entity_id.nil?
       query = klass
-      query = query.within_time(entity_reset_time_span(klass), @parent.device_message.created_at) if use_reset_policy
-      query.find_by_entity_id(entity_id, @parent.institution.id)
+      query = query.within_time(entity_reset_time_span(klass), @parent.device_message.created_at) if klass != Patient
+      query_opts = { institution_id: @parent.institution.id }
+      query_opts[:site_id] = @parent.device.site_id unless @parent.device.site_id.nil? || @parent.institution.kind_manufacturer?
+      query.find_by_entity_id(entity_id, query_opts)
     end
 
     def attributes_for(scope)

--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -84,8 +84,8 @@ class Encounter < ActiveRecord::Base
     }}.deep_stringify_keys).fields
   end
 
-  def self.find_by_entity_id(entity_id, institution_id)
-    find_by(entity_id: entity_id.to_s, institution_id: institution_id)
+  def self.find_by_entity_id(entity_id, opts)
+    find_by(entity_id: entity_id.to_s, institution_id: opts.fetch(:institution_id))
   end
 
   def self.query params, user

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -37,6 +37,12 @@ class Institution < ActiveRecord::Base
     name
   end
 
+  KINDS.each do |kind|
+    define_method "kind_#{kind}?" do
+      self.kind.try(:to_s) == kind
+    end
+  end
+
   private
 
   def update_owner_policies

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -17,8 +17,10 @@ class Sample < ActiveRecord::Base
     "sample"
   end
 
-  def self.find_by_entity_id(entity_id, institution_id)
-    joins(:sample_identifiers).where(sample_identifiers: {entity_id: entity_id.to_s}, institution_id: institution_id).first
+  def self.find_by_entity_id(entity_id, opts)
+    query = joins(:sample_identifiers).where(sample_identifiers: {entity_id: entity_id.to_s}, institution_id: opts.fetch(:institution_id))
+    query = query.where(sample_identifiers: {site_id: opts[:site_id]}) if opts[:site_id]
+    query.first
   end
 
   def self.find_all_by_any_uuid(uuids)

--- a/app/models/sample_identifier.rb
+++ b/app/models/sample_identifier.rb
@@ -2,6 +2,7 @@ class SampleIdentifier < ActiveRecord::Base
   include AutoUUID
 
   belongs_to :sample, inverse_of: :sample_identifiers
+  belongs_to :site, inverse_of: :sample_identifiers
   has_many :test_results, inverse_of: :sample_identifier, dependent: :restrict_with_error
 
   def phantom?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -5,7 +5,10 @@ class Site < ActiveRecord::Base
   belongs_to :institution
   has_one :user, through: :institution
   has_many :devices, dependent: :restrict_with_exception
-  has_many :test_results, through: :devices
+  has_many :test_results
+  has_many :sample_identifiers
+  has_many :samples, through: :sample_identifiers
+
   belongs_to :parent, class_name: "Site"
   has_many :children, class_name: "Site", foreign_key: "parent_id"
 

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -86,6 +86,11 @@ class TestResult < ActiveRecord::Base
     test_result_parsed_data.last
   end
 
+  def device=(value)
+    super
+    set_foreign_keys
+  end
+
   private
 
   def destroy_from_index

--- a/db/migrate/20151116134931_add_site_id_to_sample_identifiers.rb
+++ b/db/migrate/20151116134931_add_site_id_to_sample_identifiers.rb
@@ -1,0 +1,18 @@
+class AddSiteIdToSampleIdentifiers < ActiveRecord::Migration
+  def up
+    add_column :sample_identifiers, :site_id, :integer
+
+    connection.execute <<-SQL
+      UPDATE sample_identifiers
+      SET site_id = (
+        SELECT test_results.site_id
+        FROM test_results
+        WHERE sample_identifiers.id = test_results.sample_identifier_id
+        LIMIT 1)
+    SQL
+  end
+
+  def down
+    remove_column :sample_identifiers, :site_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151116133521) do
+ActiveRecord::Schema.define(version: 20151116134931) do
 
   create_table "activation_tokens", force: :cascade do |t|
     t.string   "value",      limit: 255
@@ -260,6 +260,7 @@ ActiveRecord::Schema.define(version: 20151116133521) do
     t.integer "sample_id", limit: 4
     t.string  "entity_id", limit: 255
     t.string  "uuid",      limit: 255
+    t.integer "site_id",   limit: 4
   end
 
   add_index "sample_identifiers", ["entity_id"], name: "index_sample_identifiers_on_entity_id", using: :btree

--- a/spec/controllers/api/messages_controller_creation_spec.rb
+++ b/spec/controllers/api/messages_controller_creation_spec.rb
@@ -4,7 +4,8 @@ describe Api::MessagesController, elasticsearch: true, validate_manifest: false 
 
   let(:user) {User.make}
   let(:institution) {Institution.make user_id: user.id}
-  let(:device) {Device.make institution_id: institution.id}
+  let(:site) {Site.make institution: institution}
+  let(:device) {Device.make institution_id: institution.id, site: site}
   let(:data)  {Oj.dump test: {assays: [result: :positive]}}
   let(:datas) {Oj.dump [
     {test: {assays: [result: :positive]}},
@@ -183,7 +184,7 @@ describe Api::MessagesController, elasticsearch: true, validate_manifest: false 
     end
 
     it "merges pii from different tests in the same sample across devices" do
-      device2 = Device.make institution_id: institution.id, device_model: device.device_model
+      device2 = Device.make institution_id: institution.id, device_model: device.device_model, site: site
       device.manifest.update! definition: %{{
         "metadata" : {
           "version" : 1,

--- a/spec/models/test_result_indexer_spec.rb
+++ b/spec/models/test_result_indexer_spec.rb
@@ -22,26 +22,32 @@ describe TestResultIndexer, elasticsearch: true do
     SampleIdentifier.make(sample: sample, uuid: 'abc')
   end
 
-  let(:test){ TestResult.make(
-    "sample_identifier" => sample_identifier,
-    "patient" => patient,
-    "encounter" => encounter,
-    "institution" => institution,
-    "test_id" => '4',
-    "custom_fields" => {
-      "concentration" => "15%"
-    },
-    "core_fields" => {
-      "id" => "4",
-      "name" => "mtb",
-      "assays" => [
-        {
-          "result" => "positive",
-          "name" => "mtb"
-        }
-      ]
-    }
-  )}
+  let(:device) do
+    Device.make(institution: institution)
+  end
+
+  let(:test) do
+    TestResult.make(
+      device: device,
+      sample_identifier: sample_identifier,
+      patient: patient,
+      encounter: encounter,
+      institution: institution,
+      test_id: '4',
+      custom_fields: {
+        "concentration" => "15%"
+      },
+      core_fields: {
+        "id" => "4",
+        "name" => "mtb",
+        "assays" => [
+          {
+            "result" => "positive",
+            "name" => "mtb"
+          }
+        ]
+      })
+  end
 
   let(:test_indexer) { TestResultIndexer.new(test)}
 

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -94,10 +94,9 @@ TestResult.blueprint do
   test_id { "test-#{Sham.sn}" }
 
   device_messages { [ DeviceMessage.make(device: object.device || Device.make) ] }
-  device { device_messages.first.device || Device.make }
-  institution { device.institution || Institution.make }
-  sample_identifier { SampleIdentifier.make(sample: Sample.make(institution: object.institution, patient: object.patient, encounter: object.encounter)) }
-  # sample_identifier { SampleIdentifier.make(entity_id: "sample-#{Sham.sn}", sample: Sample.make(institution: device.institution)) }
+  device { object.device_messages.first.try(:device) || Device.make }
+  institution { object.device.try(:institution) || Institution.make }
+  sample_identifier { SampleIdentifier.make(site: object.device.try(:site), sample: Sample.make(institution: object.institution, patient: object.patient, encounter: object.encounter)) }
 
   encounter { object.sample.try(:encounter) }
   patient { object.sample.try(:patient) || object.encounter.try(:patient) }


### PR DESCRIPTION
Added site_id key to sample identifiers, not samples, as the assigned ID is scoped by site.
Changed the find_entity_by_id method to accept site_id as well as institution_id, used only for samples.
Updated blueprints and specs as needed.

Fixes #524