### PR TITLE
refactor spec that imports csv from samples

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,7 +1,8 @@
 class Device < ActiveRecord::Base
   include Resource
   include SiteContained
-
+  acts_as_paranoid
+  
   belongs_to :device_model
 
   has_one :manifest, through: :device_model

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -12,7 +12,7 @@ class TestResult < ActiveRecord::Base
   has_and_belongs_to_many :device_messages
   has_many :test_result_parsed_data
 
-  belongs_to :device
+  belongs_to :device, -> { with_deleted }
   belongs_to :sample_identifier, inverse_of: :test_results, autosave: true
   belongs_to :patient
   belongs_to :encounter

--- a/db/migrate/20160215195614_add_deleted_at_to_devices.rb
+++ b/db/migrate/20160215195614_add_deleted_at_to_devices.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToDevices < ActiveRecord::Migration
+  def change
+    add_column :devices, :deleted_at, :datetime
+    add_index :devices, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160210193741) do
+ActiveRecord::Schema.define(version: 20160215195614) do
 
   create_table "computed_policies", force: :cascade do |t|
     t.integer "user_id",                  limit: 4
@@ -124,7 +124,10 @@ ActiveRecord::Schema.define(version: 20160210193741) do
     t.string   "ftp_password",     limit: 255
     t.string   "ftp_directory",    limit: 255
     t.integer  "ftp_port",         limit: 4
+    t.datetime "deleted_at"
   end
+
+  add_index "devices", ["deleted_at"], name: "index_devices_on_deleted_at", using: :btree
 
   create_table "encounters", force: :cascade do |t|
     t.integer  "institution_id",  limit: 4

--- a/features/support/page_objects/cdx_page_base.rb
+++ b/features/support/page_objects/cdx_page_base.rb
@@ -7,11 +7,16 @@ class CdxPageBase < SitePrism::Page
     end
   end
 
+  class ConfirmationSection < SitePrism::Section
+    element :delete, :button, 'Delete'
+  end
+
   element :navigation_context_handle, "#nav-context"
   section :navigation_context, NavigationContextSection, "#context_side_bar"
   element :primary, ".btn-primary"
   element :content, ".content", match: :first
   element :logout_link, :link, "Log out"
+  section :confirmation, ConfirmationSection, '[data-react-class="ConfirmationModal"]'
 
   def logout
     logout_link.trigger('click')

--- a/features/support/page_objects/device_page.rb
+++ b/features/support/page_objects/device_page.rb
@@ -18,6 +18,8 @@ end
 class DevicePage < DeviceSetupPage
   set_url '/devices/{id}'
 
+  element :edit, "a[title='Edit']"
+
   section :tab_header, '.tabs' do
     element :setup, :link, 'Setup'
   end
@@ -25,6 +27,12 @@ class DevicePage < DeviceSetupPage
   section :tabs_content, '.tabs-content' do
     element :explore_tests, :link, 'Explore tests'
   end
+end
+
+class DeviceEditPage < CdxPageBase
+  set_url '/devices/{id}/edit{?query*}'
+
+  element :delete, :link, 'Delete'
 end
 
 class NewDevicePage < CdxPageBase

--- a/features/support/page_objects/test_results_page.rb
+++ b/features/support/page_objects/test_results_page.rb
@@ -1,0 +1,5 @@
+class TestResultsPage < CdxPageBase
+  set_url '/test_results/{?query*}'
+
+  section :table, CdxTable, "table"
+end

--- a/spec/support/device_spec_helper.rb
+++ b/spec/support/device_spec_helper.rb
@@ -1,0 +1,39 @@
+class DeviceSpecHelper
+  attr_reader :device_model
+
+  def initialize(name)
+    @device_model = DeviceModel.make name: name
+    @sync_dir = CDXSync::SyncDirectory.new(Dir.mktmpdir('sync'))
+
+    load_manifest @device_model, "#{name}_manifest.json"
+
+    @sync_dir.ensure_sync_path!
+  end
+
+  def make(attributes = {})
+    device = Device.make({device_model: device_model}.merge(attributes))
+
+    @sync_dir.ensure_client_sync_paths! device.uuid
+
+    device
+  end
+
+  def import_sample_csv(device, name)
+    copy_sample_csv device, name
+    DeviceMessageImporter.new("*.csv").import_from @sync_dir
+  end
+
+  private
+
+  def load_manifest(device_model, name)
+    Manifest.create! device_model: device_model, definition: IO.read(File.join(Rails.root, 'db', 'seeds', 'manifests', name))
+  end
+
+  def copy_sample_csv(device, name)
+    copy_sample(device, name, 'csvs')
+  end
+
+  def copy_sample(device, name, format)
+    FileUtils.cp File.join(Rails.root, 'spec', 'fixtures', format, name), @sync_dir.inbox_path(device.uuid)
+  end
+end


### PR DESCRIPTION
fixes #764
make device acts_as_paranoid
ensure test_results of soft deleted devices can be accessed.