### PR TITLE
Enable cache block for location service when processing device messages

### DIFF
--- a/app/models/concerns/with_location.rb
+++ b/app/models/concerns/with_location.rb
@@ -3,6 +3,7 @@ module WithLocation
 
   included do
     def location(opts={})
+      return nil if self.location_geoid.blank?
       @location = nil if @location_opts.presence != opts.presence || @location.try(:geo_id) != location_geoid
       @location_opts = opts
       @location ||= Location.find(location_geoid, opts)
@@ -14,7 +15,7 @@ module WithLocation
     end
 
     def self.preload_locations!
-      locations = Location.details(all.map(&:location_geoid).uniq).index_by(&:id)
+      locations = Location.details(all.map(&:location_geoid).map(&:presence).compact.uniq).index_by(&:id)
       all.to_a.each do |record|
         record.location = locations[record.location_geoid]
       end

--- a/app/models/device_message_processor.rb
+++ b/app/models/device_message_processor.rb
@@ -7,8 +7,10 @@ class DeviceMessageProcessor
   end
 
   def process
-    @device_message.parsed_messages.map do |parsed_message|
-      SingleMessageProcessor.new(self, parsed_message).process
+    Location.with_cache do
+      @device_message.parsed_messages.map do |parsed_message|
+        SingleMessageProcessor.new(self, parsed_message).process
+      end
     end
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -11,8 +11,26 @@ class Location
     ancestors + [self]
   end
 
-  def self.common_root(locations)
-    locations.map(&:self_and_ancestors).inject(:&).last
+  class << self
+    @cache = nil
+
+    def common_root(locations)
+      locations.map(&:self_and_ancestors).inject(:&).last
+    end
+
+    def find_with_cache(geoid, opts={})
+      return nil if geoid.blank?
+      return find_without_cache(geoid, opts) if @cache.nil?
+      (@cache[opts] ||= {})[geoid] ||= find_without_cache(geoid, opts)
+    end
+
+    def with_cache
+      @cache = Hash.new
+      yield
+      @cache = nil
+    end
+
+    alias_method_chain :find, :cache
   end
 
 end

--- a/app/models/test_result_indexer.rb
+++ b/app/models/test_result_indexer.rb
@@ -26,7 +26,7 @@ class TestResultIndexer < EntityIndexer
     return {
       'test'        => test_fields(test_result),
       'device'      => device_fields(test_result.device),
-      'location'    => location_fields(test_result.device.site.try(:location)),
+      'location'    => location_fields(test_result.device.site.try(:location, ancestors: true)),
       'institution' => institution_fields(test_result.device.institution),
       'site'        => site_fields(test_result.device.site),
       'sample'      => sample_fields(test_result.sample),


### PR DESCRIPTION
Fixes #746 (multiple requests to location service when processing messages)