### PR TITLE
Restrict role policy to its institution

### DIFF
--- a/app/models/computed_policy.rb
+++ b/app/models/computed_policy.rb
@@ -224,11 +224,14 @@ class ComputedPolicy < ActiveRecord::Base
         entry.merge(exceptions_attributes: applicable_exceptions)
       end.compact
 
-      granted_statements = if policy.granter.nil?
-        granted_statements
-      else
+      granted_statements = if policy.granter
         granter_statements = policy.granter.computed_policies.delegable.map(&:computed_attributes)
         intersect(granted_statements, granter_statements)
+      elsif policy.role
+        granter_statements = Policy.owner(nil, policy.role.institution.id, policy.role.institution.kind).to_computed_policies.select(&:delegable).map(&:computed_attributes)
+        intersect(granted_statements, granter_statements)
+      else
+        granted_statements
       end
 
       granted_statements.map do |g|

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -2,6 +2,8 @@ class Policy < ActiveRecord::Base
   belongs_to :user
   belongs_to :granter, class_name: 'User', foreign_key: 'granter_id'
 
+  has_one :role, inverse_of: :policy
+
   validates_presence_of :name, :definition
 
   attr_accessor :allows_implicit
@@ -127,6 +129,11 @@ class Policy < ActiveRecord::Base
   def self_granted?
     self.user_id && self.user_id == self.granter_id
   end
+
+  def to_computed_policies
+    ComputedPolicy::PolicyComputer.new.compute_for(self)
+  end
+
 
   # Not evaluated as part of validations in ActiveModel lifecycle
   def validate_owner_permissions

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -52,4 +52,50 @@ describe RolesController do
 
   end
 
+  context "authorizations" do
+
+    let(:grantee) { User.make }
+
+    let!(:site)  { Site.make(institution: institution) }
+    let!(:site2) { Site.make(institution: institution2) }
+
+    def create_role(args)
+      expect {
+        post :create, role: args
+      }.to change(institution.roles, :count).by(1)
+
+    end
+
+    def add_grantee_to_role(role_name)
+      grantee.roles << Role.where(name: role_name).first
+      grantee.update_computed_policies
+      grantee.reload
+    end
+
+    it "should not allow to access a site from a different institution when not scoping sites in policy" do
+      create_role name: "All sites", definition: policy_definition('site', '*').to_json
+      add_grantee_to_role 'All sites'
+
+      assert_cannot grantee, site2, 'site:read'
+      assert_can grantee, site, 'site:read'
+    end
+
+    it "should not allow to access a site from a different institution when scoping by another institution in policy" do
+      create_role name: "Sites from institution 2", definition: policy_definition("site?institution=#{institution2.id}", '*').to_json
+      add_grantee_to_role "Sites from institution 2"
+
+      assert_cannot grantee, site2, 'site:read'
+      assert_cannot grantee, site, 'site:read'
+    end
+
+    it "should not allow to access a forbidden resource when creating a role" do
+      device_model = DeviceModel.make
+      create_role name: "Device models", definition: policy_definition("deviceModel", '*').to_json
+      add_grantee_to_role "Device models"
+
+      assert_cannot grantee, device_model, 'deviceModel:read'
+    end
+
+  end
+
 end

--- a/spec/models/computed_policy_spec.rb
+++ b/spec/models/computed_policy_spec.rb
@@ -716,7 +716,7 @@ describe ComputedPolicy do
         expect(p.action).to eq(READ_DEVICE)
         expect(p.resource_type).to eq('device')
         expect(p.resource_id).to eq(device.id.to_s)
-        expect(p.condition_institution_id).to be_nil
+        expect(p.condition_institution_id).to eq(role.institution.id)
         expect(p.condition_site_id).to be_nil
       end
     end


### PR DESCRIPTION
Use institution owner policy to intersect the policy of a new role for that institution. Fixes #673.