### PR TITLE
Support attachments in non-default S3 regions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,6 +106,12 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 ```
 
+If the S3 bucket is not in the default (`us-east-1`) region, you need to also specify the [bucket's region-specific host name](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region):
+
+```
+PAPERCLIP_S3_HOST_NAME=s3.us-west-1.amazonaws.com
+```
+
 #### Local storage
 
 Alternatively, attachments can be stored locally. Create a folder within the data directory owned by user `9999` and mount it in `/app/public/system`. Assuming the data directory is `/u/apps/cdx/data/uploads`, then:

--- a/config/initializers/paperclip_defaults.rb
+++ b/config/initializers/paperclip_defaults.rb
@@ -4,8 +4,12 @@ Paperclip::Attachment.default_options.update({
 })
 
 if s3_bucket = ENV['PAPERCLIP_S3_BUCKET'].presence
-  Rails.application.config.paperclip_defaults = {
+  paperclip_defaults = {
     storage: :s3,
     bucket: s3_bucket
   }
+  if s3_host_name = ENV['PAPERCLIP_S3_HOST_NAME'].presence
+    paperclip_defaults[:s3_host_name] = s3_host_name
+  end
+  Rails.application.config.paperclip_defaults = paperclip_defaults
 end

--- a/config/initializers/paperclip_defaults.rb
+++ b/config/initializers/paperclip_defaults.rb
@@ -8,8 +8,6 @@ if s3_bucket = ENV['PAPERCLIP_S3_BUCKET'].presence
     storage: :s3,
     bucket: s3_bucket
   }
-  if s3_host_name = ENV['PAPERCLIP_S3_HOST_NAME'].presence
-    paperclip_defaults[:s3_host_name] = s3_host_name
-  end
+  paperclip_defaults[:s3_host_name] = ENV['PAPERCLIP_S3_HOST_NAME'].presence
   Rails.application.config.paperclip_defaults = paperclip_defaults
 end


### PR DESCRIPTION
Uploading attachments crashed with an exception due to an issue with S3.

```
AWS::S3::Errors::PermanentRedirect (The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.)
```

We now allow to specify the region-specific endpoint of the S3 bucket to avoid this.