### PR TITLE
Add SpecimenRole validation to only permit allowed values

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -26,6 +26,8 @@ class Batch < ActiveRecord::Base
   INACTIVATION_METHOD_VALUES = Batch.entity_fields.detect { |f| f.name == 'inactivation_method' }.options
   validates_presence_of :inactivation_method
   validates_inclusion_of :inactivation_method, in: INACTIVATION_METHOD_VALUES, message: "is not within valid options (should be one of #{INACTIVATION_METHOD_VALUES.join(', ')})"
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
+
 
   validates_presence_of :date_produced
   validates_presence_of :volume

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -26,7 +26,7 @@ class Batch < ActiveRecord::Base
   INACTIVATION_METHOD_VALUES = Batch.entity_fields.detect { |f| f.name == 'inactivation_method' }.options
   validates_presence_of :inactivation_method
   validates_inclusion_of :inactivation_method, in: INACTIVATION_METHOD_VALUES, message: "is not within valid options (should be one of #{INACTIVATION_METHOD_VALUES.join(', ')})"
-  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
 
 
   validates_presence_of :date_produced

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -26,7 +26,7 @@ class Batch < ActiveRecord::Base
   INACTIVATION_METHOD_VALUES = Batch.entity_fields.detect { |f| f.name == 'inactivation_method' }.options
   validates_presence_of :inactivation_method
   validates_inclusion_of :inactivation_method, in: INACTIVATION_METHOD_VALUES, message: "is not within valid options (should be one of #{INACTIVATION_METHOD_VALUES.join(', ')})"
-  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES.map {|key, value| "#{key.upcase} - #{value}"}, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
 
 
   validates_presence_of :date_produced

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -21,6 +21,8 @@ class Sample < ActiveRecord::Base
   validate :validate_patient
 
   SPECIMEN_ROLES = YAML.load_file(File.join(File.dirname(__FILE__), ".", "config", "specimen_roles.yml"))["specimen_roles"]
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
+
 
   def self.entity_scope
     "sample"

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -21,7 +21,7 @@ class Sample < ActiveRecord::Base
   validate :validate_patient
 
   SPECIMEN_ROLES = YAML.load_file(File.join(File.dirname(__FILE__), ".", "config", "specimen_roles.yml"))["specimen_roles"]
-  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES.map {|key, value| "#{key.upcase} - #{value}"}, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
 
 
   def self.entity_scope


### PR DESCRIPTION
-Related #1312 

Only allow to save permitted values for Samples and Batches models. It should only allow options in `specimen_roles.yml` and should allow blanks for Batches since it isn't a required field as described in #1311 . It should allow blanks for Samples as well, described in #1278 

<img width="1046" alt="Screen Shot 2021-09-03 at 15 59 52" src="https://user-images.githubusercontent.com/23437283/132054136-8c74c5d5-981e-4bd6-9812-c55583126196.png">
