### PR TITLE
Feature set patient id

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -4,7 +4,7 @@ class PatientsController < ApplicationController
     @patients = check_access(Patient.where(institution: @navigation_context.institution), READ_PATIENT).order(:name)
 
     @patients = @patients.within(@navigation_context.entity)
-    
+
     @patients = @patients.where("name LIKE concat('%', ?, '%')", params[:name]) unless params[:name].blank?
     @patients = @patients.where("entity_id LIKE concat('%', ?, '%')", params[:entity_id]) unless params[:entity_id].blank?
     # location_geoid is hierarchical so a prefix search works
@@ -83,6 +83,6 @@ class PatientsController < ApplicationController
   private
 
   def patient_params
-    params.require(:patient).permit(:name, :gender, :dob, :lat, :lng, :location_geoid, :address, :email, :phone)
+    params.require(:patient).permit(:name, :entity_id, :gender, :dob, :lat, :lng, :location_geoid, :address, :email, :phone)
   end
 end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,7 +1,7 @@
 class PatientsController < ApplicationController
   def index
     @can_create = has_access?(@navigation_context.institution, CREATE_INSTITUTION_PATIENT)
-    @patients = check_access(Patient.where(institution: @navigation_context.institution), READ_PATIENT).order(:name)
+    @patients = check_access(Patient.where(is_phantom: false).where(institution: @navigation_context.institution), READ_PATIENT).order(:name)
 
     @patients = @patients.within(@navigation_context.entity)
 

--- a/app/models/concerns/auto_id_hash.rb
+++ b/app/models/concerns/auto_id_hash.rb
@@ -3,7 +3,7 @@ module AutoIdHash
 
   included do
     validates_uniqueness_of :entity_id_hash, scope: :institution_id, allow_nil: true
-    before_create :ensure_entity_id_hash
+    before_validation :ensure_entity_id_hash
   end
 
   def ensure_entity_id_hash

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -12,6 +12,8 @@ class Patient < ActiveRecord::Base
   has_many :encounters, dependent: :restrict_with_error
 
   validates_presence_of :institution
+  validates_uniqueness_of :entity_id, scope: :institution_id, allow_nil: true
+  validate :entity_id_not_changed
 
   scope :within, -> (institution_or_site) {
     if institution_or_site.is_a?(Institution)
@@ -39,5 +41,13 @@ class Patient < ActiveRecord::Base
 
   def last_encounter
     encounters.order(start_time: :desc).first.try &:start_time
+  end
+
+  private
+
+  def entity_id_not_changed
+    if entity_id_changed? && self.persisted? && entity_id_was.present?
+      errors.add(:entity_id, "can't be changed after assigned")
+    end
   end
 end

--- a/app/views/patients/_form.html.haml
+++ b/app/views/patients/_form.html.haml
@@ -15,6 +15,12 @@
 
   .row
     .col.pe-2
+      = f.label :entity_id
+    .col
+      = f.text_field :entity_id, :class => 'input-large'
+
+  .row
+    .col.pe-2
       = f.label :gender
     .col
       = cdx_select form: f, name: :gender do |select|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
         parent: Parent site
       patient:
         dob: Birthday
+        entity_id: Patient id
 
   user:
     settings:

--- a/spec/models/blender_spec.rb
+++ b/spec/models/blender_spec.rb
@@ -351,7 +351,8 @@ describe Blender do
     context "when phantom" do
 
       before(:each) do
-        @patient_p2.update_attributes!(is_phantom: true, plain_sensitive_data: Hash.new, entity_id_hash: nil)
+        @patient_p2.attributes = { is_phantom: true, plain_sensitive_data: Hash.new, entity_id_hash: nil }
+        @patient_p2.save(validate: false)
         blender.merge_parent(blender_p2e1s1t1, blender_p1e1)
       end
 
@@ -384,7 +385,8 @@ describe Blender do
     context "when merging on phantom" do
 
       before(:each) do
-        @patient_p2.update_attributes!(is_phantom: true, plain_sensitive_data: Hash.new, entity_id_hash: nil)
+        @patient_p2.attributes = { is_phantom: true, plain_sensitive_data: Hash.new, entity_id_hash: nil }
+        @patient_p2.save(validate: false)
         blender.merge_parent(blender_p1e1s1t1, blender_p2e1)
       end
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -8,6 +8,16 @@ describe Patient do
       expect(Patient.make_unsaved).to be_valid
     end
 
+    it "should validate uniqness of entity_id_hash and entity_id" do
+      institution = Institution.make
+      Patient.make entity_id: '1001', institution: institution
+      patient = Patient.make_unsaved entity_id: '1001', institution: institution
+
+      expect(patient).to be_invalid
+      expect(patient.errors).to have_key(:entity_id_hash)
+      expect(patient.errors).to have_key(:entity_id)
+    end
+
     context "on fields" do
       let(:patient) { Patient.make_unsaved }
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -6,6 +6,15 @@ describe Patient do
 
     it "should make a valid patient" do
       expect(Patient.make_unsaved).to be_valid
+      expect(Patient.make_unsaved :phantom).to be_valid
+    end
+
+    it "should make phantom if required" do
+      expect(Patient.make :phantom).to be_phantom
+    end
+
+    it "should make non phantom if required" do
+      expect(Patient.make).to_not be_phantom
     end
 
     it "should validate uniqness of entity_id_hash and entity_id" do

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -119,6 +119,16 @@ Patient.blueprint do
   }
 end
 
+Patient.blueprint :phantom do
+  name
+  plain_sensitive_data {
+    {}.tap do |h|
+      h["id"] = nil
+      h["name"] = object.name if object.name
+    end
+  }
+end
+
 TestResult.blueprint do
   test_id { "test-#{Sham.sn}" }
 


### PR DESCRIPTION
fixes #696
allow user to set patient id. either in creation and in edit of patients
disallow users to change patient id if already set
ensure edited patients via web are marked as non phantom
list only non phantom patients
improve promotion of validations from patient model to patient form