### PR TITLE
fixed #962 ,for an alert only detect specimen test types

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -106,6 +106,7 @@ class AlertsController < ApplicationController
       condition_result_ok, error_text = set_category(params, alert_info, error_text, condition_result_ok, edit)
       set_sample_id(params, alert_info)
       set_sites_devices_institutions(params, alert_info, edit)
+      only_allow_specimen_test_type(alert_info)
       alert_query_updated_ok = alert_info.update(query: alert_info.query)
     end
 
@@ -196,6 +197,10 @@ class AlertsController < ApplicationController
     end
   end
 
+  def only_allow_specimen_test_type(alert_info)
+    alert_info.query=alert_info.query.merge ({"test.type"=>"specimen"})
+  end
+  
   def set_sites_devices_institutions(params, alert_info, is_edit)
     if is_edit==true
       alert_info.devices.destroy_all
@@ -214,7 +219,7 @@ class AlertsController < ApplicationController
         alert_info.sites << site
         query_sites << site.uuid
       end
-      #Note:  the institution uuid should not be necessary
+      
       alert_info.query=alert_info.query.merge ({"site.uuid"=>query_sites})
     end
 

--- a/features/alert.feature
+++ b/features/alert.feature
@@ -9,6 +9,11 @@ Feature: create an alert
     Then the user should have error_code alert result 
     Then the user should have an incident
 
+  Scenario: Successful create error category alert with all fields but no incident for QC test type
+    Given the user creates a new error category alert with all fields with name "errorcategory"
+    Then the user should see in list alerts "errorcategory"
+    Then the user should have no error_code alert result for qc test 
+
   Scenario: Successful create anomalie category alert with all fields
     Given the user creates a new anomalie category alert with all fields with name "anomaliecategory"
     Then the user should see in list alerts "anomaliecategory"

--- a/features/step_definitions/alert_steps.rb
+++ b/features/step_definitions/alert_steps.rb
@@ -168,10 +168,26 @@ Then (/^the user should have error_code alert result$/) do
   device1 = Device.make institution: @institution, site: site1
 
   #note: make sure the test above using thise does not have sample-id set, and aggregation type = record
-  DeviceMessage.create_and_process device: device1, plain_text_data: (Oj.dump test:{assays:[result: :negative], error_code: 2}, sample: {id: 'a'}, patient: {id: 'a',gender: :male})
+  DeviceMessage.create_and_process device: device1, plain_text_data: (Oj.dump test:{assays:[result: :negative], error_code: 2, type: 'specimen'}, sample: {id: 'a'}, patient: {id: 'a',gender: :male})
   after_test_history_count = AlertHistory.count
 
   expect(after_test_history_count).to be > before_test_history_count
+end
+
+Then (/^the user should have no error_code alert result for qc test$/) do
+  parent_location = Location.make
+  leaf_location1 = Location.make parent: parent_location
+  upper_leaf_location = Location.make
+
+  before_test_history_count = AlertHistory.count
+  site1 = Site.make institution: @institution, location_geoid: leaf_location1.id
+  device1 = Device.make institution: @institution, site: site1
+
+  #note: make sure the test above using thise does not have sample-id set, and aggregation type = record
+  DeviceMessage.create_and_process device: device1, plain_text_data: (Oj.dump test:{assays:[result: :negative], error_code: 2, type: 'qc'}, sample: {id: 'a'}, patient: {id: 'a',gender: :male})
+  after_test_history_count = AlertHistory.count
+
+  expect(after_test_history_count).to equal(before_test_history_count)
 end
 
 Then (/^the user should have no_sample_id alert result$/) do
@@ -184,7 +200,7 @@ Then (/^the user should have no_sample_id alert result$/) do
   device1 = Device.make institution: @institution, site: site1
 
   #note: make sure the test above using thise does not have sample-id set, and aggregation type = record
-  DeviceMessage.create_and_process device: device1, plain_text_data: (Oj.dump test:{assays:[result: :negative]}, sample: {}, patient: {id: 'a',gender: :male})
+  DeviceMessage.create_and_process device: device1, plain_text_data: (Oj.dump test:{assays:[result: :negative], type: 'specimen'}, sample: {}, patient: {id: 'a',gender: :male})
   after_test_history_count = AlertHistory.count
 
   expect(before_test_history_count+1).to eq(after_test_history_count)

--- a/spec/lib/sms_spec.rb
+++ b/spec/lib/sms_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 include Alerts
 
-
 describe "SMS" do
-
   before(:each) do
     stub_request(:get, "https://CDx%2FCDx-Dev:cdx123cdx@nuntium.instedd.org/CDx/CDx-Dev/send_ao?body=welcome%20mr%20smith&from=sms://442393162302&to=sms://123444").
     with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}).
@@ -16,7 +14,6 @@ describe "SMS" do
 
   context "sms operation" do
     it "should test sending sms" do
-
       alert = Alert.make
       alert.name="test alert"
       alert.sms_message="welcome mr {lastname}"
@@ -33,7 +30,6 @@ describe "SMS" do
       person[:user_id] = nil
       person[:recipient_id] = recipient.id
       tel_list.push person
-
 
       recipient2 = AlertRecipient.make
       recipient2.recipient_type = AlertRecipient.recipient_types["external_user"]
@@ -51,80 +47,9 @@ describe "SMS" do
       alert_history = AlertHistory.new
       alert_history.alert = alert
 
-
       alert_sms_inform_recipient(alert, alert_history, tel_list, alert_count=0)
 
       expect(RecipientNotificationHistory.count).to eq(2)
     end
-
   end
-
-
-=begin
-  context "sms exceeded" do
-
-    it "should test exceeding sms limit" do
-
-
-      alert = Alert.make
-      alert.name="test alert"
-      alert.sms_message="welcome mr {lastname}"
-
-      recipient = AlertRecipient.make
-      recipient.recipient_type = AlertRecipient.recipient_types["external_user"]
-      recipient.alert=alert
-
-      tel_list=[]
-      person = Hash.new
-      person[:telephone] = "123444"
-      person[:first_name] = recipient.first_name
-      person[:last_name] = recipient.last_name
-      person[:user_id] = nil
-      person[:recipient_id] = recipient.id
-      tel_list.push person
-
-      alert_history = AlertHistory.new
-      alert_history.alert = alert
-
-      alert.sms_limit=2
-
-      alert.error_code=155
-      binding.pry
-      alert.category_type= "device_errors"
-      alert.save
-
-
-      #insert test result
-      binding.pry
-      user = User.make
-      institution = Institution.make user_id: user.id
-      site =  Site.make institution: institution
-      device =  Device.make institution: institution, site: site
-      data = Oj.dump test:{assays: [result: :positive]}
-
-
-      #  DeviceMessage.create_and_process device: device, plain_text_data: Oj.dump(test:{assays:[condition: "flu_a"]}, sample: {id: 'a'}, patient: {id: 'a'})
-
-      DeviceMessage.create_and_process device: device, plain_text_data: (Oj.dump test:{assays:[result: :negative], error_code: 155}, sample: {id: 'a'}, patient: {id: 'a',gender: :male})
-
-
-
-
-
-      #     alert_sms_inform_recipient(alert, alert_history, tel_list, alert_count=0)
-      #     binding.pry
-      #     alert_sms_inform_recipient(alert, alert_history, tel_list, alert_count=0)
-      #     binding.pry
-      #     alert_sms_inform_recipient(alert, alert_history, tel_list, alert_count=0)
-      #     binding.pry
-      #    alert_sms_inform_recipient(alert, alert_history, tel_list, alert_count=0)
-
-      binding.pry
-      expect(RecipientNotificationHistory.count).to eq(2)
-
-    end
-  end
-=end
-
-
 end


### PR DESCRIPTION
For a new alert created add a filter for specimen test type.