### PR TITLE
Improve specimen role ux

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -26,8 +26,13 @@ class Batch < ActiveRecord::Base
   validates_presence_of :inactivation_method
   validates_inclusion_of :inactivation_method, in: INACTIVATION_METHOD_VALUES, message: "is not within valid options (should be one of #{INACTIVATION_METHOD_VALUES.join(', ')})"
 
-  SPECIMEN_ROLES = YAML.load_file(File.join(File.dirname(__FILE__), ".", "config", "specimen_roles.yml"))["specimen_roles"]
-  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES.map {|key, value| "#{key.upcase} - #{value}"}, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
+  SPECIMEN_ROLES_IDS = Batch.entity_fields.detect { |f| f.name == 'specimen_role' }.options
+  SPECIMEN_ROLES_DESCRIPTION = YAML.load_file(File.join(File.dirname(__FILE__), ".", "config", "specimen_roles.yml"))["specimen_roles"]
+  SPECIMEN_ROLES = SPECIMEN_ROLES_IDS.map { |id|
+    { id: id, description: "#{id.upcase} - #{SPECIMEN_ROLES_DESCRIPTION[id]}"}
+  }
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES_IDS, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES_IDS.map{|id| id.upcase}.join(', ')})"
+
 
   validates_presence_of :date_produced
   validates_presence_of :volume

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -31,7 +31,7 @@ class Batch < ActiveRecord::Base
   SPECIMEN_ROLES = SPECIMEN_ROLES_IDS.map { |id|
     { id: id, description: "#{id.upcase} - #{SPECIMEN_ROLES_DESCRIPTION[id]}"}
   }
-  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES_IDS, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES_IDS.map{|id| id.upcase}.join(', ')})"
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES_IDS, allow_blank: true, message: "is not within valid options"
 
 
   validates_presence_of :date_produced

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -20,14 +20,14 @@ class Batch < ActiveRecord::Base
                   :inactivation_method,
                   :volume
 
-  SPECIMEN_ROLES = YAML.load_file(File.join(File.dirname(__FILE__), ".", "config", "specimen_roles.yml"))["specimen_roles"]
   DATE_FORMAT = { pattern: I18n.t('date.input_format.pattern'), placeholder: I18n.t('date.input_format.placeholder') }
 
   INACTIVATION_METHOD_VALUES = Batch.entity_fields.detect { |f| f.name == 'inactivation_method' }.options
   validates_presence_of :inactivation_method
   validates_inclusion_of :inactivation_method, in: INACTIVATION_METHOD_VALUES, message: "is not within valid options (should be one of #{INACTIVATION_METHOD_VALUES.join(', ')})"
-  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES.map {|key, value| "#{key.upcase} - #{value}"}, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
 
+  SPECIMEN_ROLES = YAML.load_file(File.join(File.dirname(__FILE__), ".", "config", "specimen_roles.yml"))["specimen_roles"]
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES.map {|key, value| "#{key.upcase} - #{value}"}, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
 
   validates_presence_of :date_produced
   validates_presence_of :volume

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -36,7 +36,7 @@ class Sample < ActiveRecord::Base
   SPECIMEN_ROLES = SPECIMEN_ROLES_IDS.map { |id|
     { id: id, description: "#{id.upcase} - #{SPECIMEN_ROLES_DESCRIPTION[id]}"}
   }
-  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES_IDS, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES_IDS.map{|id| id.upcase}.join(', ')})"
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES_IDS, allow_blank: true, message: "is not within valid options"
 
   def self.find_by_entity_id(entity_id, opts)
     query = joins(:sample_identifiers).where(sample_identifiers: {entity_id: entity_id.to_s}, institution_id: opts.fetch(:institution_id))

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -20,10 +20,6 @@ class Sample < ActiveRecord::Base
   validate :validate_encounter
   validate :validate_patient
 
-  SPECIMEN_ROLES = YAML.load_file(File.join(File.dirname(__FILE__), ".", "config", "specimen_roles.yml"))["specimen_roles"]
-  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES.map {|key, value| "#{key.upcase} - #{value}"}, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES.transform_keys(&:upcase).keys.join(', ')})"
-
-
   def self.entity_scope
     "sample"
   end
@@ -34,6 +30,13 @@ class Sample < ActiveRecord::Base
                   :specimen_role,
                   :inactivation_method,
                   :volume
+
+  SPECIMEN_ROLES_IDS = Sample.entity_fields.detect { |f| f.name == 'specimen_role' }.options
+  SPECIMEN_ROLES_DESCRIPTION = YAML.load_file(File.join(File.dirname(__FILE__), ".", "config", "specimen_roles.yml"))["specimen_roles"]
+  SPECIMEN_ROLES = SPECIMEN_ROLES_IDS.map { |id|
+    { id: id, description: "#{id.upcase} - #{SPECIMEN_ROLES_DESCRIPTION[id]}"}
+  }
+  validates_inclusion_of :specimen_role, in: SPECIMEN_ROLES_IDS, allow_blank: true, message: "is not within valid options (should be one of #{SPECIMEN_ROLES_IDS.map{|id| id.upcase}.join(', ')})"
 
   def self.find_by_entity_id(entity_id, opts)
     query = joins(:sample_identifiers).where(sample_identifiers: {entity_id: entity_id.to_s}, institution_id: opts.fetch(:institution_id))

--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -26,9 +26,8 @@
         .col.pe-3
           = f.label :specimen_role
         .col
-          = f.text_field :specimen_role, :class => 'input-x-large'
-          - Sample::SPECIMEN_ROLES.each do |key, value|
-            = hidden_field_tag key, value, {disabled: true, class: 'specimen_role_options'}
+          = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
+            - select.items Batch::SPECIMEN_ROLES, :id, :description
 
       .row
         .col.pe-3

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -26,9 +26,8 @@
         .col.pe-4
           = f.label :specimen_role
         .col
-          = f.text_field :specimen_role, :class => 'input-x-large'
-          - Sample::SPECIMEN_ROLES.each do |key, value|
-            = hidden_field_tag key, value, {disabled: true, class: 'specimen_role_options'}
+          = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
+            - select.items Sample::SPECIMEN_ROLES, :id, :description
 
       .row
         .col.pe-4

--- a/deps/cdx_core/lib/config/fields.yml
+++ b/deps/cdx_core/lib/config/fields.yml
@@ -12,6 +12,19 @@ entities:
       collection_date:
         type: date
       specimen_role:
+        type: enum
+        options:
+          - b
+          - c
+          - e
+          - f
+          - g
+          - l
+          - o
+          - p
+          - q
+          - r
+          - v
       isolate_name:
         searchable: true
       date_produced:

--- a/deps/cdx_core/lib/config/fields.yml
+++ b/deps/cdx_core/lib/config/fields.yml
@@ -47,6 +47,19 @@ entities:
         searchable: true
       lab_technician:
       specimen_role:
+        type: enum
+        options:
+          - b
+          - c
+          - e
+          - f
+          - g
+          - l
+          - o
+          - p
+          - q
+          - r
+          - v
       isolate_name:
         searchable: true
       inactivation_method:

--- a/lib/tasks/batches.rake
+++ b/lib/tasks/batches.rake
@@ -2,13 +2,12 @@ namespace :batches do
   desc "normalize specimen_role values in Batches to be one of the options listed in fields.yml"
   task normalize_specimen_roles: :environment do
     Batch.find_each do |batch|
-      unless batch.specimen_role.nil?
-        batch.specimen_role = batch.specimen_role[0].downcase
-        if not Batch::SPECIMEN_ROLES_IDS.include? batch.specimen_role
-          batch.specimen_role = nil
-        end
-        batch.save
-      end
+      next if batch.specimen_role.nil?
+
+      specimen_role_id = batch.specimen_role[0].downcase
+      batch.specimen_role = (Batch::SPECIMEN_ROLES_IDS.include? specimen_role_id) ? specimen_role_id : nil
+
+      batch.save
     end
     puts "All Batches processed"
   end

--- a/lib/tasks/batches.rake
+++ b/lib/tasks/batches.rake
@@ -1,0 +1,15 @@
+namespace :batches do
+  desc "normalize specimen_role values in Batches to be one of the options listed in fields.yml"
+  task normalize_specimen_roles: :environment do
+    Batch.find_each do |batch|
+      unless batch.specimen_role.nil?
+        batch.specimen_role = batch.specimen_role[0].downcase
+        if not Batch::SPECIMEN_ROLES_IDS.include? batch.specimen_role
+          batch.specimen_role = nil
+        end
+        batch.save
+      end
+    end
+    puts "All Batches processed"
+  end
+end

--- a/lib/tasks/samples.rake
+++ b/lib/tasks/samples.rake
@@ -2,13 +2,12 @@ namespace :samples do
   desc "normalize specimen_role values in Samples to be one of the options listed in fields.yml"
   task normalize_specimen_roles: :environment do
     Sample.find_each do |sample|
-      unless sample.specimen_role.nil?
-        sample.specimen_role = sample.specimen_role[0].downcase
-        if not Sample::SPECIMEN_ROLES_IDS.include? sample.specimen_role
-          sample.specimen_role = nil
-        end
-        sample.save
-      end
+      next if sample.specimen_role.nil?
+
+      specimen_role_id = sample.specimen_role[0].downcase
+      sample.specimen_role = (Sample::SPECIMEN_ROLES_IDS.include? specimen_role_id) ? specimen_role_id : nil
+
+      sample.save
     end
     puts "All samples processed"
   end

--- a/lib/tasks/samples.rake
+++ b/lib/tasks/samples.rake
@@ -1,0 +1,15 @@
+namespace :samples do
+  desc "normalize specimen_role values in Samples to be one of the options listed in fields.yml"
+  task normalize_specimen_roles: :environment do
+    Sample.find_each do |sample|
+      unless sample.specimen_role.nil?
+        sample.specimen_role = sample.specimen_role[0].downcase
+        if not Sample::SPECIMEN_ROLES_IDS.include? sample.specimen_role
+          sample.specimen_role = nil
+        end
+        sample.save
+      end
+    end
+    puts "All samples processed"
+  end
+end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe BatchesController, type: :controller do
         isolate_name: 'ABC.42',
         date_produced: '08/08/2018',
         lab_technician: 'Tec.Foo',
-        specimen_role: 'Q - Control specimen',
+        specimen_role: 'q',
         inactivation_method: 'Formaldehyde',
         volume: '100',
         samples_quantity: '1'
@@ -117,7 +117,7 @@ RSpec.describe BatchesController, type: :controller do
       isolate_name: 'ABC.424',
       date_produced: Time.strptime('08/08/2021', I18n.t('date.input_format.pattern')),
       lab_technician: 'Tec.Foo',
-      specimen_role: 'Q - Control specimen',
+      specimen_role: 'q',
       inactivation_method: 'Formaldehyde',
       volume: 100
     )}
@@ -281,7 +281,7 @@ RSpec.describe BatchesController, type: :controller do
       isolate_name: 'ABC.42',
       date_produced: Time.strptime('01/01/2018', I18n.t('date.input_format.pattern')),
       lab_technician: 'Tec.Foo',
-      specimen_role: 'Q - Control specimen',
+      specimen_role: 'q',
       inactivation_method: 'Formaldehyde',
       volume: 100
     )}
@@ -325,7 +325,7 @@ RSpec.describe BatchesController, type: :controller do
       isolate_name: 'ABC.42',
       date_produced: Time.strptime('08/08/2021', I18n.t('date.input_format.pattern')),
       lab_technician: 'Tec.Foo',
-      specimen_role: 'Q - Control specimen',
+      specimen_role: 'q',
       inactivation_method: 'Formaldehyde',
       volume: 100
     )}
@@ -335,7 +335,7 @@ RSpec.describe BatchesController, type: :controller do
         isolate_name: 'ABC.42',
         date_produced: '09/09/2021',
         lab_technician: 'TecFoo',
-        specimen_role: 'P - Patient',
+        specimen_role: 'p',
         inactivation_method: 'Heat',
         volume: '200'
       }
@@ -345,7 +345,7 @@ RSpec.describe BatchesController, type: :controller do
       expect(batch.isolate_name).to eq('ABC.42')
       expect(batch.date_produced).to eq('09/09/2021')
       expect(batch.lab_technician).to eq('TecFoo')
-      expect(batch.specimen_role).to eq('P - Patient')
+      expect(batch.specimen_role).to eq('p')
       expect(batch.inactivation_method).to eq('Heat')
       expect(batch.volume).to eq('200')
     end
@@ -364,7 +364,7 @@ RSpec.describe BatchesController, type: :controller do
         isolate_name: 'ABC.42',
         date_produced: '09/09/2021',
         lab_technician: 'TecFoo',
-        specimen_role: 'P - Patient',
+        specimen_role: 'p',
         inactivation_method: 'Heat',
         volume: '200'
       }
@@ -374,7 +374,7 @@ RSpec.describe BatchesController, type: :controller do
       expect(batch.isolate_name).to eq('ABC.42')
       expect(batch.date_produced).to eq('09/09/2021')
       expect(batch.lab_technician).to eq('TecFoo')
-      expect(batch.specimen_role).to eq('P - Patient')
+      expect(batch.specimen_role).to eq('p')
       expect(batch.inactivation_method).to eq('Heat')
       expect(batch.volume).to eq('200')
     end
@@ -395,7 +395,7 @@ RSpec.describe BatchesController, type: :controller do
       isolate_name: 'ABC.42',
       date_produced: Time.strptime('08/08/2021', I18n.t('date.input_format.pattern')),
       lab_technician: 'Tec.Foo',
-      specimen_role: 'Q - Control specimen',
+      specimen_role: 'q',
       inactivation_method: 'Formaldehyde',
       volume: 100
     )}
@@ -440,7 +440,7 @@ RSpec.describe BatchesController, type: :controller do
       isolate_name: 'ABC.42',
       date_produced: Time.strptime('08/08/2021', I18n.t('date.input_format.pattern')),
       lab_technician: 'Tec.Foo',
-      specimen_role: 'Q - Control specimen',
+      specimen_role: 'q',
       inactivation_method: 'Formaldehyde',
       volume: 100
     )}
@@ -450,7 +450,7 @@ RSpec.describe BatchesController, type: :controller do
       isolate_name: 'DEF.24',
       date_produced: Time.strptime('09/09/2020', I18n.t('date.input_format.pattern')),
       lab_technician: 'Tec.Foo',
-      specimen_role: 'Q - Control specimen',
+      specimen_role: 'q',
       inactivation_method: 'Formaldehyde',
       volume: 200
     )}
@@ -461,7 +461,7 @@ RSpec.describe BatchesController, type: :controller do
       isolate_name: 'GHI.4224',
       date_produced: Time.strptime('07/07/2019', I18n.t('date.input_format.pattern')),
       lab_technician: 'Tec.Foo',
-      specimen_role: 'Q - Control specimen',
+      specimen_role: 'q',
       inactivation_method: 'Formaldehyde',
       volume: 300
     )}

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe SamplesController, type: :controller do
         date_produced: '09/09/2021',
         isolate_name: 'ABC.42',
         lab_technician: 'TecFoo',
-        specimen_role: 'Q - Control specimen',
+        specimen_role: 'q',
         inactivation_method: 'Formaldehyde',
         volume: '100'
       }
@@ -272,7 +272,7 @@ RSpec.describe SamplesController, type: :controller do
       expect(sample.date_produced).to eq('09/09/2021')
       expect(sample.isolate_name).to eq('ABC.42')
       expect(sample.lab_technician).to eq('TecFoo')
-      expect(sample.specimen_role).to eq('Q - Control specimen')
+      expect(sample.specimen_role).to eq('q')
       expect(sample.inactivation_method).to eq('Formaldehyde')
       expect(sample.volume).to eq('100')
     end
@@ -291,7 +291,7 @@ RSpec.describe SamplesController, type: :controller do
         date_produced: '09/09/2021',
         isolate_name: 'ABC.42',
         lab_technician: 'TecFoo',
-        specimen_role: 'Q - Control specimen',
+        specimen_role: 'q',
         inactivation_method: 'Formaldehyde',
         volume: '100'
       }
@@ -301,7 +301,7 @@ RSpec.describe SamplesController, type: :controller do
       expect(sample.date_produced).to eq('09/09/2021')
       expect(sample.isolate_name).to eq('ABC.42')
       expect(sample.lab_technician).to eq('TecFoo')
-      expect(sample.specimen_role).to eq('Q - Control specimen')
+      expect(sample.specimen_role).to eq('q')
       expect(sample.inactivation_method).to eq('Formaldehyde')
       expect(sample.volume).to eq('100')
     end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -135,7 +135,7 @@ Batch.blueprint do
   isolate_name { 'ABC.42.DE' }
   date_produced { Time.strptime('01/01/2018', I18n.t('date.input_format.pattern')) }
   lab_technician { 'Tec.Foo' }
-  specimen_role { 'Q - Control specimen' }
+  specimen_role { 'q' }
   inactivation_method { 'Formaldehyde' }
   volume { 100 }
 end


### PR DESCRIPTION
- Change current specimen role autocomplete component for the custom autocomplete component being used un Policies.
- Store only the code for the specimen_role field in the database.
- Build a script to substring the current saved data in specimen_role field and save only the first letter (which is the code) to make already saved batches and samples compliant with the new requirement.

New autocomplete component fixes: 
- clicking on the field will display the available options.


Current autocomplete component being used.

<img width="1378" alt="Screen Shot 2021-09-10 at 17 50 18" src="https://user-images.githubusercontent.com/23437283/132916143-60762b3b-0b12-4b63-abe1-e44e97f18b2e.png">


New autocomplete component added in these fixes:

<img width="1378" alt="Screen Shot 2021-09-10 at 17 52 03" src="https://user-images.githubusercontent.com/23437283/132916345-7314dd86-61a4-49cd-829a-4ed2eb0b84e2.png">


Related: #1313 



