### PR TITLE
Fixes #784: don't show unavailable info as "n/a" in patient card if it's missing

### DIFF
--- a/app/assets/javascripts/components/cards.js.jsx.erb
+++ b/app/assets/javascripts/components/cards.js.jsx.erb
@@ -8,6 +8,20 @@ var PatientCard = React.createClass({
   render: function () {
     var patient = this.props.patient;
 
+    function patientInfo(patient) {
+      var string = "";
+      if (patient.gender) {
+        string += patient.gender;
+        if (patient.dob) {
+          string += " - "
+        }
+      }
+      if (patient.dob) {
+        string += patient.dob + " (" + patient.age + ")";
+      }
+      return string;
+    }
+
     if (patient == null) {
       return (
         <%= to_jsx(card(image: asset_url('card-unkown.png')) do |c|
@@ -22,7 +36,7 @@ var PatientCard = React.createClass({
           c.top do
             raw <<-JSX
               <a href={"/patients/" + patient.id}>{patient.name}</a><br/>
-              {patient.gender || "n/a"} - {patient.dob || "n/a"} ({patient.age || "n/a"})
+              {patientInfo(patient)}
             JSX
           end
 


### PR DESCRIPTION
If only gender is available:

![screenshot 2016-02-24 16 39 53](https://cloud.githubusercontent.com/assets/209371/13298383/4bfab9a0-db15-11e5-810d-207277e4b76d.png)

Only age:

![screenshot 2016-02-24 16 41 15](https://cloud.githubusercontent.com/assets/209371/13298421/732001b6-db15-11e5-8f73-af8a9308e602.png)

Both:

![screenshot 2016-02-24 16 40 40](https://cloud.githubusercontent.com/assets/209371/13298399/5d2658ce-db15-11e5-80bf-468f28e07e73.png)

None:

![screenshot 2016-02-24 16 41 51](https://cloud.githubusercontent.com/assets/209371/13298450/85b5899a-db15-11e5-96e7-85a5ff0c43b1.png)

