### PR TITLE
Feature/640 scope sites in device creation

### DIFF
--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -197,15 +197,6 @@ class DevicesController < ApplicationController
     render partial: 'custom_mappings'
   end
 
-  def device_models
-    load_device_models_for_create
-
-    institution_id = params[:institution_id].to_i
-    @device_models = @device_models.select { |device_model| device_model.published? || device_model.institution_id == institution_id }.to_a
-
-    render partial: 'device_models'
-  end
-
   def performance
     @device = Device.find(params[:id])
     return unless authorize_resource(@device, READ_DEVICE)
@@ -250,7 +241,7 @@ class DevicesController < ApplicationController
   def load_device_models_for_create
     gon.device_models = @device_models = \
       (DeviceModel.includes(:institution).published.to_a + \
-       DeviceModel.includes(:institution).unpublished.where(institution_id: @institutions.map(&:id)).to_a)
+       DeviceModel.includes(:institution).unpublished.where(institution_id: @navigation_context.institution.id).to_a)
   end
 
   def load_device_models_for_update

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -206,15 +206,6 @@ class DevicesController < ApplicationController
     render partial: 'device_models'
   end
 
-  def sites
-    load_sites
-
-    institution_id = params[:institution_id].to_i
-    @sites = @sites.where(institution_id: institution_id)
-
-    render partial: 'sites'
-  end
-
   def performance
     @device = Device.find(params[:id])
     return unless authorize_resource(@device, READ_DEVICE)
@@ -244,7 +235,7 @@ class DevicesController < ApplicationController
   end
 
   def load_sites
-    @sites = check_access(Site, ASSIGN_DEVICE_SITE)
+    @sites = check_access(@navigation_context.institution.sites, ASSIGN_DEVICE_SITE)
     @sites ||= []
   end
 

--- a/app/views/devices/_device_models.haml
+++ b/app/views/devices/_device_models.haml
@@ -1,2 +1,0 @@
-= cdx_select name: 'device[device_model_id]', value: @device.try(&:device_model_id), class: 'input-x-large' do |select|
-  - select.items(@device_models, :id, :full_name)

--- a/app/views/devices/_form.haml
+++ b/app/views/devices/_form.haml
@@ -21,8 +21,9 @@
     .row
       .col.pe-2
         = f.label :site
-      .col#device_sites
-        = render "sites"
+      .col
+        = cdx_select form: f, name: :site_id, class: 'input-x-large' do |select|
+          - select.items(@sites, :id, :name)
   .row
     .col.pe-2
       = f.label :name
@@ -63,23 +64,3 @@
             cdx_init_components($("#custom_mappings"))
         )
         selected_device_model_id = device_model_id
-
-    if $('form.new_device').length > 0 && cdx_select_find("device[institution_id]").length > 0
-      selected_institution_id = #{@device.institution_id}
-      cdx_select_on_change "device[institution_id]", (institution_id) ->
-        if institution_id != selected_institution_id
-          $("#device_models").load(
-            "/devices/new/device_models",
-            {"institution_id": institution_id},
-            ->
-              cdx_init_components($("#device_models"))
-              $("#custom_mappings").empty()
-          )
-
-          $("#device_sites").load(
-            "/devices/sites",
-            {"institution_id": institution_id},
-            ->
-              cdx_init_components($("#device_sites"))
-          )
-          selected_institution_id = institution_id

--- a/app/views/devices/_form.haml
+++ b/app/views/devices/_form.haml
@@ -15,8 +15,9 @@
   .row
     .col.pe-2
       = f.label :device_model_id
-    .col#device_models
-      = render "device_models"
+    .col
+      = cdx_select form: f, name: :device_model_id, class: 'input-x-large' do |select|
+        - select.items(@device_models, :id, :full_name)
   - if has_access?(Site, Policy::Actions::READ_SITE)
     .row
       .col.pe-2

--- a/app/views/devices/_sites.haml
+++ b/app/views/devices/_sites.haml
@@ -1,2 +1,0 @@
-= cdx_select name: 'device[site_id]', value: @device.try(&:site_id), class: 'input-x-large' do |select|
-  - select.items(@sites, :id, :name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,6 @@ Rails.application.routes.draw do
     collection do
       post 'custom_mappings'
       post 'new/device_models' => 'devices#device_models'
-      post 'sites'
     end
     resources :custom_mappings, only: [:index]
     resources :ssh_keys, only: [:create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,6 @@ Rails.application.routes.draw do
     end
     collection do
       post 'custom_mappings'
-      post 'new/device_models' => 'devices#device_models'
     end
     resources :custom_mappings, only: [:index]
     resources :ssh_keys, only: [:create, :destroy]

--- a/spec/controllers/devices_controller_spec.rb
+++ b/spec/controllers/devices_controller_spec.rb
@@ -157,6 +157,16 @@ describe DevicesController do
       expect(assigns(:device_models)).to contain_exactly(published, unpublished)
     end
 
+    it "loads unpublished device models only of context institution" do
+      published = device_model
+      unpublished = institution.device_models.make(:unpublished)
+      other_institution = Institution.make(user: user)
+      other_unpublished = DeviceModel.make(:unpublished, institution: other_institution)
+
+      get :new, context: other_institution.uuid
+      expect(assigns(:device_models)).to contain_exactly(published, other_unpublished)
+    end
+
     it "loads all sites from allowed institutions in context" do
       yet_another_institution = Institution.make
       site1 = yet_another_institution.sites.make

--- a/spec/controllers/devices_controller_spec.rb
+++ b/spec/controllers/devices_controller_spec.rb
@@ -117,7 +117,7 @@ describe DevicesController do
     let!(:device2) {institution2.devices.make site: nil}
     let(:default_params) { {context: institution2.uuid} }
 
-    it "should display devices without sites when selecting instituion" do
+    it "should display devices without sites when selecting institution" do
       grant user2, user, Resource.all.map(&:resource_name), "*"
 
       get :index
@@ -157,9 +157,17 @@ describe DevicesController do
       expect(assigns(:device_models)).to contain_exactly(published, unpublished)
     end
 
-    it "loads all sites from allowed institutions" do
-      get :new
-      expect(assigns(:sites)).to contain_exactly(site, other_site)
+    it "loads all sites from allowed institutions in context" do
+      yet_another_institution = Institution.make
+      site1 = yet_another_institution.sites.make
+      site2 = yet_another_institution.sites.make
+
+      grant yet_another_institution.user, user, yet_another_institution, READ_INSTITUTION
+      grant yet_another_institution.user, user, yet_another_institution, REGISTER_INSTITUTION_DEVICE
+      grant yet_another_institution.user, user, site2, ASSIGN_DEVICE_SITE
+
+      get :new, context: yet_another_institution.uuid
+      expect(assigns(:sites)).to contain_exactly(site2)
     end
   end
 


### PR DESCRIPTION
fixes #640 
fixes #662 

remove unneeded partial page rendering actions and views due to navigation context. since the institution can't be changed inside the form all that related code is gone.