### PR TITLE
Fix file-dropzone out of view when scrolling file-container

### DIFF
--- a/app/views/laboratory_samples/_form_js.haml
+++ b/app/views/laboratory_samples/_form_js.haml
@@ -37,6 +37,12 @@
       $(this).closest('.file-uploaded').addClass('remove');
       e.stopPropagation();
     });
+
+    $('.assay > .upload-new-file').on('scroll', function(e) {
+      var scrollDiff = $(this).scrollTop();
+      // move dropzone-input into view
+      $('.upload-picture').css('top', scrollDiff);
+    });
   });
 
   document.addEventListener("dragenter", function( event ) {


### PR DESCRIPTION
The file-dropzone was being ​scrolled by the container.