### PR TITLE
Submit filter forms while user is typing (with a debounce of 2 sec)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -80,11 +80,17 @@ $(document).ready(function(){
       Turbolinks.visit(url.toString(), options);
     }, 2000);
 
-    form.on('change', function(){
+    var submitIfChanged = function() {
       if (payload != form.serialize()) {
-        payload = form.serialize()
+        payload = form.serialize();
         debouncedSubmit();
       }
+    };
+
+    form.on('change', submitIfChanged);
+    form.on('keyup', 'input[type=text]', function(){
+      // defer the keyup event so the changes due to the pressed key occur.
+      window.setTimeout(submitIfChanged, 0);
     });
   });
 


### PR DESCRIPTION
fix #789

already started requests are not cancelled once they've started. So if the user continues to type after the blue progress started, some ugly things happen (text disappear and reapear). But, for this to occur, the user needs to stop making changes for 2 sec and begin to do it again.