### PR TITLE
Feature/544 email instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'poirot_rails', git: 'https://github.com/instedd/poirot_rails.git', branch: 
 gem 'config'
 gem 'rest-client'
 gem 'barby'
+gem 'chunky_png'
 gem 'gon'
 gem 'rchardet'
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
       nenv
       rspec-logsplit (>= 0.1.2)
       timers (>= 4.1.1)
+    chunky_png (1.3.1)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     clipboard (1.0.6)
@@ -620,6 +621,7 @@ DEPENDENCIES
   cdx!
   cdx-api-elasticsearch!
   cdx-sync-server!
+  chunky_png
   config
   csv_builder
   cucumber-rails

--- a/app/assets/javascripts/components/device_setup.js.jsx
+++ b/app/assets/javascripts/components/device_setup.js.jsx
@@ -1,4 +1,10 @@
 var DeviceSetup = React.createClass({
+  getInitialState: function() {
+    return {
+      receiptment: '',
+    };
+  },
+
   showInstructionsModal: function() {
     this.refs.instructionsModal.show();
     event.preventDefault();
@@ -6,6 +12,39 @@ var DeviceSetup = React.createClass({
 
   hideInstructionsModal: function() {
     this.refs.instructionsModal.hide();
+    event.preventDefault();
+  },
+
+
+  showEmailModal: function() {
+    this.setState(React.addons.update(this.state, {
+      receiptment: { $set: '' }
+    }));
+    this.refs.emailModal.show();
+    event.preventDefault();
+  },
+
+  changeReceiptment: function(event) {
+    this.setState(React.addons.update(this.state, {
+      receiptment: { $set: event.target.value }
+    }));
+  },
+
+  sendEmail: function() {
+    $.ajax({
+      url: '/devices/' + this.props.device.id + '/send_setup_email',
+      method: 'POST',
+      data: {receiptment: this.state.receiptment},
+      success: function () {
+        this.closeEmailModal();
+        window.location.reload(true); // reload page in order to hide secret key
+      }.bind(this)
+    });
+    // TODO handle error maybe globally
+  },
+
+  closeEmailModal: function() {
+    this.refs.emailModal.hide();
     event.preventDefault();
   },
 
@@ -29,7 +68,7 @@ var DeviceSetup = React.createClass({
     return (
       <p>
         <a href='#' onClick={this.showInstructionsModal}>View instructions</a> on how to setup this device
-        or <a>email setup instructions to a lab operator</a>.
+        or <a href='#' onClick={this.showEmailModal}>email setup instructions to a lab operator</a>.
 
         <Modal ref="instructionsModal">
           <h1>
@@ -42,6 +81,20 @@ var DeviceSetup = React.createClass({
 
           <div className="modal-footer">
             <button className="btn btn-secondary" onClick={this.hideInstructionsModal}>Close</button>
+          </div>
+        </Modal>
+
+        <Modal ref="emailModal">
+          <h1>
+            Email instructions
+          </h1>
+
+          <label>Receiptment</label>
+          <input type="text" className="input-block" value={this.state.receiptment} onChange={this.changeReceiptment} />
+
+          <div className="modal-footer">
+            <button className="btn btn-primary" onClick={this.sendEmail}>Send</button>
+            <button className="btn btn-link" onClick={this.closeEmailModal}>Cancel</button>
           </div>
         </Modal>
       </p>

--- a/app/controllers/device_models_controller.rb
+++ b/app/controllers/device_models_controller.rb
@@ -41,6 +41,7 @@ class DeviceModelsController < ApplicationController
         format.json { render action: 'show', status: :created, device_model: @device_model }
       else
         @device_model.published_at = @device_model.published_at_was
+        @device_model.setup_instructions = nil
         format.html { render action: 'new' }
         format.json { render json: @device_model.errors, status: :unprocessable_entity }
       end
@@ -64,6 +65,7 @@ class DeviceModelsController < ApplicationController
         format.json { render action: 'show', status: :created, device_model: @device_model }
       else
         @device_model.published_at = @device_model.published_at_was
+        @device_model.setup_instructions = DeviceModel.find(params[:id]).setup_instructions
         format.html { render action: 'edit' }
         format.json { render json: @device_model.errors, status: :unprocessable_entity }
       end

--- a/app/helpers/barcode_helper.rb
+++ b/app/helpers/barcode_helper.rb
@@ -1,10 +1,23 @@
 require 'barby'
 require 'barby/barcode/code_93'
 require 'barby/outputter/html_outputter'
+require 'barby/outputter/png_outputter'
 
 module BarcodeHelper
   def barcode(code)
     barcode = Barby::Code93.new(code)
     Barby::HtmlOutputter.new(barcode).to_html.html_safe
+  end
+
+  def image_barcode(code)
+    barcode = Barby::Code93.new(code)
+    file = Tempfile.new(['barcode', '.png'])
+    outputter = Barby::PngOutputter.new(barcode)
+    outputter.xdim = 2
+    file.write outputter.to_png
+    file.rewind
+    yield file
+    file.close
+    file.unlink
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,4 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: "from@example.com"
+  layout 'mailer'
+end

--- a/app/mailers/device_mailer.rb
+++ b/app/mailers/device_mailer.rb
@@ -1,0 +1,22 @@
+class DeviceMailer < ApplicationMailer
+  include BarcodeHelper
+
+  def setup_instructions(sender, receiptment, device)
+    @device = device
+
+    if @device.device_model.supports_activation?
+      image_barcode(@device.activation_token.value) do |file|
+        attachments.inline['activation_token.png'] = file.read
+      end
+    else
+      image_barcode(@device.uuid) do |file|
+        attachments.inline['device_id.png'] = file.read
+      end
+      image_barcode(@device.plain_secret_key) do |file|
+        attachments.inline['plain_secret_key.png'] = file.read
+      end
+    end
+
+    mail(to: receiptment, cc: sender.email, subject: "Setup instructions for #{device.name}")
+  end
+end

--- a/app/views/device_mailer/setup_instructions.html.haml
+++ b/app/views/device_mailer/setup_instructions.html.haml
@@ -1,0 +1,26 @@
+%h1= "Setup instructions for #{@device.name}"
+
+- if @device.device_model.supports_activation?
+  %h2 Activation token
+  .p= @device.activation_token.value.scan(/.{4}/).join("-")
+  = image_tag attachments['activation_token.png'].url
+
+- else
+
+  %h2 Device Id
+  %p= @device.uuid
+  = image_tag attachments['device_id.png'].url
+
+  %h2 Secret Key
+  %p= @device.plain_secret_key
+  = image_tag attachments['plain_secret_key.png'].url
+
+- if @device.device_model.support_url.present?
+  %p
+    Online support
+    = link_to @device.device_model.support_url, @device.device_model.support_url
+
+- if @device.device_model.setup_instructions.present?
+  %p
+    Download instructions as a
+    = link_to "pdf file", "http://#{Settings.host}" + @device.device_model.setup_instructions.url

--- a/app/views/device_models/_form.haml
+++ b/app/views/device_models/_form.haml
@@ -40,7 +40,7 @@
     .col.pe-3
       = f.label :setup_instructions
     .col
-      - if !@device_model.new_record? && @device_model.setup_instructions.present? && !@device_model.errors.include?(:setup_instructions)
+      - if !@device_model.new_record? && @device_model.setup_instructions.present?
         = link_to "download", @device_model.setup_instructions.url
         = f.check_box :delete_setup_instructions
         = f.label :delete_setup_instructions

--- a/app/views/devices/setup.haml
+++ b/app/views/devices/setup.haml
@@ -4,7 +4,7 @@
   .col
     %h4 Setup
 
-    = react_component "DeviceSetup", device_model: @device.device_model.try { |device_model| { support_url: device_model.support_url, setup_instructions_url: device_model.setup_instructions.present? ? device_model.setup_instructions.url : "" } }
+    = react_component "DeviceSetup", device: { id: @device.id }, device_model: @device.device_model.try { |device_model| { support_url: device_model.support_url, setup_instructions_url: device_model.setup_instructions.present? ? device_model.setup_instructions.url : "" } }
 
     %p
       The Device Id and Secure Key allow your device to identify itself with CDx.

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -1,0 +1,3 @@
+%hmtl
+  %body
+    = yield

--- a/config/initializers/paperclip_defaults.rb
+++ b/config/initializers/paperclip_defaults.rb
@@ -1,0 +1,4 @@
+Paperclip::Attachment.default_options.update({
+  url: "/system/:class/:attachment/:id_partition/:style/:hash.:extension",
+  hash_secret: Rails.application.secrets.secret_key_base
+})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
       get :tests
       get :logs
       get :setup
+      post :send_setup_email
     end
     collection do
       post 'custom_mappings'

--- a/spec/mailers/device_mailer_spec.rb
+++ b/spec/mailers/device_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "spec_helper"
+
+RSpec.describe DeviceMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/device_mailer_preview.rb
+++ b/spec/mailers/previews/device_mailer_preview.rb
@@ -1,0 +1,8 @@
+# Preview all emails at http://localhost:3000/rails/mailers/device_mailer
+class DeviceMailerPreview < ActionMailer::Preview
+  def setup_instructions
+    device = Device.find(2)
+    device.set_key
+    DeviceMailer.setup_instructions(User.first, "jdoe@example.org", device)
+  end
+end


### PR DESCRIPTION
fixes #544 
allow user to input email
send instructions/keys with barcodes by email
non styled emails

also change default path of paperclips attachment to use hash