### PR TITLE
Fix: date-produced format in Samples list

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -92,4 +92,12 @@ class Sample < ActiveRecord::Base
       )
     end
   end
+
+  def date_produced_description
+    if date_produced.is_a?(Time)
+      return date_produced.strftime(I18n.t('date.input_format.pattern'))
+    end
+
+    date_produced
+  end
 end

--- a/app/views/samples/index.haml
+++ b/app/views/samples/index.haml
@@ -34,7 +34,7 @@
                   %label.row{for: "sample_ids.#{sample.id}"}
                 %td= sample.uuid
                 %td= sample.lab_technician
-                %td= sample.date_produced
+                %td= sample.date_produced_description
 
       .pagination
         = render 'shared/pagination'


### PR DESCRIPTION
Date produced column in Samples list was displayed without format