### PR TITLE
Reorder batch fields in batch form to be the same as laboratory samples

### DIFF
--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -6,19 +6,24 @@
     .col
       .row
         .col.pe-3
-          = f.label :batch_id
+          = f.label :batch_id, "BATCH ID"
         .col
           = f.text_field :batch_number
+      .row
+        .col.pe-3
+          = f.label :production_date
+        .col
+          = f.text_field :date_produced, placeholder: @batch_form.date_produced_placeholder
+      .row
+        .col.pe-3
+          = f.label :lab_technician
+        .col
+          = f.text_field :lab_technician, :class => 'input-x-large'
       .row
         .col.pe-3
           = f.label :isolate_name
         .col
           = f.text_field :isolate_name, :class => 'input-x-large'
-      .row
-        .col.pe-3
-          = f.label :date_produced
-        .col
-          = f.text_field :date_produced, placeholder: @batch_form.date_produced_placeholder
       .row
         .col.pe-3
           = f.label :inactivation_method
@@ -32,11 +37,6 @@
           .row.input-unit
             = f.number_field :volume, min: 0, step: :any, :class => "input-small"
             .span.unit (μl)
-      .row
-        .col.pe-3
-          = f.label :lab_technician
-        .col
-          = f.text_field :lab_technician, :class => 'input-x-large'
 
       - if @can_edit_sample_quantity
         .row


### PR DESCRIPTION
-Related: #1228 

Since the creation of laboratory samples was fixed as part of #1248, this issue only reorders input fields the same as it is in Laboratory Samples form. 
The user is not allowed to create notes or either attach assays when creating a batch, it has to be saved first. Batch_id was created in #1201.