### PR TITLE
Feature/patient details

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,7 +58,11 @@ $(document).ready(function(){
       setFilledClass($(this));
     });
 
-  $(document).on('click', '*[data-href]', function(){
+  $(document).on('click', '*[data-href]', function(event){
+    if (event.metaKey || event.shiftKey) {
+      window.open($(this).data('href'), '_blank');
+      return;
+    }
     Turbolinks.visit($(this).data('href'));
   });
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,7 +58,7 @@ $(document).ready(function(){
       setFilledClass($(this));
     });
 
-  $(document).on('click', '.row-href tr[data-href]', function(){
+  $(document).on('click', '*[data-href]', function(){
     Turbolinks.visit($(this).data('href'));
   });
 
@@ -211,5 +211,3 @@ $(document).ready(function(){
 
 
 });
-
-

--- a/app/assets/javascripts/components/cards.js.jsx.erb
+++ b/app/assets/javascripts/components/cards.js.jsx.erb
@@ -1,6 +1,14 @@
 var PatientCard = React.createClass({
+  getDefaultProps: function() {
+    return {
+      canEdit: false
+    }
+  },
+
   render: function () {
-    if (this.props.patient == null) {
+    var patient = this.props.patient;
+
+    if (patient == null) {
       return (
         <%= to_jsx(card(image: asset_url('card-unkown.png')) do |c|
           c.top do
@@ -12,7 +20,35 @@ var PatientCard = React.createClass({
       return (
         <%= to_jsx(card(image: asset_url('card-unkown.png')) do |c|
           c.top do
-            raw "<a href={'/patients/' + this.props.patient.id}>{this.props.patient.plain_sensitive_data.name}</a>"
+            raw <<-JSX
+              <a href={"/patients/" + patient.id}>{patient.name}</a><br/>
+              {patient.gender || "n/a"} - {patient.dob || "n/a"} ({patient.age || "n/a"})
+            JSX
+          end
+
+          c.bottom do
+            raw <<-JSX
+              {patient.address}<br/>
+              {patient.phone}<br/>
+              {(function(){
+                if (patient.email) {
+                  return <a href={"mailto:" + patient.email}>{patient.email}</a>;
+                }
+              }.bind(this))()}
+            JSX
+          end
+
+          c.actions do
+            raw <<-JSX
+            {(function(){
+              if (!this.props.canEdit) return;
+
+              return (
+                <a href={"/patients/" + patient.id + "/edit"} title="Edit">
+                  <img src="#{asset_url("ic-pencil.png")}"/>
+                </a>);
+            }.bind(this))()}
+            JSX
           end
         end) %>
       );

--- a/app/assets/javascripts/components/cards.js.jsx.erb
+++ b/app/assets/javascripts/components/cards.js.jsx.erb
@@ -12,7 +12,7 @@ var PatientCard = React.createClass({
       return (
         <%= to_jsx(card(image: asset_url('card-unkown.png')) do |c|
           c.top do
-            raw "<b>{this.props.patient.plain_sensitive_data.name}</b>"
+            raw "<a href={'/patients/' + this.props.patient.id}>{this.props.patient.plain_sensitive_data.name}</a>"
           end
         end) %>
       );

--- a/app/assets/javascripts/components/test_result.js.jsx
+++ b/app/assets/javascripts/components/test_result.js.jsx
@@ -78,7 +78,7 @@ var TestResult = React.createClass({
 var TestResultsList = React.createClass({
   render: function() {
     return (
-      <table className="table row-href" cellPadding="0" cellSpacing="0">
+      <table className="table" cellPadding="0" cellSpacing="0">
         <thead>
           <tr>
             <th className="tableheader" colSpan="5">Tests</th>

--- a/app/assets/stylesheets/_patients.scss
+++ b/app/assets/stylesheets/_patients.scss
@@ -1,0 +1,9 @@
+.medical-history {
+  border: 1px solid $gray2;
+  border-radius: 3px;
+  box-shadow: 0px 1px 3px rgba(0,0,0,0.4);
+
+  li {
+    border-bottom: 1px solid $gray2;
+  }
+}

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -98,7 +98,7 @@
   }
 
 
-.row-href tr[data-href] {
+*[data-href] {
   cursor: pointer;
   &:hover{
     background:#f3f3f3;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,3 +35,4 @@
 @import "charts";
 @import "maps";
 @import "encounters";
+@import "patients";

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -268,8 +268,7 @@ class EncountersController < ApplicationController
         if @encounter_blender.patient.blank?
           json.nil!
         else
-          json.(@encounter_blender.patient, :plain_sensitive_data, :core_fields)
-          json.id @encounter_blender.patient.entities.first.try :id
+          @encounter_blender.patient.preview.as_json_card(json)
         end
       end
 

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -265,7 +265,12 @@ class EncountersController < ApplicationController
       end
 
       json.patient do
-        @encounter_blender.patient.blank? ? json.nil! : json.(@encounter_blender.patient, :plain_sensitive_data, :core_fields)
+        if @encounter_blender.patient.blank?
+          json.nil!
+        else
+          json.(@encounter_blender.patient, :plain_sensitive_data, :core_fields)
+          json.id @encounter_blender.patient.entities.first.try :id
+        end
       end
 
       json.samples @encounter_blender.samples.uniq do |sample|

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -27,6 +27,7 @@ class PatientsController < ApplicationController
 
   def show
     @patient = Patient.find(params[:id])
+    @patient_json = Jbuilder.new { |json| @patient.as_json_card(json) }.attributes!
     return unless authorize_resource(@patient, READ_PATIENT)
     @can_edit = has_access?(@patient, UPDATE_PATIENT)
     @encounters = @patient.encounters.order(start_time: :desc)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -29,6 +29,7 @@ class PatientsController < ApplicationController
     @patient = Patient.find(params[:id])
     return unless authorize_resource(@patient, READ_PATIENT)
     @can_edit = has_access?(@patient, UPDATE_PATIENT)
+    @encounters = @patient.encounters.order(start_time: :desc)
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,6 +68,7 @@ module ApplicationHelper
 
   define_component :card, sections: [:top, :actions, :bottom], attributes: [:image]
   define_component :cdx_table, sections: [:columns, :thead, :tbody, :actions], attributes: [:title]
+  define_component :empty_data, sections: [:body] ,attributes: [:icon]
 
   define_component :cdx_tabs do |c|
     c.section :headers, multiple: true, component: :cdx_tabs_header

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,7 +68,7 @@ module ApplicationHelper
 
   define_component :card, sections: [:top, :actions, :bottom], attributes: [:image]
   define_component :cdx_table, sections: [:columns, :thead, :tbody, :actions], attributes: [:title]
-  define_component :empty_data, sections: [:body] ,attributes: [:icon]
+  define_component :empty_data, sections: [:body] ,attributes: [:icon, :title]
 
   define_component :cdx_tabs do |c|
     c.section :headers, multiple: true, component: :cdx_tabs_header

--- a/app/models/blender.rb
+++ b/app/models/blender.rb
@@ -471,6 +471,18 @@ class Blender
       nil
     end
 
+    def preview
+      target = @entities.find(&:not_phantom?) || @entities.first
+      target = Patient.find(target.id) if target # grab a new patient in order to avoid dirty state
+      target = self.class.entity_type.new(institution: institution) unless target
+
+      target.plain_sensitive_data = plain_sensitive_data
+      target.custom_fields = custom_fields
+      target.core_fields = core_fields
+
+      target
+    end
+
     protected
 
     def get_entity_id(plain_sensitive_data, custom_fields, core_fields)

--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -105,6 +105,27 @@ class Encounter < ActiveRecord::Base
     core_fields[Encounter::ASSAYS_FIELD]
   end
 
+  def human_diagnose
+    return unless diagnostic
+
+    positives = diagnostic.select {|a| a['result'] == 'positive'}.map { |a| a['condition'] }.to_a
+    negatives = diagnostic.select {|a| a['result'] == 'negative'}.map { |a| a['condition'] }.to_a
+
+    res = ""
+    res << positives.join(', ')
+    unless positives.empty?
+      res << " detected. "
+    end
+    res << negatives.join(', ')
+    unless negatives.empty?
+      res << " not detected. "
+    end
+
+    res
+  end
+
+  attribute_field OBSERVATIONS_FIELD
+
   def has_dirty_diagnostic?
     test_results_not_in_diagnostic.count > 0
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -43,6 +43,15 @@ class Patient < ActiveRecord::Base
     encounters.order(start_time: :desc).first.try &:start_time
   end
 
+  def as_json_card(json)
+    json.(self, :id, :name, :age, :gender, :address, :phone, :email)
+    json.dob dob_time.try { |d| d.strftime(I18n.t('date.input_format.pattern')) }
+  end
+
+  def dob_time
+    Time.parse(dob) rescue nil
+  end
+
   private
 
   def entity_id_not_changed

--- a/app/views/api_tokens/index.html.haml
+++ b/app/views/api_tokens/index.html.haml
@@ -2,17 +2,9 @@
   .col
     = link_to "+", new_api_token_path, class: 'btn-add side-link ontop fix', title: 'Add API Token'
     - if @api_tokens.empty?
-      = cdx_table title: 'API Tokens' do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-              %h1 There are no api tokens
+      = empty_data title: 'API Tokens' do |c|
+        - c.body do
+          %h1 There are no api tokens
     - else
       = cdx_table title: 'API Tokens' do |t|
         - t.columns do
@@ -27,4 +19,3 @@
             %tr
               %td= token.token
               %td= link_to "Delete", api_token_path(token.id), method: :delete, data: {confirm: "Are you sure you want to delete the following token?\n#{token.token}"}
-

--- a/app/views/components/_cdx_table.html.haml
+++ b/app/views/components/_cdx_table.html.haml
@@ -1,4 +1,4 @@
-%table.table.row-href(cellpadding="0" cellspacing="0")
+%table.table(cellpadding="0" cellspacing="0")
   = cdx_table[:columns]
   %thead
     - if cdx_table[:title] || cdx_table[:actions]

--- a/app/views/components/_empty_data.html.haml
+++ b/app/views/components/_empty_data.html.haml
@@ -1,0 +1,12 @@
+= cdx_table do |t|
+  - t.columns do
+    %col{:width => "100%"}
+  - t.thead do
+    %tr
+      %th
+  - t.tbody do
+    %tr
+      %td.empty
+        .empty-icon
+          %span{class: empty_data[:icon]}
+        = empty_data[:body]

--- a/app/views/components/_empty_data.html.haml
+++ b/app/views/components/_empty_data.html.haml
@@ -1,4 +1,4 @@
-= cdx_table do |t|
+= cdx_table title: empty_data[:title] do |t|
   - t.columns do
     %col{:width => "100%"}
   - t.thead do

--- a/app/views/device_models/index.haml
+++ b/app/views/device_models/index.haml
@@ -2,19 +2,10 @@
   .col
     = link_to "+", new_device_model_path, class: 'btn-add side-link ontop fix', title: 'Add Device Model'
     - if @device_models.empty?
-      = cdx_table title: 'Device Models' do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-                %span.ic140-device-model
-              %h1 There are no device models
-              %p Create device models and publish manifests that will allow test reporting on CDx platform
+      = empty_data title: 'Device Models', icon: 'ic140-device-model' do |c|
+        - c.body do
+          %h1 There are no device models
+          %p Create device models and publish manifests that will allow test reporting on CDx platform
     - else
       = cdx_table title: 'Device Models' do |t|
         - t.columns do

--- a/app/views/devices/index.haml
+++ b/app/views/devices/index.haml
@@ -3,19 +3,10 @@
 .row
   .col
     - if @devices.empty?
-      = cdx_table do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-                %span.ic140-devices
-              %h1 There are no devices reporting at this site
-              %p Follow the configuration steps to connect a device and start reporting
+      = empty_data icon: 'ic140-devices' do |c|
+        - c.body do
+          %h1 There are no devices reporting at this site
+          %p Follow the configuration steps to connect a device and start reporting
     - else
       = cdx_table do |t|
         - t.columns do

--- a/app/views/filters/index.html.haml
+++ b/app/views/filters/index.html.haml
@@ -1,17 +1,9 @@
 .row
   .col
     - if filters.empty?
-      = cdx_table title: 'Filters' do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-              %h1 There is no saved filters
+      = empty_data title: 'Filters' do |c|
+        - c.body do
+          %h1 There are no saved filters
     - else
       = cdx_table title: 'Filters' do |t|
         - t.columns do

--- a/app/views/patients/index.html.haml
+++ b/app/views/patients/index.html.haml
@@ -3,19 +3,10 @@
 .row
   .col
     - if @patients.empty?
-      = cdx_table do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-                %span.ic140-patients
-              %h1 No patients registered
-              %p Keep your test orders organized under patients medical history
+      = empty_data icon: 'ic140-patients' do |c|
+        - c.body do
+          %h1 No patients registered
+          %p Keep your test orders organized under patients medical history
     - else
       = cdx_table do |t|
         - t.columns do
@@ -37,5 +28,5 @@
               %td= patient.location.try(:name)
               %td= format_date(patient.last_encounter)
 
-    .pagination
-      = render 'shared/pagination'
+      .pagination
+        = render 'shared/pagination'

--- a/app/views/patients/show.html.haml
+++ b/app/views/patients/show.html.haml
@@ -10,13 +10,7 @@
 
 .row
   .col
-    = card image: "card-unkown.png" do |c|
-      - c.top do
-        %b= @patient.name
-      - if @can_edit
-        - c.actions do
-          = link_to edit_patient_path(@patient), :title => 'Edit' do
-            = image_tag "ic-pencil.png"
+    = react_component "PatientCard", patient: @patient_json, canEdit: @can_edit
 
 - if @encounters.empty?
   = empty_data icon: 'ic140-tests' do |c|

--- a/app/views/patients/show.html.haml
+++ b/app/views/patients/show.html.haml
@@ -17,3 +17,41 @@
         - c.actions do
           = link_to edit_patient_path(@patient), :title => 'Edit' do
             = image_tag "ic-pencil.png"
+
+- if @encounters.empty?
+  = empty_data icon: 'ic140-tests' do |c|
+    - c.body do
+      %h1 No medical history
+      %p Create test orders in order to start the medical history
+- else
+  .row
+    .col
+      %h1 Medical history
+  .row
+    .col
+      %ul.medical-history
+        - @encounters.each do |encounter|
+          %li{'data-href' => encounter_path(encounter)}
+            .row
+              .col.pe-2
+                %label Date
+              .col
+                .value= format_date(encounter.start_time)
+            .row
+              .col.pe-2
+                %label Diagnose
+              .col
+                .value
+                  - if encounter.diagnostic.blank?
+                    %i Pending
+                  - else
+                    = encounter.human_diagnose
+            .row
+              .col.pe-2
+                %label Comments
+              .col
+                .value
+                  - if encounter.observations.blank?
+                    %i No comments
+                  - else
+                    = encounter.observations

--- a/app/views/policies/index.haml
+++ b/app/views/policies/index.haml
@@ -2,19 +2,10 @@
   .col
     = link_to "+", new_policy_path, class: 'btn-add side-link ontop fix', title: 'Add Policy'
     - if @policies.empty?
-      = cdx_table title: 'Policies' do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-                %span.ic140-users
-              %h1 There are no users with access to this site
-              %p Invite other users to join this site's team
+      = empty_data title: 'Policies', icon: 'ic140-users' do |c|
+        - c.body do
+          %h1 There are no users with access to this site
+          %p Invite other users to join this site's team
     - else
       = cdx_table title: 'Policies' do |t|
         - t.columns do

--- a/app/views/sites/index.html.haml
+++ b/app/views/sites/index.html.haml
@@ -2,19 +2,10 @@
 .row
   .col
     - if @sites.empty?
-      = cdx_table do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-                %span.ic140-sites
-              %h1 This site has no dependencies
-              %p Create sites here to keep your institution's hierachy organized
+      = empty_data icon: 'ic140-sites' do |c|
+        - c.body do
+          %h1 This site has no dependencies
+          %p Create sites here to keep your institution's hierachy organized
     - else
       = cdx_table do |t|
         - t.columns do

--- a/app/views/subscribers/index.html.haml
+++ b/app/views/subscribers/index.html.haml
@@ -3,17 +3,9 @@
     - unless filters.empty?
       = link_to "+", new_subscriber_path, class: 'btn-add side-link ontop fix', title: 'Add Subscriber'
     - if subscribers.empty?
-      = cdx_table title: 'Subscribers' do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-              %h1 There are no subscribers
+      = empty_data title: 'Subscribers' do |c|
+        - c.body do
+          %h1 There are no subscribers
     - else
       = cdx_table title: 'Subscribers' do |t|
         - t.columns do

--- a/app/views/test_results/index.haml
+++ b/app/views/test_results/index.haml
@@ -3,19 +3,10 @@
 .row
   .col
     - if @tests.empty?
-      = cdx_table do |t|
-        - t.columns do
-          %col{:width => "100%"}
-        - t.thead do
-          %tr
-            %th
-        - t.tbody do
-          %tr
-            %td.empty
-              .empty-icon
-                %span.ic140-tests
-              %h1 No tests has been reported
-              %p Setup your devices first in order to start reporting
+      = empty_data icon: 'ic140-tests' do |c|
+        - c.body do
+          %h1 No tests has been reported
+          %p Setup your devices first in order to start reporting
     - else
       = cdx_table title: pluralize(@total, "Test") do |t|
         - t.columns do

--- a/app/views/test_results/show.haml
+++ b/app/views/test_results/show.haml
@@ -86,12 +86,12 @@
     %label Other tests
   .col
     .value
-    - case @other_tests.count
-    - when 0
-      No other test was made with this sample
-    - when 1
-      = link_to @other_tests.first.core_fields[TestResult::NAME_FIELD], test_result_path(@other_tests.first.uuid)
-      was also made with this sample
-    - else
-      = @other_tests.map { |t| link_to t.core_fields[TestResult::NAME_FIELD], test_result_path(t.uuid) }.to_sentence.html_safe
-      were also made with this sample
+      - case @other_tests.count
+      - when 0
+        No other test was made with this sample
+      - when 1
+        = link_to @other_tests.first.core_fields[TestResult::NAME_FIELD], test_result_path(@other_tests.first.uuid)
+        was also made with this sample
+      - else
+        = @other_tests.map { |t| link_to t.core_fields[TestResult::NAME_FIELD], test_result_path(t.uuid) }.to_sentence.html_safe
+        were also made with this sample

--- a/app/views/test_results/show.haml
+++ b/app/views/test_results/show.haml
@@ -29,8 +29,7 @@
       - c.bottom do
         - if @test_result.patient
           Patient
-          -# TODO add link to patient
-          = @test_result.patient.plain_sensitive_data['name']
+          = link_to @test_result.patient.name, @test_result.patient
           %br
         Test performed on
         = link_to @test_result.device.name, edit_device_path(@test_result.device)

--- a/spec/controllers/encounters_controller_spec.rb
+++ b/spec/controllers/encounters_controller_spec.rb
@@ -431,8 +431,7 @@ RSpec.describe EncountersController, type: :controller, elasticsearch: true do
       json_response = JSON.parse(response.body).with_indifferent_access
 
       expect(json_response['status']).to eq('ok')
-      expect(json_response['encounter']['patient']['plain_sensitive_data']).to eq({"custom"=>{}, 'name' => 'Doe'})
-      expect(json_response['encounter']['patient']['core_fields']).to eq({'gender' => 'male'})
+      expect(json_response['encounter']['patient']).to include({'name' => 'Doe', 'gender' => 'male'})
     end
 
     it "it merges data from another patient if one of them phantom" do
@@ -441,6 +440,7 @@ RSpec.describe EncountersController, type: :controller, elasticsearch: true do
       DeviceMessage.create_and_process device: device, plain_text_data: Oj.dump(test:{assays:[condition: "flu_a"]}, sample: {id: 'b'}, patient: {name: 'Doe', id: 'P10'})
 
       sample_with_patient1, sample_with_patient2 = Sample.all.to_a
+      patient2 = sample_with_patient2.patient
 
       put :add_sample, sample_uuid: sample_with_patient2.uuid, encounter: {
         institution: { uuid: institution.uuid },
@@ -454,8 +454,7 @@ RSpec.describe EncountersController, type: :controller, elasticsearch: true do
       json_response = JSON.parse(response.body).with_indifferent_access
 
       expect(json_response['status']).to eq('ok')
-      expect(json_response['encounter']['patient']['plain_sensitive_data']).to eq({'name' => 'Doe', 'id' => 'P10', "custom"=>{}})
-      expect(json_response['encounter']['patient']['core_fields']).to eq({'gender' => 'male'})
+      expect(json_response['encounter']['patient']).to include({'name' => 'Doe', 'id' => patient2.id, 'gender' => 'male'})
     end
 
     it "ensure only samples withing permissions can be used" do


### PR DESCRIPTION
fixes #695.
show test orders history (no paging, fixed order by start_time)
DRY patient card. refactor patient info in encounter
allow user to cmd+click or shift+click "links" of tables and now any `*[data-href]` element.
include `human_diagnose` to summarize the encounter diagnosis in 1 phrase. 
DRY empty_data notifications

pending better images and font/style adjustments by @Mscebba 