### PR TITLE
Add remove recent assays

### DIFF
--- a/app/assets/stylesheets/_test_qc_results.scss
+++ b/app/assets/stylesheets/_test_qc_results.scss
@@ -3,6 +3,16 @@
   height: auto;
   width: 100%;
   padding: 0px;
+
+  &+ .actions {
+    margin: 0 15px 15px;
+
+    .btn-icon {
+      background: none !important;
+      color: inherit;
+      margin: -3px 0 0;
+    }
+  }
 }
 
 .assay {
@@ -13,7 +23,7 @@
     overflow: auto;
     padding: 7px;
     min-height: 145px;
-    max-height: 300px;
+    max-height: 310px;
 
     .upload-picture-title {
       align-self: center;

--- a/app/views/laboratory_samples/_form.haml
+++ b/app/views/laboratory_samples/_form.haml
@@ -37,6 +37,10 @@
                     = image_tag "ic-cross.png"
 
             = qc.file_field :files, :class => "upload-picture",  accept: 'image/png,image/jpeg,image/gif', multiple: true
+        .actions
+          = button_tag id: 'undo_added_files', class: 'btn-link hidden' do
+            .icon-close.btn-icon
+            Undo added files
 
 
   - if @sample.is_quality_control

--- a/app/views/laboratory_samples/_form_js.haml
+++ b/app/views/laboratory_samples/_form_js.haml
@@ -2,7 +2,7 @@
   (function() {
     var onloadPicture = function(filename) {
       return function(event) {
-        var fileDiv = $('<div>', { class: 'picture-container' })
+        var fileDiv = $('<div>', { class: 'picture-container new-file' })
           .append(
             $('<img>')
               .attr('src', event.target.result)
@@ -29,10 +29,14 @@
         reader.onload = onloadPicture(name);
         reader.readAsDataURL(files[i]);
       }
+
+      if (files.length > 0) {
+        $('#undo_added_files').removeClass('hidden');
+      }
     });
 
     // Change the class on the target zone when dragging a file over it
-    $(".clear-label").on('click', function (e) {
+    $(".clear-label").on('click', function(e) {
       $(this).closest('.file-uploaded').addClass('remove');
       e.stopPropagation();
     });
@@ -53,6 +57,21 @@
       var scrollDiff = $(this).scrollTop();
       // move dropzone-input into view
       $('.upload-picture').css('top', scrollDiff);
+    });
+
+    // Reset
+    $('#undo_added_files').on('click', function(e) {
+      event.preventDefault();
+
+      // remove file preview
+      $('.new-file').remove();
+      // hide button
+      $('#undo_added_files').addClass('hidden');
+
+      // remove files from input FileList
+      var emptyClonedInput = $('#laboratory_sample_test_qc_result_attributes_files').val('').clone(true);
+      $('#laboratory_sample_test_qc_result_attributes_files')
+        .replaceWith(emptyClonedInput);
     });
   })();
 


### PR DESCRIPTION
When the user adds new assays a button is shown with the option to remove the new added assays.
[FileList API](https://developer.mozilla.org/en-US/docs/Web/API/FileList) is readonly and files cannot be removed once added to the input that's why this solution removes all the recent added assays. 