### PR TITLE
Fix AssayFile filename and filesize bugs

### DIFF
--- a/app/views/samples/_form_assays.haml
+++ b/app/views/samples/_form_assays.haml
@@ -45,7 +45,7 @@
                 .file
                   .picture-container.picture-required
                     .icon-alert.icon-red
-                    = "You must define a result or an attachment"
+                    = "The file can’t exceed 10 MB"
               - else
                 - if ay.object.assay_file.nil? or not ay.object.assay_file.is_image?
                   .file

--- a/app/views/samples/_form_assays_js.haml
+++ b/app/views/samples/_form_assays_js.haml
@@ -107,7 +107,7 @@
   }, false);
 
   function updateAddAssaysControls() {
-    var assays = $('.assay-file');
+    var assays = $('.card-container');
     if (assays.length > 0) {
       $('.assay > .upload-new-file > .tooltip').addClass('nodisplay');
     } else {

--- a/app/views/samples/_form_assays_js.haml
+++ b/app/views/samples/_form_assays_js.haml
@@ -9,7 +9,7 @@
       uploadMultiple: true,
       renameFile: function (file) {
         var completeFileName = file.name;
-        var sanitizedName = completeFileName.replace(/[^a-z^A-Z^0-9\^_.-]/g, '_');
+        var sanitizedName = completeFileName.replace(/[^\p{Letter}\p{Number}_.-]/gu, '_');
         var fileName = sanitizedName.split('.')[0];
         return sanitizedName.replace(fileName, fileName + Date.now());
       },
@@ -18,13 +18,11 @@
       },
       successmultiple: function(files, response) {
         var assay_files = response.assay_files_data || {}
-        if(assay_files){
-          Object.keys(assay_files).forEach(function(filename) {
-            var fileInput = $( ".info input[value='" + filename + "']" )
-            var mockIndex = fileInput.closest('.card-container').find('input[name="mockIndex"]').val() || ''
-            fileInput.replaceWith($('<input>', {type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][assay_file_id]`, value: assay_files[filename]}))
-          })
-        }
+        Object.keys(assay_files).forEach(function(filename) {
+          var fileInput = $( ".info input[value='" + filename + "']" )
+          var mockIndex = fileInput.closest('.card-container').find('input[name="mockIndex"]').val() || ''
+          fileInput.replaceWith($('<input>', {type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][assay_file_id]`, value: assay_files[filename]}))
+        })
         $('#btn-save').prop('disabled', false);
       },
       thumbnail: function(file, url) {

--- a/app/views/samples/_form_assays_js.haml
+++ b/app/views/samples/_form_assays_js.haml
@@ -55,6 +55,7 @@
     $('#add-assays').on('click', function(e) {
       e.preventDefault();
       createCardWithoutFile()
+      updateAddAssaysControls()
     });
 
     // Change the class on the target zone when dragging a file over it

--- a/app/views/samples/_form_assays_js.haml
+++ b/app/views/samples/_form_assays_js.haml
@@ -3,6 +3,7 @@
     dropzoneOptions = {
       paramName: "assay_files",
       autoProcessQueue: true,
+      maxThumbnailFilesize: 20,
       parallelUploads: 10,
       url: '/assay_files/create',
       uploadMultiple: true,
@@ -10,18 +11,20 @@
         var completeFileName = file.name;
         var sanitizedName = completeFileName.replace(/[^a-z^A-Z^0-9\^_.-]/g, '_');
         var fileName = sanitizedName.split('.')[0];
-        return sanitizedName.replace(fileName, fileName + new Date().getTime());
+        return sanitizedName.replace(fileName, fileName + Date.now());
       },
       sendingmultiple: function () {
         $('#btn-save').prop('disabled', true);
       },
       successmultiple: function(files, response) {
-        var assay_files = response.assay_files_data
-        Object.keys(assay_files).forEach(function(filename) {
-          var fileInput = $( ".info input[value='" + filename + "']" )
-          var mockIndex = fileInput.closest('.card-container').find('input[name="mockIndex"]').val()
-          fileInput.replaceWith($('<input>', {type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][assay_file_id]`, value: assay_files[filename]}))
-        })
+        var assay_files = response.assay_files_data || {}
+        if(assay_files){
+          Object.keys(assay_files).forEach(function(filename) {
+            var fileInput = $( ".info input[value='" + filename + "']" )
+            var mockIndex = fileInput.closest('.card-container').find('input[name="mockIndex"]').val() || ''
+            fileInput.replaceWith($('<input>', {type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][assay_file_id]`, value: assay_files[filename]}))
+          })
+        }
         $('#btn-save').prop('disabled', false);
       },
       thumbnail: function(file, url) {

--- a/app/views/samples/_form_assays_js.haml
+++ b/app/views/samples/_form_assays_js.haml
@@ -6,6 +6,12 @@
       parallelUploads: 10,
       url: '/assay_files/create',
       uploadMultiple: true,
+      renameFile: function (file) {
+        var completeFileName = file.name;
+        var sanitizedName = completeFileName.replace(/[^a-z^A-Z^0-9\^_.-]/g, '_');
+        var fileName = sanitizedName.split('.')[0];
+        return sanitizedName.replace(fileName, fileName + new Date().getTime());
+      },
       sendingmultiple: function () {
         $('#btn-save').prop('disabled', true);
       },
@@ -170,7 +176,7 @@
           .append($('<input>', { type: 'text', class: 'result_input', name: `sample[assay_attachments_attributes][${mockIndex}][result]` } )))
       )
       .append($('<div>')
-        .append($('<input>', { type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][filename]`, value: file.name.replaceAll(' ', '_') } )))
+        .append($('<input>', { type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][filename]`, value: file.upload.filename } )))
   }
 
   function updateCardInfoColumn(card, file) {
@@ -179,7 +185,7 @@
     cardInfo.find(`div > input[name="sample[assay_attachments_attributes][${mockIndex}][filename]"]`).remove()
     cardInfo
       .append($('<div>')
-        .append($('<input>', { type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][filename]`, value: file.name.replaceAll(' ', '_') } )))
+        .append($('<input>', { type: 'hidden', name: `sample[assay_attachments_attributes][${mockIndex}][filename]`, value: file.upload.filename } )))
 
   }
 
@@ -189,8 +195,8 @@
             .append(
               $('<div>', { class: 'picture-container assay-file'})
               .append(fileThumbnail(file, url))
-              .append($('<div>', { class: 'picture-title', title: file.name })
-              .append($('<div>').text(file.name)))
+              .append($('<div>', { class: 'picture-title', title: file.upload.filename })
+              .append($('<div>').text(file.upload.filename)))
             )
   }
 
@@ -201,8 +207,8 @@
       .append(
         $('<div>', { class: 'picture-container assay-file'})
           .append(fileThumbnail(file, url))
-          .append($('<div>', { class: 'picture-title', title: file.name })
-          .append($('<div>').text(file.name)))
+          .append($('<div>', { class: 'picture-title', title: file.upload.filename })
+          .append($('<div>').text(file.upload.filename)))
       )
   }
 


### PR DESCRIPTION
-Related #1372 

-Fix filename problems when they include special characters.
-Change thumbnail size to allow dropzone to generate thumbnails largar than 10MB so it generates the assay card. We are not allowing files larger than 10mb to be saved, but we generate the card to force the validation to fail when it gets saved and show the correct error message to the user.
-Change error message when the AssayAttachment validation fails.

## Before this fix
<img width="1680" alt="Screen Shot 2021-11-26 at 13 57 38" src="https://user-images.githubusercontent.com/23437283/143612551-2dcae946-039a-4d8b-8d8f-52c29de62fb8.png">

## After this fix
<img width="1680" alt="Screen Shot 2021-11-26 at 13 59 39" src="https://user-images.githubusercontent.com/23437283/143612764-05a6c557-1137-431b-b1d6-d9d45432646d.png">


