### PR TITLE
Clear mail deliveries before each spec

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -52,8 +52,6 @@ describe UsersController, type: :controller do
   describe 'POST create' do
     let(:role) { institution.roles.first }
 
-    after(:each) { ActionMailer::Base.deliveries.clear }
-
     it "sends an invitation to a new user" do
       post :create, {users: 'new@example.com', role: role.id}
       expect(ActionMailer::Base.deliveries.count).to eq(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,17 +70,15 @@ RSpec.configure do |config|
   config.include FeatureSpecHelpers, :type => :feature
 
   config.before(:each) do
-    LocationService.fake!
-  end
-
-  config.before(:each) do
     stub_request(:get, "http://fonts.googleapis.com/css").
          with(:query => hash_including(:family)).
          to_return(:status => 200, :body => "", :headers => {})
   end
 
   config.before(:each) do
+    LocationService.fake!
     Timecop.return
+    ActionMailer::Base.deliveries.clear
   end
 
   config.after(:each) do


### PR DESCRIPTION
Ensure we start with a fresh outbox. Fixes incorrect assertions on deliveries count depending on order of specs.