### PR TITLE
Rearrange column order in Batch list view

### DIFF
--- a/app/views/batches/index.haml
+++ b/app/views/batches/index.haml
@@ -23,22 +23,22 @@
           - t.thead do
             %tr
               %th
-              %th Isolate name
               %th Batch ID
-              %th Lab Technician
+              %th Isolate name
               %th Inactivation Method
               %th Production Date
+              %th Lab Technician
           - t.tbody do
             - @batches.each do |batch|
               %tr.laboratory-sample-row{data: {href: edit_batch_path(batch) }}
                 %td
                   =check_box_tag 'batch_ids[]', batch.id, false, { id: "batch_ids.#{batch.id}" }
                   %label.row{for: "batch_ids.#{batch.id}"}
-                %td= batch.isolate_name
                 %td= batch.batch_number
-                %td= batch.lab_technician
+                %td= batch.isolate_name
                 %td= batch.inactivation_method
                 %td= batch.date_produced_description
+                %td= batch.lab_technician
 
       .pagination
         = render 'shared/pagination'


### PR DESCRIPTION
-Related #1361 

-Reorder the columns for batch index.

## Before this change, this was the column order

<img width="1339" alt="Screen Shot 2021-11-09 at 17 23 30" src="https://user-images.githubusercontent.com/23437283/140998929-6c60fa4b-90f7-497d-81b8-e39879169c4c.png">

## After this change, the new column order is

<img width="1339" alt="Screen Shot 2021-11-09 at 17 24 48" src="https://user-images.githubusercontent.com/23437283/140999128-e139f4ef-d89c-4fa1-95b2-e1ca026c1864.png">


