### PR TITLE
fix #644 hide create encounter button in test results if user can't create encounters

### DIFF
--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -14,7 +14,7 @@ class EncountersController < ApplicationController
   end
 
   def sites
-    sites = check_access(@navigation_context.institution.sites, READ_SITE)
+    sites = check_access(@navigation_context.institution.sites, CREATE_SITE_ENCOUNTER)
     render json: as_json_site_list(sites).attributes!
   end
 

--- a/app/controllers/test_results_controller.rb
+++ b/app/controllers/test_results_controller.rb
@@ -32,6 +32,8 @@ class TestResultsController < ApplicationController
 
         @filter["device.uuid"] = @devices.first.uuid if @devices.size == 1
 
+        @can_create_encounter = check_access(@navigation_context.institution.sites, CREATE_SITE_ENCOUNTER).size > 0
+
         execute_query
       end
 

--- a/app/views/test_results/_filters.haml
+++ b/app/views/test_results/_filters.haml
@@ -6,7 +6,8 @@
         .row
           .col
             %h1
-              = link_to "+", new_encounter_path, class: 'btn-add side-link fix', title: 'Add encounter'
+              - if @can_create_encounter
+                = link_to "+", new_encounter_path, class: 'btn-add side-link fix', title: 'Add encounter'
               Tests
         .row
           .filter

--- a/spec/controllers/encounters_controller_spec.rb
+++ b/spec/controllers/encounters_controller_spec.rb
@@ -72,13 +72,14 @@ RSpec.describe EncountersController, type: :controller, elasticsearch: true do
   end
 
   describe "GET #sites" do
-    it "returns sites of the context institution if user has access to them" do
+    it "returns sites of the context institution if user has access to create them" do
       i1 = Institution.make
       s1 = Site.make institution: i1
       s2 = Site.make institution: i1
 
       grant i1.user, user, i1, READ_INSTITUTION
       grant i1.user, user, s1, READ_SITE
+      grant i1.user, user, s1, CREATE_SITE_ENCOUNTER
 
       get :sites, context: i1.uuid
 


### PR DESCRIPTION
Although #644 is fixed in release-0.7, for 0.8 requires different changes.
This should overwrite 0.7 changes on master 

cc: @nekron 