### PR TITLE
Fixes #823: show user email in Settings

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -433,3 +433,9 @@ label.on {
     display: block;
   }
 }
+
+#edit_user {
+  input[type="text"], input[type="password"] {
+    width: 400px;
+  }
+}

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -17,6 +17,11 @@
       = f.text_field :last_name
   .row
     .col.pe-2
+      = f.label :email
+    .col
+      = f.text_field :email, readonly: true
+  .row
+    .col.pe-2
       = f.label :telephone
     .col
       = f.text_field :telephone


### PR DESCRIPTION
Adds the email as a **readonly** input.

![screenshot 2016-02-24 15 54 57](https://cloud.githubusercontent.com/assets/209371/13297030/14ccbf9c-db0f-11e5-8caf-cf94d229db6c.png)
