### PR TITLE
Fix default value for specimen_roles on samples and batch form views

### DIFF
--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -26,7 +26,7 @@
         .col.pe-3
           = f.label :specimen_role
         .col
-          = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
+          = cdx_select form: f, name: :specimen_role, value: 'q', searchable: true, :class => 'input-x-large' do |select|
             - select.items Batch.specimen_roles, :id, :description
 
       .row

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -26,7 +26,7 @@
         .col.pe-4
           = f.label :specimen_role
         .col
-          = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
+          = cdx_select form: f, name: :specimen_role, searchable: true, value: 'q', :class => 'input-x-large' do |select|
             - select.items Sample.specimen_roles, :id, :description
 
       .row


### PR DESCRIPTION
-Related #1344 

## Before this fix

![image](https://user-images.githubusercontent.com/23437283/137730682-bfce3499-084c-4095-8a3f-99f2b1d7c449.png)

## After this fix
- Default value for Specimen Role select was fixed in order to allow Samples and Batches to be saved correctly without the need of changing the salector value to have a valid one.

![Screen Shot 2021-10-18 at 09 31 49](https://user-images.githubusercontent.com/23437283/137730927-a98f43e6-4b3a-4acb-8909-8aacdbda1bf6.png)


