### PR TITLE
Fix notes error when sample form has validation errors

### DIFF
--- a/app/views/samples/_form_notes.haml
+++ b/app/views/samples/_form_notes.haml
@@ -3,6 +3,8 @@
     = f.label :notes
   #notes.col
     = f.fields_for :notes, @sample_form.notes do |note|
+      #note-id-info
+        = hidden_field_tag "note_is_saved_" + note.index.to_s, note.object.id.present?, {disabled: true}
       .note
         .info
           = "by #{note.object.user.full_name} #{@localization_helper.format_datetime(note.object.updated_at)} "

--- a/app/views/samples/_form_notes_js.haml
+++ b/app/views/samples/_form_notes_js.haml
@@ -1,34 +1,51 @@
 :javascript
   (function() {
+    if(#{@sample_form.errors.any?}) {
+      $("input[id^=note_is_saved]").each(function( index, element ) {
+        var isNewNote = !($(element).val() === "true");
+        if(isNewNote) {
+          // get always first note since we remove it later on
+          var noteContainer = $(element).parent().siblings('.note').eq(0)
+          var description = $(noteContainer).children('.description').text().trim();
+          noteContainer.remove()
+          createNote(description);
+        }
+      });
+    }
+
     $(".clear-note > input[type='checkbox']").on('click', function(e) {
       $(this).closest('.note').hide();
     });
 
     $("#add-note").on('click', function (e) {
       e.preventDefault()
-
-      var newNote = {
-        info: "by #{current_user.full_name}",
-        description: $('#new-note').val().trim()
-      };
-
-      if (newNote.description === "") {
-        return;
-      }
-
-      // clear input
-      $('#new-note').val('');
-
-      var note = $('<div>', { class: 'note'})
-        .append($('<div>', { class: 'info' }).text(newNote.info))
-        .append($('<div>', { class: 'description' }).text(newNote.description))
-        .append($('<div>', { class: 'dashed-line' }));
-
-      var inputHidden = $('<input>', {
-        type: 'hidden',
-        name: 'sample[new_notes][]'
-      }).val(newNote.description);
-
-      $('#notes').append(note).append(inputHidden);
+      var description = $('#new-note').val().trim();
+      createNote(description);
     });
   })();
+
+  function createNote(description) {
+    var newNote = {
+      info: "by #{current_user.full_name}",
+      description: description
+    };
+
+    if (newNote.description === "") {
+      return;
+    }
+
+    // clear input
+    $('#new-note').val('');
+
+    var note = $('<div>', { class: 'note'})
+      .append($('<div>', { class: 'info' }).text(newNote.info))
+      .append($('<div>', { class: 'description' }).text(newNote.description))
+      .append($('<div>', { class: 'dashed-line' }));
+
+    var inputHidden = $('<input>', {
+      type: 'hidden',
+      name: 'sample[new_notes][]'
+    }).val(newNote.description);
+
+    $('#notes').append(note).append(inputHidden);
+  }


### PR DESCRIPTION
- Related: #1342 

## Before this fix

-Samples where throwing an error because rails treated new notes as saved notes when the form had error validations. This caused nil references to a "saved" object that did not exist.

## After this fix
- Recreate the notes as new ones, when the form has error validations, so nil references are not longer created.
