### PR TITLE
Fix Sample QC missing icon

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -21,8 +21,7 @@ class SamplesController < ApplicationController
     sample = Sample.new({
       institution: @navigation_context.institution,
       site: @navigation_context.site,
-      sample_identifiers: [SampleIdentifier.new({uuid: session[:creating_sample_uuid]})],
-      specimen_role: "Q - Control specimen"
+      sample_identifiers: [SampleIdentifier.new({uuid: session[:creating_sample_uuid]})]
     })
 
     @sample_form = SampleForm.for(sample)

--- a/app/models/batch_form.rb
+++ b/app/models/batch_form.rb
@@ -108,8 +108,6 @@ class BatchForm
     return false
   end
 
-  SPECIMEN_ROLE_VALUES = Batch.specimen_roles
-
   validates_numericality_of :samples_quantity, greater_than: 0, message: "value must be greater than 0", if: :creating_batch?
 
   def creating_batch?

--- a/app/models/concerns/specimen_role.rb
+++ b/app/models/concerns/specimen_role.rb
@@ -9,19 +9,33 @@ module SpecimenRole
 
   end
 
+  def is_quality_control
+    specimen_role == 'q'
+  end
+
   class_methods do
+    def specimen_roles
+      @@specimen_roles ||= build_specimen_roles
+    end
+
+    private
+
+    def build_specimen_roles
+      specimen_role_ids.map do |id|
+        { id: id, description: "#{id.upcase} - #{specimen_role_descriptions[id]}" }
+      end
+    end
+
     def specimen_role_ids
-      @specimen_role_ids ||= entity_fields.detect { |f| f.name == 'specimen_role' }.options
+      @@specimen_role_ids ||= entity_fields.detect { |f| f.name == 'specimen_role' }.options
     end
 
     def specimen_role_descriptions
-      YAML.load_file(File.join("app", "models", "config", "specimen_roles.yml"))["specimen_roles"]
+      @@descriptions ||= load_specimen_role_descriptions
     end
 
-    def specimen_roles
-      @specimen_roles ||= specimen_role_ids.map do |id|
-        { id: id, description: "#{id.upcase} - #{specimen_role_descriptions[id]}" }
-      end
+    def load_specimen_role_descriptions
+      YAML.load_file(File.join("app", "models", "config", "specimen_roles.yml"))["specimen_roles"]
     end
   end
 end

--- a/app/models/concerns/specimen_role.rb
+++ b/app/models/concerns/specimen_role.rb
@@ -6,7 +6,6 @@ module SpecimenRole
                            in: -> (x) { specimen_role_ids },
                            allow_blank: true,
                            message: "is not within valid options"
-
   end
 
   def is_quality_control
@@ -15,7 +14,7 @@ module SpecimenRole
 
   class_methods do
     def specimen_roles
-      @@specimen_roles ||= build_specimen_roles
+      @specimen_roles ||= build_specimen_roles
     end
 
     private
@@ -27,11 +26,11 @@ module SpecimenRole
     end
 
     def specimen_role_ids
-      @@specimen_role_ids ||= entity_fields.detect { |f| f.name == 'specimen_role' }.options
+      @specimen_role_ids ||= entity_fields.detect { |f| f.name == 'specimen_role' }.options
     end
 
     def specimen_role_descriptions
-      @@descriptions ||= load_specimen_role_descriptions
+      @descriptions ||= load_specimen_role_descriptions
     end
 
     def load_specimen_role_descriptions

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -79,10 +79,6 @@ class Sample < ActiveRecord::Base
     entity_ids.compact.any?
   end
 
-  def is_quality_control
-    specimen_role == 'Q - Control specimen'
-  end
-
   def new_notes=(notes_list = [])
     notes_list.each do |note|
       notes.build(

--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -26,7 +26,7 @@
         .col.pe-3
           = f.label :specimen_role
         .col
-          = cdx_select form: f, name: :specimen_role, value: 'q', searchable: true, :class => 'input-x-large' do |select|
+          = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
             - select.items Batch.specimen_roles, :id, :description
 
       .row

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -26,7 +26,7 @@
         .col.pe-4
           = f.label :specimen_role
         .col
-          = cdx_select form: f, name: :specimen_role, searchable: true, value: 'q', :class => 'input-x-large' do |select|
+          = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
             - select.items Sample.specimen_roles, :id, :description
 
       .row


### PR DESCRIPTION
Related #1360 

When editing a Batch, the list of samples inside that batch is shown. The QC samples should have a distinctive icon but this icon was not showing. This PR fixes this bug.

Also in this PR:
- SpecimenRole Concern: Code refactor. Declare private some class methods that should not be part of the class API.

**Specimen Role** select component
Fix Samples and Batches form: specimen_role select component always had the QC option selected (when creating and when **updating** a `sample` or a `batch`)

Related to #1344 (issue) and #1345 (PR). `specimen_role` is optional in `Samples` and `Batches` models. But if a default `specimen_role` needs to be shown when creating a `sample` or a `batch` (ask: @diegoliberman @devduarte) then the fix should be applied to the model used in the create form (and not to the views/forms)
