### PR TITLE
Feature/search patients

### DIFF
--- a/app/assets/javascripts/components/location_select.js.jsx
+++ b/app/assets/javascripts/components/location_select.js.jsx
@@ -69,9 +69,10 @@ var LocationSelect = React.createClass({
 
     var _this = this;
     var location = (selection && selection[0]) ? selection[0].location : null;
+    var latlng = location ? { lat: location.lat, lng: location.lng} : null;
     _this.setState(function(state) { return React.addons.update(state, {
       value: { $set: _this.formatLocation(location) },
-      latlng: { $set: { lat: location.lat, lng: location.lng} }
+      latlng: { $set: latlng }
     })});
 
     if (_this.props.onChange) {
@@ -127,6 +128,9 @@ var LocationSelect = React.createClass({
   },
 
   formatLocation: function(location) {
+    if (location == null) {
+      return {value: null, label: '', location: null};
+    }
     var name = location.name;
     if (location.ancestors && location.ancestors.length > 0) {
       var ancestorsNames = _.pluck(location.ancestors, 'name');

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -4,6 +4,7 @@ class PatientsController < ApplicationController
     @patients = check_access(Patient.where(institution: @navigation_context.institution), READ_PATIENT).order(updated_at: :desc)
 
     @patients = @patients.where("name LIKE concat('%', ?, '%')", params[:name]) unless params[:name].blank?
+    @patients = @patients.where("entity_id LIKE concat('%', ?, '%')", params[:entity_id]) unless params[:entity_id].blank?
 
     @page_size = (params["page_size"] || 10).to_i
     @page = (params["page"] || 1).to_i

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -19,6 +19,8 @@ class PatientsController < ApplicationController
       @patients = @patients.where("id in (#{Encounter.within(@navigation_context.entity).where("start_time > ?", @last_encounter).select(:patient_id).to_sql})")
     end
 
+    @patients.preload_locations!
+
     @page_size = (params["page_size"] || 10).to_i
     @page = (params["page"] || 1).to_i
     @patients = @patients.page(@page).per(@page_size)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -3,6 +3,10 @@ class PatientsController < ApplicationController
     @can_create = has_access?(@navigation_context.institution, CREATE_INSTITUTION_PATIENT)
     @patients = check_access(Patient.where(institution: @navigation_context.institution), READ_PATIENT).order(updated_at: :desc)
 
+    if @navigation_context.site
+      @patients = @patients.where("id in (#{Encounter.within(@navigation_context.site).select(:patient_id).to_sql})")
+    end
+
     @patients = @patients.where("name LIKE concat('%', ?, '%')", params[:name]) unless params[:name].blank?
     @patients = @patients.where("entity_id LIKE concat('%', ?, '%')", params[:entity_id]) unless params[:entity_id].blank?
     # location_geoid is hierarchical so a prefix search works

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -3,6 +3,8 @@ class PatientsController < ApplicationController
     @can_create = has_access?(@navigation_context.institution, CREATE_INSTITUTION_PATIENT)
     @patients = check_access(Patient.where(institution: @navigation_context.institution), READ_PATIENT).order(updated_at: :desc)
 
+    @patients = @patients.where("name LIKE concat('%', ?, '%')", params[:name]) unless params[:name].blank?
+
     @page_size = (params["page_size"] || 10).to_i
     @page = (params["page"] || 1).to_i
     @patients = @patients.page(@page).per(@page_size)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,7 +1,7 @@
 class PatientsController < ApplicationController
   def index
     @can_create = has_access?(@navigation_context.institution, CREATE_INSTITUTION_PATIENT)
-    @patients = check_access(Patient.where(institution: @navigation_context.institution), READ_PATIENT).order(updated_at: :desc)
+    @patients = check_access(Patient.where(institution: @navigation_context.institution), READ_PATIENT).order(:name)
 
     if @navigation_context.site
       @patients = @patients.where("id in (#{Encounter.within(@navigation_context.site).select(:patient_id).to_sql})")

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -5,6 +5,8 @@ class PatientsController < ApplicationController
 
     @patients = @patients.where("name LIKE concat('%', ?, '%')", params[:name]) unless params[:name].blank?
     @patients = @patients.where("entity_id LIKE concat('%', ?, '%')", params[:entity_id]) unless params[:entity_id].blank?
+    # location_geoid is hierarchical so a prefix search works
+    @patients = @patients.where("location_geoid LIKE concat(?, '%')", params[:location]) unless params[:location].blank?
 
     @page_size = (params["page_size"] || 10).to_i
     @page = (params["page"] || 1).to_i

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,6 +39,14 @@ module ApplicationHelper
     I18n.localize(value, locale: current_user.locale, format: :long)
   end
 
+  def format_date(value, time_zone = nil)
+    return nil unless value
+
+    value = Time.parse(value) unless value.is_a?(Time)
+    value = value.in_time_zone(time_zone) if time_zone
+    I18n.localize(value, locale: current_user.locale, format: I18n.t('date.input_format.pattern'))
+  end
+
   def flash_message
     res = nil
 

--- a/app/models/concerns/entity.rb
+++ b/app/models/concerns/entity.rb
@@ -17,6 +17,47 @@ module Entity
     validate    :valid_sensitive_fields
 
     acts_as_paranoid
+
+    # Creates accessors for Entity fields
+    #
+    # `attribute_field :foo, :bar` will generate r/w accessors for foo and bar fields, despite pii value
+    # `attribute_field :foo, source: :foo_field_name` will use "foo_field_name" as the source.
+    # `attribute_field :foo, copy: true` will ensure a copy of the value is keept in the foo attribute
+    #
+    def self.attribute_field(*args)
+      options = args.extract_options!
+      options.reverse_merge! copy: false
+      do_copy = options[:copy]
+
+      args.each do |arg|
+        field_name = (options[:field] || arg).to_s
+        field_source = if self.entity_fields.detect { |f| f.name == field_name }.pii?
+          "plain_sensitive_data"
+        else
+          "core_fields"
+        end
+
+        define_method arg do
+          send(field_source)[field_name]
+        end
+
+        define_method "#{arg}=" do |value|
+          write_attribute(arg, value) if do_copy
+          if value.blank?
+            send(field_source).delete(field_name)
+          else
+            send(field_source)[field_name] = value
+          end
+        end
+
+        if do_copy
+          # copy attribute to db, in case the entity_field was changed directly
+          before_validation do
+            write_attribute(arg, send(arg))
+          end
+        end
+      end
+    end
   end
 
   attr_writer :plain_sensitive_data

--- a/app/models/concerns/site_contained.rb
+++ b/app/models/concerns/site_contained.rb
@@ -1,0 +1,33 @@
+# SiteContained applies to entities that belongs both to Institution and to Site.
+# It keeps up to date a site_prefix field required to descendant filtering
+# Institution is mandatory. Site is optional.
+module SiteContained
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :institution
+    belongs_to :site
+
+    validates_presence_of :institution
+    validate :same_institution_of_site
+    before_save :set_site_prefix
+
+    scope :within, -> (institution_or_site) {
+      if institution_or_site.is_a?(Institution)
+        where(institution: institution_or_site)
+      else
+        where("site_prefix LIKE concat(?, '%')", institution_or_site.prefix)
+      end
+    }
+
+    def set_site_prefix
+      self.site_prefix = site.try(:prefix)
+    end
+
+    def same_institution_of_site
+      if self.site && self.site.institution != self.institution
+        errors.add(:site, "must belong to the institution")
+      end
+    end
+  end
+end

--- a/app/models/concerns/with_location.rb
+++ b/app/models/concerns/with_location.rb
@@ -1,0 +1,23 @@
+module WithLocation
+  extend ActiveSupport::Concern
+
+  included do
+    def location(opts={})
+      @location = nil if @location_opts.presence != opts.presence || @location.try(:geo_id) != location_geoid
+      @location_opts = opts
+      @location ||= Location.find(location_geoid, opts)
+    end
+
+    def location=(value)
+      @location = value
+      self.location_geoid = value.try(:id)
+    end
+
+    def self.preload_locations!
+      locations = Location.details(all.map(&:location_geoid).uniq).index_by(&:id)
+      all.to_a.each do |record|
+        record.location = locations[record.location_geoid]
+      end
+    end
+  end
+end

--- a/app/models/date_distance_helper.rb
+++ b/app/models/date_distance_helper.rb
@@ -1,0 +1,37 @@
+module DateDistanceHelper
+  include ActionView::Helpers::DateHelper
+
+  def years_between(first_date, second_date)
+    distance_between(first_date, second_date, :years)
+  end
+
+  def months_between(first_date, second_date)
+    distance_between(first_date, second_date, :months)
+  end
+
+  def days_between(first_date, second_date)
+    distance_between(first_date, second_date, :days)
+  end
+
+  def hours_between(first_date, second_date)
+    distance_between(first_date, second_date, :hours)
+  end
+
+  def minutes_between(first_date, second_date)
+    distance_between(first_date, second_date, :minutes)
+  end
+
+  def seconds_between(first_date, second_date)
+    distance_between(first_date, second_date, :seconds)
+  end
+
+  def milliseconds_between(first_date, second_date)
+    seconds_between(first_date, second_date) * 1000
+  end
+
+  def distance_between(first_date, second_date, unit)
+    second_date = DateTime.parse(second_date.to_s)
+    first_date = DateTime.parse(first_date.to_s)
+    distance_of_time_in_words_hash(first_date, second_date, accumulate_on: unit)[unit]
+  end
+end

--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -18,6 +18,12 @@ class Encounter < ActiveRecord::Base
 
   before_save :ensure_entity_id
 
+  def self.entity_scope
+    "encounter"
+  end
+
+  attribute_field :start_time, copy: true
+
   attr_accessor :new_samples # Array({entity_id: String}) of new generated samples from UI.
 
   def entity_id

--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -2,6 +2,7 @@ class Encounter < ActiveRecord::Base
   include Entity
   include AutoUUID
   include Resource
+  include SiteContained
 
   ASSAYS_FIELD = 'diagnosis'
   OBSERVATIONS_FIELD = 'observations'
@@ -9,13 +10,9 @@ class Encounter < ActiveRecord::Base
   has_many :samples, dependent: :restrict_with_error
   has_many :test_results, dependent: :restrict_with_error
 
-  belongs_to :institution
-  belongs_to :site
   belongs_to :patient
 
-  validates_presence_of :institution
   validates_presence_of :site, if: Proc.new { |encounter| encounter.institution && !encounter.institution.kind_manufacturer? }
-  validate :same_institution_of_site
 
   validate :validate_patient
 
@@ -95,7 +92,7 @@ class Encounter < ActiveRecord::Base
   end
 
   def test_results_not_in_diagnostic
-    diagnostic.present? ? test_results.where("updated_at > ?", self.user_updated_at || self.created_at) : test_results 
+    diagnostic.present? ? test_results.where("updated_at > ?", self.user_updated_at || self.created_at) : test_results
   end
 
   def diagnostic
@@ -123,12 +120,6 @@ class Encounter < ActiveRecord::Base
 
   def ensure_entity_id
     self.entity_id = entity_id
-  end
-
-  def same_institution_of_site
-    if self.site && self.site.institution != self.institution
-      errors.add(:site, "must belong to the institution of the device")
-    end
   end
 
 end

--- a/app/models/manifest_field_mapping.rb
+++ b/app/models/manifest_field_mapping.rb
@@ -1,5 +1,5 @@
 class ManifestFieldMapping
-  include ActionView::Helpers::DateHelper
+  include DateDistanceHelper
 
   def initialize(manifest, field, device, data)
     @manifest = manifest
@@ -264,40 +264,6 @@ class ManifestFieldMapping
         [key, traverse(value, data).to_i]
       end
     ]
-  end
-
-  def years_between(first_date, second_date)
-    distance_between(first_date, second_date, :years)
-  end
-
-  def months_between(first_date, second_date)
-    distance_between(first_date, second_date, :months)
-  end
-
-  def days_between(first_date, second_date)
-    distance_between(first_date, second_date, :days)
-  end
-
-  def hours_between(first_date, second_date)
-    distance_between(first_date, second_date, :hours)
-  end
-
-  def minutes_between(first_date, second_date)
-    distance_between(first_date, second_date, :minutes)
-  end
-
-  def seconds_between(first_date, second_date)
-    distance_between(first_date, second_date, :seconds)
-  end
-
-  def milliseconds_between(first_date, second_date)
-    seconds_between(first_date, second_date) * 1000
-  end
-
-  def distance_between(first_date, second_date, unit)
-    second_date = DateTime.parse(second_date.to_s)
-    first_date = DateTime.parse(first_date.to_s)
-    distance_of_time_in_words_hash(first_date, second_date, accumulate_on: unit)[unit]
   end
 
   def convert_time(time_interval, source_unit, desired_unit)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -20,47 +20,6 @@ class Patient < ActiveRecord::Base
     "patient"
   end
 
-  # Creates accessors for Entity fields
-  #
-  # `attribute_field :foo, :bar` will generate r/w accessors for foo and bar fields, despite pii value
-  # `attribute_field :foo, source: :foo_field_name` will use "foo_field_name" as the source.
-  # `attribute_field :foo, copy: true` will ensure a copy of the value is keept in the foo attribute
-  #
-  def self.attribute_field(*args)
-    options = args.extract_options!
-    options.reverse_merge! copy: false
-    do_copy = options[:copy]
-
-    args.each do |arg|
-      field_name = (options[:field] || arg).to_s
-      field_source = if self.entity_fields.detect { |f| f.name == field_name }.pii?
-        "plain_sensitive_data"
-      else
-        "core_fields"
-      end
-
-      define_method arg do
-        send(field_source)[field_name]
-      end
-
-      define_method "#{arg}=" do |value|
-        write_attribute(arg, value) if do_copy
-        if value.blank?
-          send(field_source).delete(field_name)
-        else
-          send(field_source)[field_name] = value
-        end
-      end
-
-      if do_copy
-        # copy attribute to db, in case the entity_field was changed directly
-        before_validation do
-          write_attribute(arg, send(arg))
-        end
-      end
-    end
-  end
-
   attribute_field :name, copy: true
   attribute_field :entity_id, field: :id, copy: true
   attribute_field :gender, :dob, :email, :phone

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -12,10 +12,6 @@ class Patient < ActiveRecord::Base
 
   validates_presence_of :institution
 
-  def entity_id
-    plain_sensitive_data["id"]
-  end
-
   def has_entity_id?
     entity_id_hash.not_nil?
   end
@@ -24,32 +20,39 @@ class Patient < ActiveRecord::Base
     "patient"
   end
 
+  # Creates accessors for Entity fields
+  #
+  # `attribute_field :foo, :bar` will generate r/w accessors for foo and bar fields, despite pii value
+  # `attribute_field :foo, source: :foo_field_name` will use "foo_field_name" as the source.
+  # `attribute_field :foo, copy: true` will ensure a copy of the value is keept in the foo attribute
+  #
   def self.attribute_field(*args)
     options = args.extract_options!
     options.reverse_merge! copy: false
-    db_attribute = options[:copy]
+    do_copy = options[:copy]
 
     args.each do |arg|
-      field_source = if self.entity_fields.detect { |f| f.name == arg.to_s }.pii?
+      field_name = (options[:field] || arg).to_s
+      field_source = if self.entity_fields.detect { |f| f.name == field_name }.pii?
         "plain_sensitive_data"
       else
         "core_fields"
       end
 
       define_method arg do
-        send(field_source)[arg.to_s]
+        send(field_source)[field_name]
       end
 
       define_method "#{arg}=" do |value|
-        write_attribute(arg, value) if db_attribute
+        write_attribute(arg, value) if do_copy
         if value.blank?
-          send(field_source).delete(arg.to_s)
+          send(field_source).delete(field_name)
         else
-          send(field_source)[arg.to_s] = value
+          send(field_source)[field_name] = value
         end
       end
 
-      if db_attribute
+      if do_copy
         # copy attribute to db, in case the entity_field was changed directly
         before_validation do
           write_attribute(arg, send(arg))
@@ -59,6 +62,7 @@ class Patient < ActiveRecord::Base
   end
 
   attribute_field :name, copy: true
+  attribute_field :entity_id, field: :id, copy: true
   attribute_field :gender, :dob, :email, :phone
 
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -3,6 +3,8 @@ class Patient < ActiveRecord::Base
   include AutoUUID
   include AutoIdHash
   include Resource
+  include DateDistanceHelper
+  include WithLocation
 
   belongs_to :institution
 
@@ -24,4 +26,11 @@ class Patient < ActiveRecord::Base
   attribute_field :entity_id, field: :id, copy: true
   attribute_field :gender, :dob, :email, :phone
 
+  def age
+    years_between Time.parse(dob), Time.now rescue nil
+  end
+
+  def last_encounter
+    encounters.order(start_time: :desc).first.try &:start_time
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,6 +1,7 @@
 class Site < ActiveRecord::Base
   include AutoUUID
   include Resource
+  include WithLocation
 
   belongs_to :institution
   has_one :user, through: :institution
@@ -30,24 +31,6 @@ class Site < ActiveRecord::Base
       where("prefix LIKE concat(?, '%')", institution_or_site.prefix)
     end
   }
-
-  def location(opts={})
-    @location = nil if @location_opts.presence != opts.presence || @location.try(:geo_id) != location_geoid
-    @location_opts = opts
-    @location ||= Location.find(location_geoid, opts)
-  end
-
-  def location=(value)
-    @location = value
-    self.location_geoid = value.try(:id)
-  end
-
-  def self.preload_locations!
-    locations = Location.details(all.map(&:location_geoid).uniq).index_by(&:id)
-    all.to_a.each do |site|
-      site.location = locations[site.location_geoid]
-    end
-  end
 
   def self.filter_by_owner(user, check_conditions)
     if check_conditions

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -2,6 +2,7 @@ class TestResult < ActiveRecord::Base
   include AutoUUID
   include Entity
   include Resource
+  include SiteContained
 
   NAME_FIELD = 'name'
   LAB_USER_FIELD = 'site_user'
@@ -12,8 +13,6 @@ class TestResult < ActiveRecord::Base
   has_many :test_result_parsed_data
 
   belongs_to :device
-  belongs_to :institution
-  belongs_to :site
   belongs_to :sample_identifier, inverse_of: :test_results, autosave: true
   belongs_to :patient
   belongs_to :encounter
@@ -25,7 +24,7 @@ class TestResult < ActiveRecord::Base
   validate :validate_encounter
   validate :validate_patient
 
-  before_save   :set_foreign_keys
+  before_save   :set_foreign_keys, prepend: true
   before_save   :set_entity_id
   after_destroy :destroy_from_index
 
@@ -99,7 +98,6 @@ class TestResult < ActiveRecord::Base
   def set_foreign_keys
     self.site_id = device.try(:site_id)
     self.institution_id = device.try(:institution_id)
-    self.site_prefix = device.try(:site).try(:prefix)
   end
 
   def set_entity_id

--- a/app/views/patients/_filters.haml
+++ b/app/views/patients/_filters.haml
@@ -13,3 +13,6 @@
           .filter
             %label.block Name
             %input{type: "text", name: "name", value: params["name"]}
+          .filter
+            %label.block Patient Id
+            %input{type: "text", name: "entity_id", value: params["entity_id"]}

--- a/app/views/patients/_filters.haml
+++ b/app/views/patients/_filters.haml
@@ -16,3 +16,6 @@
           .filter
             %label.block Patient Id
             %input{type: "text", name: "entity_id", value: params["entity_id"]}
+          .filter
+            %label.block Location
+            = react_component "LocationSelect", placeholder: "Choose a location", name: "location", defaultValue: params["location"]

--- a/app/views/patients/_filters.haml
+++ b/app/views/patients/_filters.haml
@@ -19,3 +19,6 @@
           .filter
             %label.block Location
             = react_component "LocationSelect", placeholder: "Choose a location", name: "location", defaultValue: params["location"]
+          .filter
+            %label.block Last encounter
+            %input{type: "text", name: "last_encounter", value: params["last_encounter"]}

--- a/app/views/patients/_filters.haml
+++ b/app/views/patients/_filters.haml
@@ -11,3 +11,5 @@
         %input{type: "hidden", name: "page_size", value: @page_size}
         .row
           .filter
+            %label.block Name
+            %input{type: "text", name: "name", value: params["name"]}

--- a/app/views/patients/index.html.haml
+++ b/app/views/patients/index.html.haml
@@ -14,7 +14,7 @@
             %td.empty
               .empty-icon
                 %span.ic140-patients
-              %h1 No patients registered at this institution
+              %h1 No patients registered
               %p Keep your test orders organized under patients medical history
     - else
       = cdx_table do |t|

--- a/app/views/patients/index.html.haml
+++ b/app/views/patients/index.html.haml
@@ -25,11 +25,17 @@
           %tr
             %th Name
             %th Patient Id
+            %th Age
+            %th Location
+            %th Last encounter
         - t.tbody do
           - @patients.each do |patient|
             %tr{data: {href: patient_path(patient) }}
               %td= patient.name
               %td= patient.entity_id
+              %td= patient.age
+              %td= patient.location.try(:name)
+              %td= format_date(patient.last_encounter)
 
     .pagination
       = render 'shared/pagination'

--- a/db/migrate/20160108181427_add_name_to_patients.rb
+++ b/db/migrate/20160108181427_add_name_to_patients.rb
@@ -1,0 +1,5 @@
+class AddNameToPatients < ActiveRecord::Migration
+  def change
+    add_column :patients, :name, :string
+  end
+end

--- a/db/migrate/20160108194936_add_entity_id_to_patients.rb
+++ b/db/migrate/20160108194936_add_entity_id_to_patients.rb
@@ -1,0 +1,5 @@
+class AddEntityIdToPatients < ActiveRecord::Migration
+  def change
+    add_column :patients, :entity_id, :string
+  end
+end

--- a/db/migrate/20160112190503_add_site_prefix_to_encounters.rb
+++ b/db/migrate/20160112190503_add_site_prefix_to_encounters.rb
@@ -1,0 +1,5 @@
+class AddSitePrefixToEncounters < ActiveRecord::Migration
+  def change
+    add_column :encounters, :site_prefix, :string
+  end
+end

--- a/db/migrate/20160114154732_add_start_time_to_encounters.rb
+++ b/db/migrate/20160114154732_add_start_time_to_encounters.rb
@@ -1,0 +1,5 @@
+class AddStartTimeToEncounters < ActiveRecord::Migration
+  def change
+    add_column :encounters, :start_time, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160108194936) do
+ActiveRecord::Schema.define(version: 20160112190503) do
 
   create_table "computed_policies", force: :cascade do |t|
     t.integer "user_id",                  limit: 4
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 20160108194936) do
     t.datetime "deleted_at"
     t.integer  "site_id",         limit: 4
     t.datetime "user_updated_at"
+    t.string   "site_prefix",     limit: 255
   end
 
   add_index "encounters", ["deleted_at"], name: "index_encounters_on_deleted_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160105165742) do
+ActiveRecord::Schema.define(version: 20160108181427) do
 
   create_table "computed_policies", force: :cascade do |t|
     t.integer "user_id",                  limit: 4
@@ -240,6 +240,7 @@ ActiveRecord::Schema.define(version: 20160105165742) do
     t.float    "lat",            limit: 24
     t.float    "lng",            limit: 24
     t.string   "address",        limit: 255
+    t.string   "name",           limit: 255
   end
 
   add_index "patients", ["deleted_at"], name: "index_patients_on_deleted_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160108181427) do
+ActiveRecord::Schema.define(version: 20160108194936) do
 
   create_table "computed_policies", force: :cascade do |t|
     t.integer "user_id",                  limit: 4
@@ -241,6 +241,7 @@ ActiveRecord::Schema.define(version: 20160108181427) do
     t.float    "lng",            limit: 24
     t.string   "address",        limit: 255
     t.string   "name",           limit: 255
+    t.string   "entity_id",      limit: 255
   end
 
   add_index "patients", ["deleted_at"], name: "index_patients_on_deleted_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160112190503) do
+ActiveRecord::Schema.define(version: 20160114154732) do
 
   create_table "computed_policies", force: :cascade do |t|
     t.integer "user_id",                  limit: 4
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 20160112190503) do
     t.integer  "site_id",         limit: 4
     t.datetime "user_updated_at"
     t.string   "site_prefix",     limit: 255
+    t.datetime "start_time"
   end
 
   add_index "encounters", ["deleted_at"], name: "index_encounters_on_deleted_at", using: :btree

--- a/lib/tasks/site.rake
+++ b/lib/tasks/site.rake
@@ -1,7 +1,24 @@
 namespace :site do
-  desc "Adds a prefix to existing sites"
+  desc "Adds a prefix to existing sites and related entities"
   task :add_prefix => :environment do
-    Site.find_each { |site| site.send :compute_prefix }
-    Device.find_each { |device| device.set_site_prefix; device.save! }
+    Site.find_each do |site|
+      begin
+        site.send :compute_prefix
+      rescue => e
+        puts "Error Site (id=#{site.id}) #{e.message}"
+      end
+    end
+
+    # classes that includes SiteContained
+    [Device, Encounter, TestResult].each do |type|
+      type.find_each do |record|
+        begin
+          record.set_site_prefix
+          record.save!
+        rescue => e
+          puts "Error #{type} (id=#{record.id}) #{e.message}"
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe PatientsController, type: :controller do
       get :index
       expect(assigns(:can_create)).to be_falsy
     end
+
+    it "should filter by name" do
+      institution.patients.make name: 'John'
+      institution.patients.make name: 'Clark'
+      institution.patients.make name: 'Mery johana'
+
+      get :index, name: 'jo'
+      expect(response).to be_success
+      expect(assigns(:patients).count).to eq(2)
+    end
   end
 
   context "show" do

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe PatientsController, type: :controller do
       patient1 = institution.patients.make
       patient2 = institution.patients.make
 
-      patient1.encounters.make start_time: DateTime.new(2016, 1, 14, 0, 0, 0)
-      patient2.encounters.make start_time: DateTime.new(2016, 1, 7, 0, 0, 0)
+      patient1.encounters.make start_time: Time.new(2016, 1, 14, 0, 0, 0)
+      patient2.encounters.make start_time: Time.new(2016, 1, 7, 0, 0, 0)
 
       get :index, last_encounter: '1/10/2016'
 

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe PatientsController, type: :controller do
       expect(response).to be_success
       expect(assigns(:patients).count).to eq(2)
     end
+
+    it "should filter based con navigation_context site" do
+      site1 = institution.sites.make
+      site11 = Site.make :child, parent: site1
+      site2 = institution.sites.make
+
+      patient1 = institution.patients.make
+      patient2 = institution.patients.make
+
+      patient1.encounters.make site: site11
+      patient2.encounters.make site: site2
+
+      get :index, context: site1.uuid
+
+      expect(response).to be_success
+      expect(assigns(:patients).to_a).to eq([patient1])
+    end
   end
 
   context "show" do

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe PatientsController, type: :controller do
       expect(response).to be_success
       expect(assigns(:patients).count).to eq(2)
     end
+
+    it "should filter by entity_id" do
+      institution.patients.make entity_id: '10110'
+      institution.patients.make entity_id: '21100'
+      institution.patients.make entity_id: '40440'
+
+      get :index, entity_id: '11'
+      expect(response).to be_success
+      expect(assigns(:patients).count).to eq(2)
+    end
   end
 
   context "show" do

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe PatientsController, type: :controller do
       expect(response).to be_success
       expect(assigns(:patients).count).to eq(2)
     end
+
+    it "should filter by entity_id" do
+      institution.patients.make location_geoid: 'ne:US3245'
+      institution.patients.make location_geoid: 'ne:US3432'
+      institution.patients.make location_geoid: 'ne:ARne:US'
+
+      get :index, location: 'ne:US'
+      expect(response).to be_success
+      expect(assigns(:patients).count).to eq(2)
+    end
   end
 
   context "show" do

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -95,6 +95,19 @@ RSpec.describe PatientsController, type: :controller do
       expect(response).to be_success
       expect(assigns(:patients).to_a).to eq([patient1])
     end
+
+    it "should filter based con last encounter date" do
+      patient1 = institution.patients.make
+      patient2 = institution.patients.make
+
+      patient1.encounters.make start_time: DateTime.new(2016, 1, 14, 0, 0, 0)
+      patient2.encounters.make start_time: DateTime.new(2016, 1, 7, 0, 0, 0)
+
+      get :index, last_encounter: '1/10/2016'
+
+      expect(response).to be_success
+      expect(assigns(:patients).to_a).to eq([patient1])
+    end
   end
 
   context "show" do

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -84,7 +84,11 @@ end
 Encounter.blueprint do
   institution { object.patient.try(:institution) || Institution.make }
   site { object.institution.sites.first || object.institution.sites.make }
-  core_fields { { "id" => "encounter-#{Sham.sn}" } }
+  core_fields {
+    { "id" => "encounter-#{Sham.sn}" }.tap do |h|
+      h["start_time"] = object.start_time if object.start_time
+    end
+  }
 end
 
 def first_or_make_site_unless_manufacturer(institution)

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -108,7 +108,8 @@ end
 Patient.blueprint do
   institution
   plain_sensitive_data {
-    { "id" => "patient-#{Sham.sn}" }.tap do |h|
+    {}.tap do |h|
+      h["id"] = object.entity_id || "patient-#{Sham.sn}"
       h["name"] = object.name if object.name
     end
   }

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -107,7 +107,11 @@ end
 
 Patient.blueprint do
   institution
-  plain_sensitive_data { { "id" => "patient-#{Sham.sn}" } }
+  plain_sensitive_data {
+    { "id" => "patient-#{Sham.sn}" }.tap do |h|
+      h["name"] = object.name if object.name
+    end
+  }
 end
 
 TestResult.blueprint do


### PR DESCRIPTION
fixes #606. Add filtering options to patients. 
sort patients by name (fixed)
add missing columns in patients index

* fixes issue with location select in order to be able to deselect values
* refactor formatting date/time and distance functions 
* move attribute_field mixin to Entity (reuse it in encounters)
* extract SiteContained to a mixin (update migration rake task, it is required to run it on next deploy)
* extract WithLocation to prefetch location for patients page
