### PR TITLE
Feature/514 site navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,10 @@ gem 'doorkeeper'
 
 gem 'faker'
 
+source 'https://rails-assets.org' do
+  gem 'rails-assets-urijs'
+end
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rescue'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,6 +448,7 @@ GEM
       railties (= 4.2.3)
       sprockets-rails
     rails-assets-es5-shim (4.3.1)
+    rails-assets-urijs (1.17.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.7)
@@ -678,6 +679,7 @@ DEPENDENCIES
   quiet_assets
   rails (~> 4.2.0)
   rails-assets-es5-shim!
+  rails-assets-urijs!
   rails-i18n (~> 4.0.0)
   rchardet
   react-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery.turbolinks
 //= require jquery_ujs
 //= require jquery.are-you-sure
+//= require urijs
 //= require lodash
 //= require select2
 //= require react
@@ -24,6 +25,7 @@
 //= require components
 //= require d3
 //= require_tree .
+//= require turbolinks
 
 function cdx_init_components(dom) {
   ReactRailsUJS.mountComponents(dom);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -59,7 +59,10 @@ $(document).ready(function(){
     var payload = form.serialize();
 
     var debouncedSubmit = _.debounce(function(){
-      form.submit();
+      var options = {};
+      var action = form.attr('action') || window.location.href;
+      var url = action + (action.indexOf('?') === -1 ? '?' : '&') + form.serialize();
+      Turbolinks.visit(url.toString(), options);
     }, 2000);
 
     form.on('change', function(){

--- a/app/assets/javascripts/components/navigation_context_picker.js.jsx
+++ b/app/assets/javascripts/components/navigation_context_picker.js.jsx
@@ -1,0 +1,65 @@
+$(document).ready(function(){
+  $("#nav-context").click(function(event){
+    var container = $("#context_side_bar");
+    if ($("[data-react-class=NavigationContextPicker]:first").length == 0) {
+      // initialize react component for context picker
+      // this is done only the first time user clicks on the nav bar link
+      // on other clicks even across page navigations, due to Turbolinks,
+      // the component is kept alive.
+      container.append(
+        $("<div>")
+          .attr("data-react-class", "NavigationContextPicker")
+          .attr("data-react-props", container.attr("data-context-react-props"))
+      )
+      cdx_init_components(container);
+    }
+
+    $("body").toggleClass("show-navigation-context-picker");
+    $("input:first", container).focus();
+    event.preventDefault();
+    return false;
+  });
+
+  // preserve the #context_side_bar element
+  // and preserve the status of the body.show-navigation-context-picker css class
+  var context_side_bar = null;
+  var show_navigation_context = false;
+  $(document).on("page:fetch", function() {
+    context_side_bar = $('#context_side_bar');
+    show_navigation_context = $("body").hasClass("show-navigation-context-picker");
+  });
+  $(document).on("page:change", function() {
+    if (show_navigation_context) {
+      $("body").addClass("show-navigation-context-picker");
+    }
+    $('#context_side_bar').append(context_side_bar);
+  });
+});
+
+var NavigationContextPicker = React.createClass({
+  getInitialState: function() {
+    return { context: this.props.context };
+  },
+
+  changeContextSite: function(site) {
+    this.setState(React.addons.update(this.state, {
+      context: { $set: site }
+    }), function() {
+      var new_context_url = URI(window.location.href).search({context: site.uuid}).toString();
+      Turbolinks.visit(new_context_url);
+    });
+  },
+
+  render: function() {
+    // since the picker tracks the selected state
+    // there is no need to update the properties
+    return (
+      <div>
+        <p>
+        Selected: {this.state.context.name} - {this.state.context.uuid}
+        </p>
+        <SitePicker selected_uuid={this.props.context.uuid} onSiteSelected={this.changeContextSite} />
+      </div>
+    );
+  }
+});

--- a/app/assets/javascripts/components/navigation_context_picker.js.jsx
+++ b/app/assets/javascripts/components/navigation_context_picker.js.jsx
@@ -32,7 +32,9 @@ $(document).ready(function(){
     if (show_navigation_context) {
       $("body").addClass("show-navigation-context-picker");
     }
-    $('#context_side_bar').append(context_side_bar);
+    if (context_side_bar) {
+      $('#context_side_bar').append(context_side_bar.children());
+    }
   });
 });
 
@@ -55,9 +57,6 @@ var NavigationContextPicker = React.createClass({
     // there is no need to update the properties
     return (
       <div>
-        <p>
-        Selected: {this.state.context.name} - {this.state.context.uuid}
-        </p>
         <SitePicker selected_uuid={this.props.context.uuid} onSiteSelected={this.changeContextSite} />
       </div>
     );

--- a/app/assets/javascripts/components/sites.js.jsx
+++ b/app/assets/javascripts/components/sites.js.jsx
@@ -1,11 +1,11 @@
-var ContextSitePicker = React.createClass({
+var NavigationContextPicker = React.createClass({
   getInitialState: function() {
-    return { site: this.props.site };
+    return { context: this.props.context };
   },
 
   changeContextSite: function(site) {
     this.setState(React.addons.update(this.state, {
-      site: { $set: site }
+      context: { $set: site }
     }));
   },
 
@@ -15,9 +15,9 @@ var ContextSitePicker = React.createClass({
     return (
       <div>
         <p>
-        Selected: {this.state.site.name} - {this.state.site.uuid}
+        Selected: {this.state.context.name} - {this.state.context.uuid}
         </p>
-        <SitePicker selected_uuid={this.props.site.uuid} onSiteSelected={this.changeContextSite} />
+        <SitePicker selected_uuid={this.props.context.uuid} onSiteSelected={this.changeContextSite} />
       </div>
     );
   }

--- a/app/assets/javascripts/components/sites.js.jsx
+++ b/app/assets/javascripts/components/sites.js.jsx
@@ -31,14 +31,14 @@ var SitePicker = React.createClass({
   },
 
   getInitialState: function() {
-    return { sites: [], sites_tree: [], selected_site: null };
+    return { sites: [], sites_tree: [], selected_site: null, query: '' };
   },
 
   componentDidMount: function() {
     $.get(this.props.url, function(result) {
       if (!this.isMounted()) return;
 
-      roots_and_selected = this._buildTree(result.sites) || this.state.selected_site;
+      roots_and_selected = this._buildTree(result.sites, '', this.props.selected_uuid);
 
       this.setState(React.addons.update(this.state, {
         sites: { $set: result.sites },
@@ -48,21 +48,36 @@ var SitePicker = React.createClass({
     }.bind(this));
   },
 
-  _buildTree: function(sites) {
+  _siteMatch: function(site, query) {
+    return _.deburr(site.name.toLowerCase()).indexOf(query) != -1;
+  },
+
+  _buildTree: function(sites, query, selected_uuid) {
     var sites_by_uuid = {};
     var roots = [];
     var selected = null;
+    var matched_sites = [];
+    query = _.deburr(query).toLowerCase();
 
+    // prepares a matched_sites with all sites that match query
+    // but it prepares a children property on each site for
+    // building later the tree
     _.each(sites, function(site){
+      if (query != '' && !this._siteMatch(site, query)) return;
+      matched_sites.push(site);
       sites_by_uuid[site.uuid] = site;
       site.children = [];
-      site.selected = site.uuid == this.props.selected_uuid;
+      site.selected = site.uuid == selected_uuid;
       if (site.selected) {
         selected = site;
       }
     }.bind(this));
 
-    _.each(sites, function(site) {
+    // builds a tree with all matched_sites and with the children
+    // information. If parent is not present, it is considered a root.
+    // Roots may vary depending on the query argument due to non-match of parents.
+    // TODO what should happen in Match1 -> NonMatch1 -> Match2 ?
+    _.each(matched_sites, function(site) {
       parent = sites_by_uuid[site.parent_uuid]
       if (parent) {
         parent.children.push(site)
@@ -87,10 +102,33 @@ var SitePicker = React.createClass({
     this.props.onSiteSelected(site);
   },
 
+  // debounce: http://stackoverflow.com/a/24679479/30948
+  componentWillMount: function() {
+    this.handleSearchDebounced = _.debounce(function(){
+      this.handleSearch.apply(this, [this.state.query]);
+    }, 500);
+  },
+
+  onSearchChange: function(event) {
+    this.setState(React.addons.update(this.state, {
+      query: { $set: event.target.value }
+    }));
+    this.handleSearchDebounced();
+  },
+
+  handleSearch: function(query) {
+    roots_and_selected = this._buildTree(this.state.sites, query, this.state.selected_site.uuid);
+    // should not change selected site while filtering
+
+    this.setState(React.addons.update(this.state, {
+      sites_tree: { $set: roots_and_selected[0] },
+    }));
+  },
+
   render: function() {
     return (
       <div>
-        <input type="text" onChange={this.onChange} autoFocus="true" />
+        <input type="text" onChange={this.onSearchChange} autoFocus="true" />
         <SitesTreeView sites={this.state.sites_tree} onSiteClick={this.selectSite} />
       </div>
     )

--- a/app/assets/javascripts/components/sites.js.jsx
+++ b/app/assets/javascripts/components/sites.js.jsx
@@ -1,0 +1,155 @@
+var ContextSitePicker = React.createClass({
+  getInitialState: function() {
+    return { site: this.props.site };
+  },
+
+  changeContextSite: function(site) {
+    this.setState(React.addons.update(this.state, {
+      site: { $set: site }
+    }));
+  },
+
+  render: function() {
+    // since the picker tracks the selected state
+    // there is no need to update the properties
+    return (
+      <div>
+        <p>
+        Selected: {this.state.site.name}
+        </p>
+        <SitePicker selected_uuid={this.props.site.uuid} onSiteSelected={this.changeContextSite} />
+      </div>
+    );
+  }
+});
+
+var SitePicker = React.createClass({
+  getDefaultProps: function() {
+    return {
+      url: '/api/sites'
+    }
+  },
+
+  getInitialState: function() {
+    return { sites: [], sites_tree: [], selected_site: null };
+  },
+
+  componentDidMount: function() {
+    $.get(this.props.url, function(result) {
+      if (!this.isMounted()) return;
+
+      roots_and_selected = this._buildTree(result.sites) || this.state.selected_site;
+
+      this.setState(React.addons.update(this.state, {
+        sites: { $set: result.sites },
+        sites_tree: { $set: roots_and_selected[0] },
+        selected_site: { $set: roots_and_selected[1] }
+      }));
+    }.bind(this));
+  },
+
+  _buildTree: function(sites) {
+    var sites_by_uuid = {};
+    var roots = [];
+    var selected = null;
+
+    _.each(sites, function(site){
+      sites_by_uuid[site.uuid] = site;
+      site.children = [];
+      site.selected = site.uuid == this.props.selected_uuid;
+      if (site.selected) {
+        selected = site;
+      }
+    }.bind(this));
+
+    _.each(sites, function(site) {
+      parent = sites_by_uuid[site.parent_uuid]
+      if (parent) {
+        parent.children.push(site)
+      } else {
+        roots.push(site)
+      }
+    });
+
+    return [roots, selected];
+  },
+
+  selectSite: function(site) {
+    if (this.state.selected_site) {
+      this.state.selected_site.selected = false;
+    }
+    site.selected = true;
+
+    this.setState(React.addons.update(this.state, {
+      selected_site: { $set: site }
+    }));
+
+    this.props.onSiteSelected(site);
+  },
+
+  render: function() {
+    return (
+      <div>
+        <input type="text" onChange={this.onChange} autoFocus="true" />
+        <SitesTreeView sites={this.state.sites_tree} onSiteClick={this.selectSite} />
+      </div>
+    )
+  }
+});
+
+var SitesTreeView = React.createClass({
+  onSiteClick: function(site) {
+    this.props.onSiteClick(site);
+  },
+
+  render: function() {
+    return (
+      <ul className="sites-tree-view">
+      {this.props.sites.map(function(site){
+        return <SiteTreeViewNode key={site.uuid} site={site} onSiteClick={this.onSiteClick}/>;
+      }.bind(this))}
+      </ul>
+    );
+  }
+});
+
+var SiteTreeViewNode = React.createClass({
+  getInitialState: function() {
+    return { expanded: true };
+  },
+
+  toggle: function() {
+    this.setState(React.addons.update(this.state, {
+      expanded: { $set: !this.state.expanded }
+    }));
+  },
+
+  onSiteClick: function(event) {
+    this.props.onSiteClick(this.props.site);
+    event.preventDefault();
+  },
+
+  render: function() {
+    var site = this.props.site;
+    var inner = null;
+
+    if (site.children.length > 0 && this.state.expanded) {
+      inner = (
+        <ul>
+        {site.children.map(function(site){
+          return <SiteTreeViewNode onSiteClick={this.props.onSiteClick} key={site.uuid} site={site} />;
+        }.bind(this))}
+        </ul>
+      );
+    }
+
+    return (
+      <li key={site.uuid} className={(this.state.expanded ? "expanded" : "") + " " + (site.selected ? "selected" : "")}>
+        <button onClick={this.toggle} />
+
+        <a href="#" onClick={this.onSiteClick}>{site.name}</a>
+        {inner}
+      </li>
+    );
+  }
+});

--- a/app/assets/javascripts/components/sites.js.jsx
+++ b/app/assets/javascripts/components/sites.js.jsx
@@ -114,7 +114,7 @@ var SitePicker = React.createClass({
   render: function() {
     return (
       <div>
-        <input type="text" onChange={this.onSearchChange} autoFocus="true" />
+        <input type="text" onChange={this.onSearchChange} autoFocus="true" placeholder="Search sites" />
         <SitesTreeView sites={this.state.sites_tree} onSiteClick={this.selectSite} />
       </div>
     )

--- a/app/assets/javascripts/components/sites.js.jsx
+++ b/app/assets/javascripts/components/sites.js.jsx
@@ -1,28 +1,3 @@
-var NavigationContextPicker = React.createClass({
-  getInitialState: function() {
-    return { context: this.props.context };
-  },
-
-  changeContextSite: function(site) {
-    this.setState(React.addons.update(this.state, {
-      context: { $set: site }
-    }));
-  },
-
-  render: function() {
-    // since the picker tracks the selected state
-    // there is no need to update the properties
-    return (
-      <div>
-        <p>
-        Selected: {this.state.context.name} - {this.state.context.uuid}
-        </p>
-        <SitePicker selected_uuid={this.props.context.uuid} onSiteSelected={this.changeContextSite} />
-      </div>
-    );
-  }
-});
-
 var SitePicker = React.createClass({
   getDefaultProps: function() {
     return {

--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -78,3 +78,13 @@
     width: 4em;
   }
 }
+
+.sites-tree-view {
+  li li {
+    padding-left: 1em;
+  }
+
+  .selected > a {
+    background-color: #ccc;
+  }
+}

--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -204,3 +204,7 @@ a[title="Back"] {
   }
 
 }
+
+#nav-context {
+  color: $white;
+}

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -178,6 +178,34 @@ footer {
     position: absolute;
     display: block;
     width: 300px;
+    background-color: $gray4;
+    padding: 10px;
+    color: $white-dark;
+
+    input, input:focus {
+      color: $white-light;
+    }
+
+    a {
+      color: $white-dark;
+    }
+
+    .sites-tree-view {
+      .selected > a::before {
+        content: '';
+        background-color: $black;
+        right: 0;
+        left: 0;
+        position: absolute;
+        height: 1.4em;
+        z-index: -1;
+      }
+
+      .selected > a {
+        color: $white-light;
+        background-color: $black;
+      }
+    }
   }
 
   .content {

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -168,3 +168,19 @@ footer {
     }
   }
 }
+
+#context_side_bar {
+  display: none;
+}
+
+.show-navigation-context-picker {
+  #context_side_bar {
+    position: absolute;
+    display: block;
+    width: 300px;
+  }
+
+  .content {
+    margin-left: 300px;
+  }
+}

--- a/app/controllers/api/sites_controller.rb
+++ b/app/controllers/api/sites_controller.rb
@@ -10,7 +10,7 @@ class Api::SitesController < ApiController
     @sites = check_access(@sites, READ_SITE).map do |site|
       @uuids << site.uuid
 
-      {"uuid" => site.uuid, "name" => site.name, "location" => site.location_geoid, "parent_uuid" => site.parent.try(:uuid) }
+      {"uuid" => site.uuid, "name" => site.name, "location" => site.location_geoid, "parent_uuid" => site.parent.try(:uuid), "institution_uuid" => site.institution.uuid }
     end
 
     @sites.each do |site|
@@ -19,7 +19,7 @@ class Api::SitesController < ApiController
 
     respond_to do |format|
       format.csv do
-        build_csv 'Sites', CSVBuilder.new(@sites, column_names: ["uuid", "name", "location"])
+        build_csv 'Sites', CSVBuilder.new(@sites, column_names: ["uuid", "name", "location", "parent_uuid", "institution_uuid"])
         render :layout => false
       end
       format.json do

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,6 +4,8 @@ class ApiController < ApplicationController
 
   skip_before_filter :authenticate_user!
   skip_before_filter :verify_authenticity_token
+  skip_before_filter :ensure_context_in_url
+  skip_before_filter :load_context
 
   before_action :doorkeeper_authorize!, unless: lambda { current_user }
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,8 +4,7 @@ class ApiController < ApplicationController
 
   skip_before_filter :authenticate_user!
   skip_before_filter :verify_authenticity_token
-  skip_before_filter :ensure_context_in_url
-  skip_before_filter :load_context
+  skip_before_filter :ensure_context
 
   before_action :doorkeeper_authorize!, unless: lambda { current_user }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,6 +88,7 @@ class ApplicationController < ActionController::Base
   end
 
   def ensure_context_in_url
+    return if request.xhr? || !request.get?
     default_context = default_url_options[:context]
     if params[:context].blank? && default_context
       redirect_to url_for(params)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :check_no_institution!
   before_action :load_js_global_settings
+  before_action :load_context
 
   decent_configuration do
     strategy DecentExposure::StrongParametersStrategy
@@ -65,6 +66,21 @@ class ApplicationController < ActionController::Base
       @institutions
     else
       @institutions
+    end
+  end
+
+  def default_url_options(options={})
+    if current_user
+      default_context = params[:context_uuid] || check_access(Institution, READ_INSTITUTION).first.try(:uuid)
+      return {:context_uuid => default_context} if default_context
+    end
+
+    {}
+  end
+
+  def load_context
+    if current_user
+      @navigation_context = NavigationContext.new(current_user, params[:context_uuid])
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,17 +55,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # filters/authorize @institutions by action. Assign calls resource.institution= if only one institution was left
+  # filters/authorize navigation_context institutions by action. Assign calls resource.institution= if action is allowed
   def prepare_for_institution_and_authorize(resource, action)
-    @institutions = authorize_resource(@institutions, action)
-    if @institutions.blank?
+    if authorize_resource(@navigation_context.institution, action).blank?
       head :forbidden
       nil
-    elsif @institutions.one?
-      resource.institution = @institutions.first
-      @institutions
     else
-      @institutions
+      resource.institution = @navigation_context.institution
     end
   end
 

--- a/app/controllers/device_logs_controller.rb
+++ b/app/controllers/device_logs_controller.rb
@@ -3,6 +3,7 @@ class DeviceLogsController < ApplicationController
 
   skip_before_filter :verify_authenticity_token, only: [:create]
   skip_before_filter :authenticate_user!, only: [:create]
+  skip_before_filter :ensure_context_in_url, only: [:create]
 
   def index
     @device_logs = @device.device_logs.order(created_at: :desc)

--- a/app/controllers/device_logs_controller.rb
+++ b/app/controllers/device_logs_controller.rb
@@ -3,7 +3,7 @@ class DeviceLogsController < ApplicationController
 
   skip_before_filter :verify_authenticity_token, only: [:create]
   skip_before_filter :authenticate_user!, only: [:create]
-  skip_before_filter :ensure_context_in_url, only: [:create]
+  skip_before_filter :ensure_context, only: [:create]
 
   def index
     @device_logs = @device.device_logs.order(created_at: :desc)

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -14,8 +14,7 @@ class DevicesController < ApplicationController
     @devices = check_access(Device, READ_DEVICE).joins(:device_model).includes(:site, :institution, device_model: :institution)
     @manufacturers = Institution.where(id: @devices.select('device_models.institution_id'))
 
-    @devices = @devices.where(institution_id: params[:institution].to_i) if params[:institution].presence
-    @devices = @devices.where(site_id: params[:site].to_i) if params[:site].presence
+    @devices = @devices.within(@navigation_context.entity)
     @devices = @devices.where(device_models: { institution_id: params[:manufacturer].to_i}) if params[:manufacturer].presence
 
     @can_create = has_access?(Institution, REGISTER_INSTITUTION_DEVICE)

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -12,9 +12,9 @@ class DevicesController < ApplicationController
 
   def index
     @devices = check_access(Device, READ_DEVICE).joins(:device_model).includes(:site, :institution, device_model: :institution)
+    @devices = @devices.within(@navigation_context.entity)
     @manufacturers = Institution.where(id: @devices.select('device_models.institution_id'))
 
-    @devices = @devices.within(@navigation_context.entity)
     @devices = @devices.where(device_models: { institution_id: params[:manufacturer].to_i}) if params[:manufacturer].presence
 
     @can_create = has_access?(Institution, REGISTER_INSTITUTION_DEVICE)

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -37,7 +37,7 @@ class DevicesController < ApplicationController
 
   def create
     @device = Device.new(device_params)
-    @institution = Institution.find_by_id params[:device][:institution_id]
+    @institution = @navigation_context.institution
     if @institution
       return unless authorize_resource(@institution, READ_INSTITUTION)
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,4 +11,7 @@ class HomeController < ApplicationController
   def join
     render layout: "clean"
   end
+
+  def design
+  end
 end

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -1,7 +1,7 @@
 class InstitutionsController < ApplicationController
   before_filter :load_institutions
   skip_before_filter :check_no_institution!, only: [:new, :create, :pending_approval]
-  skip_before_action :ensure_context_in_url
+  skip_before_action :ensure_context
 
   def index
     @can_create = has_access?(Institution, CREATE_INSTITUTION)

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -1,6 +1,7 @@
 class InstitutionsController < ApplicationController
   before_filter :load_institutions
   skip_before_filter :check_no_institution!, only: [:new, :create, :pending_approval]
+  skip_before_action :ensure_context_in_url
 
   def index
     @can_create = has_access?(Institution, CREATE_INSTITUTION)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,4 @@
 class SessionsController < Devise::SessionsController
   skip_before_action :check_no_institution!, only: :destroy
-  skip_before_action :ensure_context_in_url
+  skip_before_action :ensure_context
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,4 @@
 class SessionsController < Devise::SessionsController
   skip_before_action :check_no_institution!, only: :destroy
+  skip_before_action :ensure_context_in_url
 end

--- a/app/controllers/subscribers_controller.rb
+++ b/app/controllers/subscribers_controller.rb
@@ -1,5 +1,6 @@
 class SubscribersController < ApplicationController
   include Concerns::SubscribersController
+  skip_before_action :ensure_context_in_url
 
   respond_to :html, :json
   expose(:subscribers) do

--- a/app/controllers/subscribers_controller.rb
+++ b/app/controllers/subscribers_controller.rb
@@ -1,6 +1,6 @@
 class SubscribersController < ApplicationController
   include Concerns::SubscribersController
-  skip_before_action :ensure_context_in_url
+  skip_before_action :ensure_context
 
   respond_to :html, :json
   expose(:subscribers) do

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -32,6 +32,14 @@ class Device < ActiveRecord::Base
 
   delegate :current_manifest, to: :device_model
 
+  scope :within, -> (institution_or_site) {
+    if institution_or_site.is_a?(Institution)
+      where(institution: institution_or_site)
+    else
+      where("site_prefix LIKE concat(?, '%')", institution_or_site.prefix)
+    end
+  }
+
   CUSTOM_FIELD_TARGETS = ["patient.id", "sample.id", "encounter.id"]
 
   def self.filter_by_owner(user, check_conditions)

--- a/app/models/navigation_context.rb
+++ b/app/models/navigation_context.rb
@@ -4,7 +4,7 @@ class NavigationContext
   attr_reader :institution
   attr_reader :site
 
-  def initialize(user, uuid)
+  def initialize(user = nil, uuid = nil)
     @user = user
 
     @institution = Institution.where(uuid: uuid).first
@@ -26,11 +26,11 @@ class NavigationContext
   end
 
   def name
-    entity.name
+    entity.try :name
   end
 
   def uuid
-    entity.uuid
+    entity.try :uuid
   end
 
   def to_hash

--- a/app/models/navigation_context.rb
+++ b/app/models/navigation_context.rb
@@ -1,0 +1,39 @@
+class NavigationContext
+  attr_reader :user
+
+  attr_reader :institution
+  attr_reader :site
+
+  def initialize(user, uuid)
+    @user = user
+
+    @institution = Institution.where(uuid: uuid).first
+    @site = nil
+
+    if @institution
+      Policy.authorize Policy::Actions::READ_INSTITUTION, @institution, @user
+    else
+      @site = Site.where(uuid: uuid).first
+      if @site
+        Policy.authorize Policy::Actions::READ_SITE, @site, @user
+        @institution = @site.institution
+      end
+    end
+  end
+
+  def entity
+    site || institution
+  end
+
+  def name
+    entity.name
+  end
+
+  def uuid
+    entity.uuid
+  end
+
+  def to_hash
+    entity ? {name: name, uuid: uuid} : {}
+  end
+end

--- a/app/models/navigation_context.rb
+++ b/app/models/navigation_context.rb
@@ -10,14 +10,19 @@ class NavigationContext
     @institution = Institution.where(uuid: uuid).first
     @site = nil
 
-    if @institution
-      Policy.authorize Policy::Actions::READ_INSTITUTION, @institution, @user
-    else
+    unless @institution
       @site = Site.where(uuid: uuid).first
-      if @site
-        Policy.authorize Policy::Actions::READ_SITE, @site, @user
-        @institution = @site.institution
-      end
+      @institution = @site.try :institution
+    end
+  end
+
+  def can_read?
+    if @site
+      Policy.can?(Policy::Actions::READ_SITE, @site, @user)
+    elsif @institution
+      Policy.can?(Policy::Actions::READ_INSTITUTION, @institution, @user)
+    else
+      false
     end
   end
 

--- a/app/views/device_models/_form.haml
+++ b/app/views/device_models/_form.haml
@@ -7,7 +7,12 @@
             %li= msg
 
 = form_for(@device_model, html: { multipart: true }) do |f|
-  = render 'shared/select_institution_or_hidden', f: f, label_col_class: 'pe-3'
+  .row
+    .col.pe-3
+      = f.label :institution
+    .col
+      .value= f.object.institution
+
   .row
     .col.pe-3
       = f.label :name

--- a/app/views/device_models/index.haml
+++ b/app/views/device_models/index.haml
@@ -5,14 +5,9 @@
       - t.thead do
         %tr
           %th Name
-          - unless @institutions.one?
-            %th Institution
           %th Version
       - t.tbody do
         - @device_models.each do |device_model|
           %tr{data: {href: try_edit_device_model_path(device_model) }}
             %td= device_model.name
-            - unless @institutions.one?
-              %td= device_model.institution.try(:name)
             %td= device_model.current_manifest.try(:version)
-

--- a/app/views/devices/_filters.haml
+++ b/app/views/devices/_filters.haml
@@ -9,19 +9,6 @@
             Devices
       %form(data-auto-submit)
         .row
-          - if @institutions.size > 1
-            .filter
-              %label.block Institution
-              = cdx_select name: "institution", value: params["institution"] do |select|
-                - select.item "", "(all)"
-                - select.items @institutions, :id, :name
-          - if @sites.size > 1
-            .filter
-              %label.block Site
-              = cdx_select name: "site", value: params["site"] do |select|
-                - select.item "", "(all)"
-                - select.items @sites, :id, :name
-
           .filter
             %label.block Manufacturer
             = cdx_select name: "manufacturer", value: params["manufacturer"] do |select|

--- a/app/views/devices/_filters.haml
+++ b/app/views/devices/_filters.haml
@@ -7,7 +7,7 @@
             - if @can_create
               = link_to "+", new_device_path, class: 'btn-add side-link fix', title: 'Add Device'
             Devices
-      %form(data-auto-submit)
+      %form{action: devices_path, "data-auto-submit" => true}
         .row
           .filter
             %label.block Manufacturer

--- a/app/views/devices/_form.haml
+++ b/app/views/devices/_form.haml
@@ -6,7 +6,11 @@
           - @device.errors.full_messages.each do |msg|
             %li= msg
 
-  = render 'shared/select_institution_or_hidden', f: f
+  .row
+    .col.pe-2
+      = f.label :institution
+    .col
+      .value= f.object.institution
 
   .row
     .col.pe-2

--- a/app/views/devices/index.haml
+++ b/app/views/devices/index.haml
@@ -6,8 +6,6 @@
       - t.thead do
         %tr
           %th Name
-          - unless @institutions.one?
-            %th Institution
           %th Manufacturer
           %th Model
           %th Site
@@ -16,8 +14,6 @@
           %tr
           %tr{data: (@devices_to_read.include?(device.id) ? {href: device_path(device) } : {})}
             %td= device.name
-            - unless @institutions.one?
-              %td= device.institution.name
             %td= device.device_model.institution.try :name
             %td= device.device_model.full_name
             %td= device.site.try(:name)

--- a/app/views/home/design.haml
+++ b/app/views/home/design.haml
@@ -1,1 +1,4 @@
-= react_component('ContextSitePicker', {site: check_access(Site, Policy::Actions::READ_SITE).sample.tap{ |site| { uuid: site.uuid, name: site.name } } })
+= react_component('NavigationContextPicker', {context: @navigation_context.to_hash })
+
+
+%h1= @navigation_context.name

--- a/app/views/home/design.haml
+++ b/app/views/home/design.haml
@@ -1,4 +1,1 @@
-= react_component('NavigationContextPicker', {context: @navigation_context.to_hash })
-
-
-%h1= @navigation_context.name
+%h1= @navigation_context.name || 'No context'

--- a/app/views/home/design.haml
+++ b/app/views/home/design.haml
@@ -1,0 +1,1 @@
+= react_component('ContextSitePicker', {site: check_access(Site, Policy::Actions::READ_SITE).sample.tap{ |site| { uuid: site.uuid, name: site.name } } })

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,6 +12,8 @@
       %header
         = render "shared/header_nav"
 
+      #context_side_bar{"data-context-react-props": {context: @navigation_context.to_hash}.to_json}
+
       .content
         = flash_message
         = yield(:subheader)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,7 @@
       %header
         = render "shared/header_nav"
 
-      #context_side_bar{"data-context-react-props": {context: @navigation_context.to_hash}.to_json}
+      #context_side_bar{"data-context-react-props": {context: @navigation_context.try(:to_hash) || {}}.to_json}
 
       .content
         = flash_message

--- a/app/views/shared/_header_nav.haml
+++ b/app/views/shared/_header_nav.haml
@@ -2,6 +2,11 @@
   .logo
     = image_tag 'cdx-logo.png'
 
+  - if @navigation_context.entity
+    %a#nav-context(href='#')
+      at
+      = @navigation_context.name
+
   %nav
     - if current_user && !@hide_nav_bar
       %ul

--- a/app/views/shared/_header_nav.haml
+++ b/app/views/shared/_header_nav.haml
@@ -2,7 +2,7 @@
   .logo
     = image_tag 'cdx-logo.png'
 
-  - if @navigation_context.entity
+  - if @navigation_context.try(:entity)
     %a#nav-context(href='#')
       at
       = @navigation_context.name

--- a/app/views/sites/_filters.haml
+++ b/app/views/sites/_filters.haml
@@ -8,7 +8,7 @@
               = link_to "+", new_site_path, class: 'btn-add side-link fix', title: 'Add Site'
             Sites
       - unless @institutions.one?
-        %form(data-auto-submit)
+        %form{action: sites_path, "data-auto-submit" => true}
           .row
             .filter
               %label.block Institution

--- a/app/views/test_results/_filters.haml
+++ b/app/views/test_results/_filters.haml
@@ -1,5 +1,5 @@
 - content_for(:subheader) do
-  %form#filters-form(data-auto-submit)
+  %form#filters-form{action: test_results_path, "data-auto-submit" => true}
     %input{type: "hidden", name: "page_size", value: @page_size}
     .row.center.filters
       .col.pe-10

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
   root :to => 'home#index'
   get 'verify' => 'home#verify'
   get 'join' => 'home#join'
+  get 'design' => 'home#design'
 
   namespace :api, defaults: { format: 'json' } do
     resources :activations, only: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Rails.application.routes.draw do
     registrations: 'registrations'
   }
 
+  scope 'c/:context_uuid' do
+    get 'design' => 'home#design'
+  end
+
   resources :sites do
     member do
       get :devices
@@ -91,7 +95,6 @@ Rails.application.routes.draw do
   root :to => 'home#index'
   get 'verify' => 'home#verify'
   get 'join' => 'home#join'
-  get 'design' => 'home#design'
 
   namespace :api, defaults: { format: 'json' } do
     resources :activations, only: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,10 +11,6 @@ Rails.application.routes.draw do
     registrations: 'registrations'
   }
 
-  scope 'c/:context_uuid' do
-    get 'design' => 'home#design'
-  end
-
   resources :sites do
     member do
       get :devices
@@ -95,6 +91,7 @@ Rails.application.routes.draw do
   root :to => 'home#index'
   get 'verify' => 'home#verify'
   get 'join' => 'home#join'
+  get 'design' => 'home#design'
 
   namespace :api, defaults: { format: 'json' } do
     resources :activations, only: :create

--- a/db/migrate/20151120181949_add_last_navigation_context_to_users.rb
+++ b/db/migrate/20151120181949_add_last_navigation_context_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastNavigationContextToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :last_navigation_context, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -394,6 +394,7 @@ ActiveRecord::Schema.define(version: 20151130130846) do
     t.integer  "invited_by_id",                  limit: 4
     t.string   "invited_by_type",                limit: 255
     t.integer  "invitations_count",              limit: 4,   default: 0
+    t.string   "last_navigation_context",        limit: 255
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/features/support/page_objects/cdx_page_base.rb
+++ b/features/support/page_objects/cdx_page_base.rb
@@ -1,7 +1,20 @@
 class CdxPageBase < SitePrism::Page
   include CdxPageHelper
 
+  class NavigationContextSection < SitePrism::Section
+    def select(text)
+      click_link text
+    end
+  end
+
+  element :navigation_context_handle, "#nav-context"
+  section :navigation_context, NavigationContextSection, "#context_side_bar"
   element :primary, ".btn-primary"
+
+  def open_context_picker
+    navigation_context_handle.click
+    yield navigation_context
+  end
 
   def submit
     primary.click

--- a/features/support/page_objects/cdx_page_base.rb
+++ b/features/support/page_objects/cdx_page_base.rb
@@ -10,6 +10,7 @@ class CdxPageBase < SitePrism::Page
   element :navigation_context_handle, "#nav-context"
   section :navigation_context, NavigationContextSection, "#context_side_bar"
   element :primary, ".btn-primary"
+  element :content, ".content", match: :first
 
   def open_context_picker
     navigation_context_handle.click
@@ -19,5 +20,13 @@ class CdxPageBase < SitePrism::Page
   def submit
     primary.click
     wait_for_submit
+  end
+
+  def success?
+    status_code == 200
+  end
+
+  def forbidden?
+    status_code == 403
   end
 end

--- a/features/support/page_objects/device_page.rb
+++ b/features/support/page_objects/device_page.rb
@@ -25,7 +25,7 @@ class DevicePage < DeviceSetupPage
 end
 
 class NewDevicePage < CdxPageBase
-  set_url '/devices/new'
+  set_url '/devices/new{?query*}'
 
   section :device_model, CdxSelect, "label", text: /Device Model/i
   element :name, :field, "Name"

--- a/features/support/page_objects/home_page.rb
+++ b/features/support/page_objects/home_page.rb
@@ -1,4 +1,4 @@
-class HomePage < SitePrism::Page
+class HomePage < CdxPageBase
   set_url '/'
 
   element :sign_in, :link, "Sign in", match: :first

--- a/spec/controllers/api/sites_controller_spec.rb
+++ b/spec/controllers/api/sites_controller_spec.rb
@@ -13,7 +13,7 @@ describe Api::SitesController do
       institution = Institution.make user: user
       sites = 3.times.map do
         site = Site.make(institution: institution)
-        {'uuid' => site.uuid, 'name' => site.name, 'location' => site.location_geoid, 'parent_uuid' => site.parent.try(:uuid)}
+        {'uuid' => site.uuid, 'name' => site.name, 'location' => site.location_geoid, 'parent_uuid' => site.parent.try(:uuid), 'institution_uuid' => site.institution.uuid}
       end
 
       result = get :index, format: 'json'
@@ -24,7 +24,7 @@ describe Api::SitesController do
       institution = Institution.make user: user
       sites = 3.times.map do
         site = Site.make(institution: institution)
-        {'uuid' => site.uuid, 'name' => site.name, 'location' => site.location_geoid, 'parent_uuid' => site.parent.try(:uuid)}
+        {'uuid' => site.uuid, 'name' => site.name, 'location' => site.location_geoid, 'parent_uuid' => site.parent.try(:uuid), 'institution_uuid' => site.institution.uuid}
       end
 
       Site.make institution: (Institution.make user: user)
@@ -52,7 +52,7 @@ describe Api::SitesController do
         get :index, format: 'json'
         expect(json_response).to include({'total_count' => 5})
         [root, site_a, site_a_1, site_b, site_b_1].map { |site|
-          expect(response_of(site)).to eq({'uuid' => site.uuid, 'name' => site.name, 'location' => site.location_geoid, 'parent_uuid' => site.parent.try(:uuid)})
+          expect(response_of(site)).to eq({'uuid' => site.uuid, 'name' => site.name, 'location' => site.location_geoid, 'parent_uuid' => site.parent.try(:uuid), 'institution_uuid' => site.institution.uuid})
         }
       end
 
@@ -63,7 +63,7 @@ describe Api::SitesController do
 
         get :index, format: 'json'
         expect(json_response).to include({'total_count' => 1})
-        expect(response_of(site_a_1)).to eq({'uuid' => site_a_1.uuid, 'name' => site_a_1.name, 'location' => site_a_1.location_geoid, 'parent_uuid' => nil})
+        expect(response_of(site_a_1)).to eq({'uuid' => site_a_1.uuid, 'name' => site_a_1.name, 'location' => site_a_1.location_geoid, 'parent_uuid' => nil, 'institution_uuid' => site_a_1.institution.uuid})
       end
 
       it "READ_SITE should propagate to the childs" do
@@ -73,9 +73,9 @@ describe Api::SitesController do
 
         get :index, format: 'json'
         expect(json_response).to include({'total_count' => 3})
-        expect(response_of(site_a)).to eq({'uuid' => site_a.uuid, 'name' => site_a.name, 'location' => site_a.location_geoid, 'parent_uuid' => nil})
-        expect(response_of(site_a_1)).to eq({'uuid' => site_a_1.uuid, 'name' => site_a_1.name, 'location' => site_a_1.location_geoid, 'parent_uuid' => site_a_1.parent.uuid})
-        expect(response_of(site_b_1)).to eq({'uuid' => site_b_1.uuid, 'name' => site_b_1.name, 'location' => site_b_1.location_geoid, 'parent_uuid' => nil})
+        expect(response_of(site_a)).to eq({'uuid' => site_a.uuid, 'name' => site_a.name, 'location' => site_a.location_geoid, 'parent_uuid' => nil, 'institution_uuid' => site_a.institution.uuid})
+        expect(response_of(site_a_1)).to eq({'uuid' => site_a_1.uuid, 'name' => site_a_1.name, 'location' => site_a_1.location_geoid, 'parent_uuid' => site_a_1.parent.uuid, 'institution_uuid' => site_a_1.institution.uuid})
+        expect(response_of(site_b_1)).to eq({'uuid' => site_b_1.uuid, 'name' => site_b_1.name, 'location' => site_b_1.location_geoid, 'parent_uuid' => nil, 'institution_uuid' => site_b_1.institution.uuid})
       end
     end
 
@@ -101,7 +101,7 @@ describe Api::SitesController do
         get :index, format: 'csv'
 
         check_sites_csv response
-        expect(response.body).to eq("uuid,name,location\n#{site.uuid},#{site.name},#{site.location_geoid}\n")
+        expect(response.body).to eq("uuid,name,location,parent_uuid,institution_uuid\n#{site.uuid},#{site.name},#{site.location_geoid},\"#{site.parent.try(:uuid)}\",#{site.institution.uuid}\n")
       end
 
       it "renders column names even when there are no sites to render" do
@@ -110,7 +110,7 @@ describe Api::SitesController do
         get :index, format: 'csv'
 
         check_sites_csv response
-        expect(response.body).to eq("uuid,name,location\n")
+        expect(response.body).to eq("uuid,name,location,parent_uuid,institution_uuid\n")
       end
     end
   end

--- a/spec/controllers/device_models_controller_spec.rb
+++ b/spec/controllers/device_models_controller_spec.rb
@@ -13,6 +13,7 @@ describe DeviceModelsController do
   let!(:device_model3) { institution2.device_models.make(:unpublished) }
 
   before(:each) {sign_in user}
+  let(:default_params) { {context: institution.uuid} }
 
   let(:manifest_attributes) do
     {"definition" => %{{

--- a/spec/controllers/devices_controller_spec.rb
+++ b/spec/controllers/devices_controller_spec.rb
@@ -12,6 +12,7 @@ describe DevicesController do
   let!(:other_site) {other_institution.sites.make}
 
   before(:each) {sign_in user}
+  let(:default_params) { {context: institution.uuid} }
 
   context "Index" do
 

--- a/spec/controllers/devices_controller_spec.rb
+++ b/spec/controllers/devices_controller_spec.rb
@@ -30,17 +30,26 @@ describe DevicesController do
     it "should display index when other user grants permissions" do
       grant user2, user, [Institution.resource_name, Device.resource_name], "*"
 
-      get :index
+      get :index, context: institution2.uuid
       expect(response).to be_success
-      expect(assigns(:devices)).to contain_exactly(device, device2)
+      expect(assigns(:devices)).to contain_exactly(device2)
     end
 
     it "should display index filtered by institution" do
-      grant user2, user, [Institution.resource_name, Device.resource_name], "*"
+      other_device = Device.make institution: other_institution
 
-      get :index, institution: institution2.id
+      get :index, context: other_institution.uuid
       expect(response).to be_success
-      expect(assigns(:devices)).to contain_exactly(device2)
+      expect(assigns(:devices)).to contain_exactly(other_device)
+    end
+
+    it "should display index filtered by site" do
+      other_site = Site.make institution: institution
+      other_device = Device.make site: other_site
+
+      get :index, context: other_site.uuid
+      expect(response).to be_success
+      expect(assigns(:devices)).to contain_exactly(other_device)
     end
 
     it "should display index filtered by manufacturer" do
@@ -49,10 +58,11 @@ describe DevicesController do
         device_model.institution = manufacturer
         device_model.save!
       end
+      Device.make institution: institution2
 
       grant user2, user, [Institution.resource_name, Device.resource_name], "*"
 
-      get :index, manufacturer: manufacturer.id
+      get :index, context: institution2.uuid, manufacturer: manufacturer.id
       expect(response).to be_success
       expect(assigns(:devices)).to contain_exactly(device2)
     end
@@ -105,18 +115,15 @@ describe DevicesController do
     let!(:user2) {User.make}
     let!(:institution2) {Institution.make user: user2}
     let!(:device2) {institution2.devices.make site: nil}
+    let(:default_params) { {context: institution2.uuid} }
 
-    it "should display filters when there are devices from more than one institution or site" do
+    it "should display devices without sites when selecting instituion" do
       grant user2, user, Resource.all.map(&:resource_name), "*"
 
       get :index
       expect(response).to be_success
-      expect(assigns(:devices)).to contain_exactly(device, device2)
-
-      expect(assigns(:institutions)).to contain_exactly(institution, institution2, other_institution)
-      expect(assigns(:sites)).to contain_exactly(site, other_site)
+      expect(assigns(:devices)).to contain_exactly(device2)
     end
-
   end
 
   context "New" do

--- a/spec/controllers/devices_controller_spec.rb
+++ b/spec/controllers/devices_controller_spec.rb
@@ -279,17 +279,6 @@ describe DevicesController do
 
     it "doesn't crash when there's no device model (#578)" do
       post :create, device: {
-        institution_id: institution.id,
-        name: "foo",
-        serial_number: "123"
-      }
-
-      expect(response).to be_ok
-    end
-
-    it "doesn't crash when there's no institution (#578)" do
-      post :create, device: {
-        device_model_id: device_model.id,
         name: "foo",
         serial_number: "123"
       }

--- a/spec/controllers/encounters_controller_spec.rb
+++ b/spec/controllers/encounters_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe EncountersController, type: :controller, elasticsearch: true do
   let(:user) { institution.user }
 
   before(:each) { sign_in user }
+  let(:default_params) { {context: institution.uuid} }
 
   describe "GET #new" do
     it "returns http success" do

--- a/spec/controllers/filters_controller_spec.rb
+++ b/spec/controllers/filters_controller_spec.rb
@@ -5,6 +5,7 @@ describe FiltersController do
   let!(:institution) { user.create Institution.make_unsaved }
   let!(:filter) { user.filters.make query: { site: 1 } }
   before(:each) { sign_in user }
+  let(:default_params) { {context: institution.uuid} }
 
   it "list filters" do
     get :index, format: :json

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -10,6 +10,7 @@ describe SitesController do
   let!(:site2)  { institution2.sites.make }
 
   before(:each) {sign_in user}
+  let(:default_params) { {context: institution.uuid} }
 
   context "index" do
 

--- a/spec/controllers/test_results_controller_spec.rb
+++ b/spec/controllers/test_results_controller_spec.rb
@@ -9,6 +9,7 @@ describe TestResultsController, elasticsearch: true do
   let(:device)      { Device.make institution_id: institution.id, site: site }
 
   before(:each) {sign_in user}
+  let(:default_params) { {context: institution.uuid} }
 
   let(:other_user)        { User.make }
   let(:other_institution) { Institution.make user_id: other_user.id }

--- a/spec/controllers/test_results_controller_spec.rb
+++ b/spec/controllers/test_results_controller_spec.rb
@@ -66,6 +66,7 @@ describe TestResultsController, elasticsearch: true do
     let!(:other_device) { Device.make institution_id: other_institution.id, site: other_site }
 
     before(:each) { sign_in user }
+    let(:default_params) { {context: other_institution.uuid} }
 
     it "should not authorize outsider user" do
       get :show, id: test_result.uuid

--- a/spec/features/navigation_context_spec.rb
+++ b/spec/features/navigation_context_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe "navigation context" do
+  let(:institution) { Institution.make }
+  let(:user) { institution.user }
+  before(:each) { sign_in(user) }
+
+  it "user without context history shold get the institution as context" do
+    goto_page HomePage
+    user.reload
+    expect(page).to have_content(institution.name)
+    expect(user.last_navigation_context).to eq(institution.uuid)
+  end
+
+  it "user get last context by default" do
+    other_institution = Institution.make user: user
+    goto_page HomePage do |page|
+      expect(page).to_not have_content(other_institution.name)
+
+      page.open_context_picker do |context|
+        context.select other_institution.name
+      end
+    end
+
+    user.reload
+    expect(user.last_navigation_context).to eq(other_institution.uuid)
+
+    goto_page HomePage do |page|
+      expect(page).to have_content(other_institution.name)
+      expect(page).to_not have_content(institution.name)
+    end
+  end
+
+  it "user is get back to a safe context if permission changed" do
+    other_institution = Institution.make
+    user.update_attribute :last_navigation_context, other_institution.uuid
+
+    goto_page HomePage
+
+    expect(page).to have_content(institution.name)
+    user.reload
+    expect(user.last_navigation_context).to eq(institution.uuid)
+  end
+end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -71,6 +71,40 @@ describe Device do
     end
   end
 
+  context "within institution or site scope" do
+    let(:institution) { Institution.make }
+    let(:other_institution) { Institution.make }
+
+    let(:site1)  { Site.make institution: institution }
+    let(:site11) { Site.make :child, parent: site1 }
+    let(:site12) { Site.make :child, parent: site1 }
+    let(:site2)  { Site.make institution: institution }
+
+    let(:device1)  { Device.make site: site1 }
+    let(:device11) { Device.make site: site11 }
+    let(:device12) { Device.make site: site12 }
+    let(:device2)  { Device.make site: site2 }
+
+    let(:other_device)  { Device.make institution: other_institution }
+
+    it "should filter by institution" do
+      expect(Device.within(institution)).to eq([device1, device11, device12, device2])
+    end
+
+    it "filtering by site should include self" do
+      expect(Device.within(site1)).to include(device1)
+    end
+
+    it "filtering by site should include descendants" do
+      expect(Device.within(site1)).to include(device11)
+      expect(Device.within(site1)).to include(device12)
+    end
+
+    it "filtering by site should not include sibling" do
+      expect(Device.within(site1)).to_not include(device2)
+    end
+  end
+
   context 'cascade destroy', elasticsearch: true do
 
     it "should delete device elements in cascade" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,7 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = 'examples.txt'
 
   config.include Devise::TestHelpers, :type => :controller
+  config.include DefaultParamsHelper, :type => :controller
   config.include ManifestSpecHelper
   config.include CdxFieldsHelper
   config.include FeatureSpecHelpers, :type => :feature

--- a/spec/support/default_params_helper.rb
+++ b/spec/support/default_params_helper.rb
@@ -1,0 +1,19 @@
+require 'active_support/concern'
+require 'active_support/core_ext/module/aliasing'
+
+# inspired in https://gist.github.com/phillbaker/7617703
+module DefaultParamsHelper
+  extend ActiveSupport::Concern
+
+  def process_with_default_params(action, *args)
+    if args[1].nil? || args[1].is_a?(Hash)
+      args[1] = default_params.merge(args[1] || {})
+    end
+    process_without_default_params(action, *args)
+  end
+
+  included do
+    let(:default_params) { {} }
+    alias_method_chain :process, :default_params
+  end
+end


### PR DESCRIPTION
fixes #514 without full styling.

Context is kept in url. Last is stored in users table. 
By default a context is enforced, if missing a redirect is performed.
All urls by default will have the current context. (see `ApplicationController#default_url_options`)
The context is institution.uuid or site.uuid (there was an idea of shortening these codes a bit upon creation).
Instituion/Sites of users are fully loaded and filtered client side (react component)

Stories around filtering / using context in devices and devices models are implemented and so this fixes #516 and fixes #577 .

NavigationContext can be accessed via `@navigation_context`

This includes Turbolinks in order to preserve navigation context control across page changes.