### PR TITLE
parse string saved dates into time for batches and samples

### DIFF
--- a/db/migrate/20211201181600_migrate_specimen_role.rb
+++ b/db/migrate/20211201181600_migrate_specimen_role.rb
@@ -1,7 +1,11 @@
 class MigrateSpecimenRole < ActiveRecord::Migration
   def up
     Sample.find_each do |sample|
-      next if sample.specimen_role.nil?
+      sample.date_produced = if sample.date_produced.is_a?(String)
+                              Time.strptime(sample.date_produced, Sample.date_format[:pattern]) rescue sample.date_produced
+                            else
+                              sample.date_produced
+                            end
       sample.save
     end
   end

--- a/db/migrate/20211201224317_migrate_date_produced_in_batches.rb
+++ b/db/migrate/20211201224317_migrate_date_produced_in_batches.rb
@@ -3,7 +3,7 @@ class MigrateDateProducedInBatches < ActiveRecord::Migration
     Batch.find_each do |batch|
       next if batch.date_produced.nil?
       batch.date_produced = if batch.date_produced.is_a?(String)
-                              Time.strptime(value, Batch.date_format[:pattern]) rescue batch.date_produced
+                              Time.strptime(batch.date_produced, Batch.date_format[:pattern]) rescue batch.date_produced
                             else
                               batch.date_produced
                             end


### PR DESCRIPTION
-Fixes: #1382 

Samples and Batches prior to #1363 and #1372 were not being considered by the new filters (specimen_role for Samples and date_produced for Batches).
-Parse String saved dates into Time for Samples.
-Fix a bug in the code that was preventing batches from being correctly saved. Replace `Time.strptime(value, Batch.date_format[:pattern]) rescue batch.date_produced` for `Time.strptime(batch.date_produced, Batch.date_format[:pattern]) rescue batch.date_produced`