### PR TITLE
Restrict institution destroy on associated entities

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -87,7 +87,6 @@
 
 }
 
-
 .btn-add,
 .btn-add-secondary {
   font-family: $sans;
@@ -125,6 +124,11 @@
   &:hover,
   &:focus {
     color: $gray4;
+  }
+
+  &.not-allowed {
+    color: $gray3;
+    cursor: default;
   }
 }
 

--- a/app/helpers/confirmation_helper.rb
+++ b/app/helpers/confirmation_helper.rb
@@ -1,5 +1,9 @@
 module ConfirmationHelper
-  def confirm_deletion_button target, entity_type
-    link_to "Delete", target, method: :delete, data: { confirm: "You're about to permanently delete this #{entity_type}. This action CANNOT be undone. Are you sure you want to proceed?" }, class: 'btn-secondary pull-right', title: "Delete #{entity_type.capitalize}"
+  def confirm_deletion_button target, entity_type=nil, relations=nil
+    entity_type ||= target.model_name.singular
+    relations ||= target.destroy_restrict_associations_with_elements.map{|assoc| assoc.plural_name.humanize(capitalize: false)}.to_sentence.presence || 'entities'
+    link_to_if target.can_destroy?, "Delete", target, method: :delete, data: { confirm: "You're about to permanently delete this #{entity_type}. This action CANNOT be undone. Are you sure you want to proceed?" }, class: 'btn-secondary pull-right', title: "Delete #{entity_type.capitalize}" do
+      content_tag :span, "Cannot delete", title: "This #{entity_type} has associated #{relations}.", class: 'btn-link not-allowed pull-right'
+    end
   end
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -6,9 +6,10 @@ class Institution < ActiveRecord::Base
 
   belongs_to :user
 
-  has_many :sites, dependent: :destroy
-  has_many :devices, dependent: :destroy
+  has_many :sites, dependent: :restrict_with_error
+  has_many :devices, dependent: :restrict_with_error
   has_many :device_models, dependent: :restrict_with_error, inverse_of: :institution
+  
   has_many :encounters, dependent: :destroy
   has_many :patients, dependent: :destroy
   has_many :samples, dependent: :destroy

--- a/app/views/institutions/_form.haml
+++ b/app/views/institutions/_form.haml
@@ -56,4 +56,4 @@
           = link_to 'Cancel', institutions_path, class: 'btn-link'
 
           - if @can_delete
-            = confirm_deletion_button @institution, 'institution'
+            = confirm_deletion_button @institution

--- a/config/initializers/activerecord.rb
+++ b/config/initializers/activerecord.rb
@@ -1,0 +1,20 @@
+class ActiveRecord::Base
+
+  def destroy_restrict_associations
+    self.class.reflect_on_all_associations.select do |assoc|
+      assoc.options[:dependent] == :restrict_with_error || assoc.options[:dependent] == :restrict_with_exception
+    end
+  end
+
+  def destroy_restrict_associations_with_elements
+    destroy_restrict_associations.select do |assoc|
+      (assoc.macro == :has_one && self.send(assoc.name).not_nil?) ||
+        (assoc.macro == :has_many && self.send(assoc.name).any?)
+    end
+  end
+
+  def can_destroy?
+    destroy_restrict_associations_with_elements.empty?
+  end
+  
+end

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -35,5 +35,17 @@ describe Institution do
         institution.destroy
       }.to change(Role, :count).by(-2)
     end
+
+    it "does not destroy if it has devices associated" do
+      institution = Institution.make
+      device = Device.make institution: institution
+      expect(institution.destroy).to be_falsey
+    end
+
+    it "does not destroy if it has sites associated" do
+      institution = Institution.make
+      site = Site.make institution: institution
+      expect(institution.destroy).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
Do not allow a user to destroy an institution if it has associated devices, sites or device models. Added a  check to the confirmation deletion helper, and added  method to activerecord base. Fixes #690.