### PR TITLE
Feature/587 scope sites with navigation context

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -14,6 +14,7 @@ class SitesController < ApplicationController
   def new
     @site = Site.new
     @sites = check_access(Site, READ_SITE)
+    @site.parent = @navigation_context.site
     prepare_for_institution_and_authorize(@site, CREATE_INSTITUTION_SITE)
   end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -22,6 +22,14 @@ class Site < ActiveRecord::Base
 
   attr_writer :location
 
+  scope :within, -> (institution_or_site) {
+    if institution_or_site.is_a?(Institution)
+      where(institution: institution_or_site)
+    else
+      where("prefix LIKE concat(?, '%')", institution_or_site.prefix)
+    end
+  }
+
   def location(opts={})
     @location = nil if @location_opts.presence != opts.presence
     @location_opts = opts

--- a/app/views/sites/_filters.haml
+++ b/app/views/sites/_filters.haml
@@ -7,11 +7,6 @@
             - if @can_create
               = link_to "+", new_site_path, class: 'btn-add side-link fix', title: 'Add Site'
             Sites
-      - unless @institutions.one?
-        %form{action: sites_path, "data-auto-submit" => true}
-          .row
-            .filter
-              %label.block Institution
-              = cdx_select name: "institution", value: params["institution"] do |select|
-                - select.item "", "(all)"
-                - select.items @institutions, :id, :name
+        -# %form{action: sites_path, "data-auto-submit" => true}
+        -#   .row
+        -#      NB: No filters available right now, but the form should be that

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -6,7 +6,11 @@
           - @site.errors.full_messages.each do |msg|
             %li= msg
 
-  = render 'shared/select_institution_or_hidden', f: f
+  .row
+    .col.pe-2
+      = f.label :institution
+    .col
+      .value= f.object.institution
 
   .row
     .col.pe-2

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -28,7 +28,7 @@
         = f.label :parent
       .col
         = cdx_select form: f, name: :parent_id, class: 'input-x-large' do |select|
-          - select.item "", "Choose one"
+          - select.item "", "None"
           - select.items @sites, :id, :name
   - elsif @site.parent
     .row

--- a/app/views/sites/index.html.haml
+++ b/app/views/sites/index.html.haml
@@ -5,11 +5,9 @@
       - t.thead do
         %tr
           %th Name
-          %th Institution
           %th Location
       - t.tbody do
         - @sites.each do |site|
           %tr{data: {href: site_path(site) }}
             %td= site.name
-            %td= site.institution.name
             %td= site.location.try(:name)

--- a/app/views/sites/index.html.haml
+++ b/app/views/sites/index.html.haml
@@ -5,13 +5,11 @@
       - t.thead do
         %tr
           %th Name
-          - unless @institutions.one?
-            %th Institution
+          %th Institution
           %th Location
       - t.tbody do
         - @sites.each do |site|
           %tr{data: {href: site_path(site) }}
             %td= site.name
-            - unless @institutions.one?
-              %td= site.institution.name
+            %td= site.institution.name
             %td= site.location.try(:name)

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -38,12 +38,24 @@ describe SitesController do
   end
 
   context "new" do
+    let!(:site) { institution.sites.make }
 
     it "should get new page" do
       get :new
       expect(response).to be_success
     end
 
+    it "should initialize no parent if context is institution" do
+      get :new, context: institution.uuid
+      expect(response).to be_success
+      expect(assigns(:site).parent).to be_nil
+    end
+
+    it "should initialize parent if context is site" do
+      get :new, context: site.uuid
+      expect(response).to be_success
+      expect(assigns(:site).parent).to eq(site)
+    end
   end
 
   context "create" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -51,4 +51,31 @@ describe Site do
     expect(Site.with_deleted).to include(site1)
     expect(site1).to be_deleted
   end
+
+  context "within institution or site scope" do
+    let(:institution) { Institution.make }
+    let(:other_institution) { Institution.make }
+
+    let(:site1)  { Site.make institution: institution }
+    let(:site11) { Site.make :child, parent: site1 }
+    let(:site12) { Site.make :child, parent: site1 }
+    let(:site2)  { Site.make institution: institution }
+
+    it "should filter by institution" do
+      expect(Site.within(institution)).to eq([site1, site11, site12, site2])
+    end
+
+    it "filtering by site should include self" do
+      expect(Site.within(site1)).to include(site1)
+    end
+
+    it "filtering by site should include descendants" do
+      expect(Site.within(site1)).to include(site11)
+      expect(Site.within(site1)).to include(site12)
+    end
+
+    it "filtering by site should not include sibling" do
+      expect(Site.within(site1)).to_not include(site2)
+    end
+  end
 end


### PR DESCRIPTION
fixes #587 
fixes #569 

There is a slightly duplicate logic between devices and sites since both are filterable within the hierarchy, but using different field names.