### PR TITLE
Create patient from new test order page

### DIFF
--- a/app/assets/javascripts/components/encounter_new.js.jsx
+++ b/app/assets/javascripts/components/encounter_new.js.jsx
@@ -3,7 +3,7 @@ var EncounterNew = React.createClass({
     return {encounter: {
       institution: this.props.context.institution,
       site: null,
-      patient: null,
+      patient: this.props.patient,
       samples: [],
       new_samples: [],
       test_results: [],
@@ -16,7 +16,7 @@ var EncounterNew = React.createClass({
     this.setState(React.addons.update(this.state, {
       encounter: {
         site: { $set: site },
-        patient: { $set: null },
+        patient: { $set: this.props.patient },
         samples: { $set: [] },
         new_samples: { $set: [] },
         test_results: { $set: [] },

--- a/app/assets/javascripts/components/fresh_tests_encounter_form.js.jsx
+++ b/app/assets/javascripts/components/fresh_tests_encounter_form.js.jsx
@@ -2,7 +2,7 @@ var FreshTestsEncounterForm = React.createClass(_.merge({
   render: function() {
     return (
       <div>
-        <PatientSelect context={this.props.context} onPatientChanged={this.onPatientChanged} />
+        <PatientSelect patient={this.state.encounter.patient} context={this.props.context} onPatientChanged={this.onPatientChanged} />
 
         <div className="row">
           <div className="col pe-2">

--- a/app/assets/javascripts/components/patient_select.js.jsx
+++ b/app/assets/javascripts/components/patient_select.js.jsx
@@ -1,6 +1,6 @@
 var PatientSelect = React.createClass({
   getInitialState: function() {
-    return { patient : null };
+    return { patient : this.props.patient };
   },
 
   getDefaultProps: function() {
@@ -34,6 +34,12 @@ var PatientSelect = React.createClass({
           cacheAsyncResults={false}
           filterOptions={this.filterOptions}>
         </Select>
+
+        {(function(){
+          if (this.state.patient == null) {
+            return <a className="btn-add-link" href={"/patients/new?" + $.param({next_url: window.location.href})} title="Create new patient"><span className="iconb-add"></span></a>;
+          }
+        }.bind(this))()}
 
         <br/>
         <br/>

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -6,6 +6,13 @@ class EncountersController < ApplicationController
   end
 
   def new
+    if params[:patient_id].present?
+      @institution = @navigation_context.institution
+      @patient_json = Jbuilder.new { |json|
+        scoped_patients.find(params[:patient_id]).as_json_card(json)
+      }.attributes!
+    end
+
     return unless authorize_resource(Site, CREATE_SITE_ENCOUNTER).empty?
   end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -61,7 +61,13 @@ class PatientsController < ApplicationController
     @patient.site = @navigation_context.site
 
     if @patient.save
-      redirect_to patient_path(@patient), notice: 'Patient was successfully created.'
+      next_url = if params[:next_url].blank?
+        patient_path(@patient)
+      else
+        "#{params[:next_url]}#{params[:next_url].include?('?') ? '&' : '?'}patient_id=#{@patient.id}"
+      end
+
+      redirect_to next_url, notice: 'Patient was successfully created.'
     else
       render action: 'new'
     end

--- a/app/views/encounters/new.html.haml
+++ b/app/views/encounters/new.html.haml
@@ -8,4 +8,4 @@
               = image_tag "arrow-left-white.png"
             New Test Order
 
-= react_component('EncounterNew', context: @navigation_context.to_hash, mode: params[:mode])
+= react_component('EncounterNew', context: @navigation_context.to_hash, patient: @patient_json, mode: params[:mode])

--- a/app/views/patients/_form.html.haml
+++ b/app/views/patients/_form.html.haml
@@ -1,4 +1,7 @@
 = form_for(@patient) do |f|
+  - unless params[:next_url].blank?
+    = hidden_field_tag :next_url, params[:next_url]
+
   = validation_errors @patient
 
   .row

--- a/features/support/page_objects/new_encounter_page.rb
+++ b/features/support/page_objects/new_encounter_page.rb
@@ -29,9 +29,11 @@ end
 
 class NewFreshEncounterPage < CdxPageBase
   set_url "/encounters/new?mode=fresh_tests"
+  set_url_matcher /\/encounters\/new?.*mode=fresh_tests/
 
   section :site, CdxSelect, "label", text: /Site/i
   section :patient, CdxSelect, "label", text: /Patient/i
+  element :new_patient, "a[title='Create new patient']"
 
   element :add_sample, :link, "Add sample"
 end

--- a/features/support/page_objects/new_patient_page.rb
+++ b/features/support/page_objects/new_patient_page.rb
@@ -1,0 +1,7 @@
+class NewPatientPage < CdxPageBase
+  set_url "/patients/new{?query*}"
+
+  element :name, :field, "Name"
+  element :patient_id, :field, "Patient id"
+
+end

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -181,6 +181,12 @@ RSpec.describe PatientsController, type: :controller do
       get :new
       expect(response).to be_forbidden
     end
+
+    it "should preserve next_url" do
+      next_url = 'http://example.org/some_next_url'
+      get :new, next_url: next_url
+      expect(response.body).to include(next_url)
+    end
   end
 
   context "create" do
@@ -197,7 +203,7 @@ RSpec.describe PatientsController, type: :controller do
         post :create, patient: patient_form_plan
       }.to change(institution.patients, :count).by(1)
 
-      expect(response).to be_redirect
+      expect(response).to redirect_to patient_path(Patient.last)
     end
 
     it "should save fields" do
@@ -318,6 +324,22 @@ RSpec.describe PatientsController, type: :controller do
       expect(response).to be_redirect
     end
 
+    it "should preserve next_url" do
+      next_url = 'http://example.org/some_next_url'
+      post :create, patient: build_patient_form_plan(name: ''), next_url: next_url
+
+      expect(assigns(:patient)).to be_invalid
+      expect(response).to render_template("patients/new")
+      expect(response.body).to include(next_url)
+    end
+
+    it "should redirects to next_url on creation with patient_id" do
+      next_url = 'http://example.org/some_next_url?foo=bar'
+      post :create, patient: build_patient_form_plan({}), next_url: next_url
+
+      patient = Patient.last
+      expect(response).to redirect_to "#{next_url}&patient_id=#{patient.id}"
+    end
   end
 
   context "edit" do

--- a/spec/features/encounter_spec.rb
+++ b/spec/features/encounter_spec.rb
@@ -274,4 +274,29 @@ describe "create encounter" do
       expect(page.encounter.test_results.count).to eq(0)
     end
   end
+
+  it "should be able to create fresh encounter with new patient" do
+    goto_page NewFreshEncounterPage do |page|
+      page.new_patient.click
+    end
+
+    expect_page NewPatientPage do |page|
+      page.name.set "John Doe"
+      page.patient_id.set "1001"
+      page.submit
+    end
+
+    expect_page NewFreshEncounterPage do |page|
+      page.add_sample.click
+      page.add_sample.click
+      page.submit
+    end
+
+    expect_page ShowEncounterPage do |page|
+      expect(page.encounter.patient.name).to eq("John Doe")
+      expect(page.encounter.patient.entity_id).to eq("1001")
+      expect(page.encounter.samples.count).to eq(2)
+      expect(page.encounter.test_results.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
fix #604 

allow PatientSelect to receive initial patient
allow patient creation flow to have a next_url (preserve it among validations)
allow patient to be created from a new fresh test order
add feature spec witth the whole flow