### PR TITLE
Add index to html input name for new added assays

### DIFF
--- a/app/views/samples/_form_assays_js.haml
+++ b/app/views/samples/_form_assays_js.haml
@@ -13,7 +13,8 @@
         var assay_files = response.assay_files_data
         Object.keys(assay_files).forEach(function(filename) {
           var fileInput = $( ".info input[value='" + filename + "']" )
-          fileInput.replaceWith($('<input>', {type: 'hidden', name: `sample[assay_attachments_attributes][][assay_file_id]`, value: assay_files[filename]}))
+          var mockIndex = fileInput.closest('.card-container').find('input[name="mockIndex"]').val()
+          fileInput.replaceWith($('<input>', {type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][assay_file_id]`, value: assay_files[filename]}))
         })
         $('#btn-save').prop('disabled', false);
       },
@@ -105,10 +106,12 @@
   }
 
   function createCardWithoutFile() {
+    var mockIndex = Date.now();
     $('.assay > .upload-new-file').append(
       $('<div>', { class: 'file-uploaded' })
         .append($('<div>', { class: 'card-container new-file' })
-          .append(createCardInfoColumnWithoutFile())
+          .append($('<input>', { type: 'hidden', name: 'mockIndex', value: mockIndex } ))
+          .append(createCardInfoColumnWithoutFile(mockIndex))
           .append(createCardPictureColumnWithoutFile())
           .append(createCardRemove())
         )
@@ -116,10 +119,12 @@
   }
 
   function createCard(file, url) {
+    var mockIndex = Date.now();
     $('.assay > .upload-new-file').append(
         $('<div>', { class: 'file-uploaded' })
           .append($('<div>', { class: 'card-container new-file' })
-            .append(createCardInfoColumn(file))
+            .append($('<input>', { type: 'hidden', name: 'mockIndex', value: mockIndex } ))
+            .append(createCardInfoColumn(file, mockIndex))
             .append(createCardPictureColumn(file, url))
             .append(createCardRemove(file))
           )
@@ -132,47 +137,48 @@
     updateCardRemove(card, file)
   }
 
-  function createCardInfoColumnWithoutFile() {
+  function createCardInfoColumnWithoutFile(mockIndex) {
     return $('<div>', { class: 'info' })
       .append($('<div>', { class: 'row' })
         .append($('<div>', { class: 'col pe-1' })
           .append($('<label>', { for: 'new_sample_assay_attachments_attributes', text: 'Loinc' })))
         .append($('<div>', { class: 'col pe-8' })
-          .append(buildLoincCodeSelect()))
+          .append(buildLoincCodeSelect({mockIndex: mockIndex})))
       )
       .append($('<div>', { class: 'row' })
         .append($('<div>', { class: 'col pe-1' })
           .append($('<label>', { for: 'new_sample_assay_attachments_attributes', text: 'Result' })))
         .append($('<div>', { class: 'col pe-8' })
-          .append($('<input>', { type: 'text', class: 'result_input', name: `sample[assay_attachments_attributes][][result]` } )))
+          .append($('<input>', { type: 'text', class: 'result_input', name: `sample[assay_attachments_attributes][${mockIndex}][result]` } )))
       )
   }
 
 
-  function createCardInfoColumn(file) {
+  function createCardInfoColumn(file, mockIndex) {
     return $('<div>', { class: 'info' })
       .append($('<div>', { class: 'row' })
         .append($('<div>', { class: 'col pe-1' })
           .append($('<label>', { for: 'new_sample_assay_attachments_attributes', text: 'Loinc' })))
         .append($('<div>', { class: 'col pe-8' })
-          .append(buildLoincCodeSelect()))
+          .append(buildLoincCodeSelect({mockIndex: mockIndex})))
       )
       .append($('<div>', { class: 'row' })
         .append($('<div>', { class: 'col pe-1' })
           .append($('<label>', { for: 'new_sample_assay_attachments_attributes', text: 'Result' })))
         .append($('<div>', { class: 'col pe-8' })
-          .append($('<input>', { type: 'text', class: 'result_input', name: `sample[assay_attachments_attributes][][result]` } )))
+          .append($('<input>', { type: 'text', class: 'result_input', name: `sample[assay_attachments_attributes][${mockIndex}][result]` } )))
       )
       .append($('<div>')
-        .append($('<input>', { type: 'hidden', name: 'sample[assay_attachments_attributes][][filename]', value: file.name.replaceAll(' ', '_') } )))
+        .append($('<input>', { type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][filename]`, value: file.name.replaceAll(' ', '_') } )))
   }
 
   function updateCardInfoColumn(card, file) {
+    var mockIndex = $(card).find('input[name="mockIndex"]').val();
     var cardInfo = $(card).find('.info')
-    cardInfo.find('div > input[name="sample[assay_attachments_attributes][][filename]"]').remove()
+    cardInfo.find(`div > input[name="sample[assay_attachments_attributes][${mockIndex}][filename]"]`).remove()
     cardInfo
       .append($('<div>')
-        .append($('<input>', { type: 'hidden', name: 'sample[assay_attachments_attributes][][filename]', value: file.name.replaceAll(' ', '_') } )))
+        .append($('<input>', { type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][filename]`, value: file.name.replaceAll(' ', '_') } )))
 
   }
 
@@ -247,8 +253,9 @@
   }
 
   function buildLoincCodeSelect(config) {
+    var mockIndex = config.mockIndex || ''
     var loincInput = (config && config.input) ? config.input : $('<input>', {type: 'text', class: 'loinc_input'});
-    var loincInputHidden = (config && config.hidden) ? config.hidden : $('<input>', {type: 'hidden', name: `sample[assay_attachments_attributes][][loinc_code_id]`});
+    var loincInputHidden = (config && config.hidden) ? config.hidden : $('<input>', {type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][loinc_code_id]`});
 
     loincInput.autocomplete({
       lookup: function (query, done) {


### PR DESCRIPTION
-Related #1371 

-Add index to name attribute in html inputs for Assay Attachments in order to allow rails to save a well formed Form. The absence of these indexes were causing Rails to not save the form correctly and throw errors.