### PR TITLE
Add site to patient

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -5,14 +5,21 @@ class Patient < ActiveRecord::Base
   include Resource
   include DateDistanceHelper
   include WithLocation
-
-  belongs_to :institution
+  include SiteContained
 
   has_many :test_results, dependent: :restrict_with_error
   has_many :samples, dependent: :restrict_with_error
   has_many :encounters, dependent: :restrict_with_error
 
   validates_presence_of :institution
+
+  scope :within, -> (institution_or_site) {
+    if institution_or_site.is_a?(Institution)
+      where(institution: institution_or_site)
+    else
+      where("site_prefix LIKE concat(?, '%') OR id in (#{Encounter.within(institution_or_site).select(:patient_id).to_sql})", institution_or_site.prefix)
+    end
+  }
 
   def has_entity_id?
     entity_id_hash.not_nil?

--- a/app/models/patient_form.rb
+++ b/app/models/patient_form.rb
@@ -2,7 +2,7 @@ class PatientForm
   include ActiveModel::Model
 
   def self.shared_attributes # shared editable attributes with patient model
-    [:institution, :name, :gender, :dob, :lat, :lng, :location_geoid, :address, :email, :phone]
+    [:institution, :site, :name, :gender, :dob, :lat, :lng, :location_geoid, :address, :email, :phone]
   end
 
   def self.model_name

--- a/db/migrate/20160115131955_add_site_id_site_prefix_to_patients.rb
+++ b/db/migrate/20160115131955_add_site_id_site_prefix_to_patients.rb
@@ -1,0 +1,6 @@
+class AddSiteIdSitePrefixToPatients < ActiveRecord::Migration
+  def change
+    add_reference :patients, :site, index: true, foreign_key: true
+    add_column :patients, :site_prefix, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160114154732) do
+ActiveRecord::Schema.define(version: 20160115131955) do
 
   create_table "computed_policies", force: :cascade do |t|
     t.integer "user_id",                  limit: 4
@@ -244,10 +244,13 @@ ActiveRecord::Schema.define(version: 20160114154732) do
     t.string   "address",        limit: 255
     t.string   "name",           limit: 255
     t.string   "entity_id",      limit: 255
+    t.integer  "site_id",        limit: 4
+    t.string   "site_prefix",    limit: 255
   end
 
   add_index "patients", ["deleted_at"], name: "index_patients_on_deleted_at", using: :btree
   add_index "patients", ["institution_id"], name: "index_patients_on_institution_id", using: :btree
+  add_index "patients", ["site_id"], name: "index_patients_on_site_id", using: :btree
 
   create_table "policies", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
@@ -440,4 +443,5 @@ ActiveRecord::Schema.define(version: 20160114154732) do
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
 
   add_foreign_key "encounters", "sites"
+  add_foreign_key "patients", "sites"
 end

--- a/lib/tasks/site.rake
+++ b/lib/tasks/site.rake
@@ -10,7 +10,7 @@ namespace :site do
     end
 
     # classes that includes SiteContained
-    [Device, Encounter, TestResult].each do |type|
+    [Device, Encounter, TestResult, Patient].each do |type|
       type.find_each do |record|
         begin
           record.set_site_prefix

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -96,6 +96,20 @@ RSpec.describe PatientsController, type: :controller do
       expect(assigns(:patients).to_a).to eq([patient1])
     end
 
+    it "should filter based con navigation_context site if no encounter" do
+      site1 = institution.sites.make
+      site11 = Site.make :child, parent: site1
+      site2 = institution.sites.make
+
+      patient1 = institution.patients.make site: site11
+      patient2 = institution.patients.make site: site2
+
+      get :index, context: site1.uuid
+
+      expect(response).to be_success
+      expect(assigns(:patients).to_a).to eq([patient1])
+    end
+
     it "should filter based con last encounter date" do
       patient1 = institution.patients.make
       patient2 = institution.patients.make
@@ -250,6 +264,18 @@ RSpec.describe PatientsController, type: :controller do
       expect(patient.gender).to be_nil
       expect(patient.core_fields).to_not have_key('gender')
     end
+
+    it "should use navigation_context as patient site" do
+      site = institution.sites.make
+      expect {
+        post :create, context: site.uuid, patient: { name: 'Lorem', gender: 'female', dob: '1/1/2000' }
+      }.to change(institution.patients, :count).by(1)
+
+      expect(Patient.last.site).to eq(site)
+
+      expect(response).to be_redirect
+    end
+
   end
 
   context "edit" do


### PR DESCRIPTION
Track site used in the creation of the patient and use it to list them despite the patient has no encounter.
It is not used for permission.
It is not displayed in the ui, it just an auxiliary field to fulfill the user experience. 

fixes #703