### PR TITLE
Redirect institution creation after email confirmation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,12 @@ class ApplicationController < ActionController::Base
 
     if current_user && current_user.institutions.empty? && current_user.policies.empty? && current_user.roles.empty?
       if has_access?(Institution, CREATE_INSTITUTION)
-        redirect_to new_institution_path
+        if PendingInstitutionInvite.user_has_pending_invites?(current_user)
+          redirect_to new_from_invite_data_institutions_path
+          return
+        else
+          redirect_to new_institution_path
+        end
       else
         redirect_to pending_approval_institutions_path
       end

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -32,7 +32,7 @@ class InstitutionsController < ApplicationController
   end
 
   def create
-    unless PendingInstitutionInvite.where(invited_user_id: current_user,  status: 'pending').count > 0
+    if PendingInstitutionInvite.where(invited_user_id: current_user,  status: 'accepted').count > 0
       no_data_allowed
       return
     end

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -32,6 +32,10 @@ class InstitutionsController < ApplicationController
   end
 
   def create
+    unless PendingInstitutionInvite.where(invited_user_id: current_user,  status: 'pending').count > 0
+      no_data_allowed
+      return
+    end
     @institution = Institution.new(institution_params)
     @institution.user_id = current_user.id
     return unless authorize_resource(Institution, CREATE_INSTITUTION)

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -2,6 +2,7 @@ class InstitutionsController < ApplicationController
   before_filter :load_institutions
   skip_before_filter :check_no_institution!, only: [:new, :create, :pending_approval, :new_from_invite_data]
   skip_before_action :ensure_context, except: [:no_data_allowed]
+  after_filter :accept_pending_invite, only: [:create]
 
   def index
     @can_create = has_access?(Institution, CREATE_INSTITUTION)
@@ -104,6 +105,14 @@ class InstitutionsController < ApplicationController
     @institution.kind = pending_invite.institution_kind
     @institution.name = pending_invite.institution_name
     render action: 'new'
+  end
+
+  def accept_pending_invite
+    pending_invite = PendingInstitutionInvite.find_by(invited_user_id: current_user)
+    unless pending_invite.nil?
+      pending_invite.status = 'accepted'
+      pending_invite.save!
+    end
   end
 
   private

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -100,11 +100,15 @@ class InstitutionsController < ApplicationController
   end
 
   def new_from_invite_data
-    pending_invite = PendingInstitutionInvite.find_by(invited_user_id: current_user)
-    @institution = current_user.institutions.new
-    @institution.kind = pending_invite.institution_kind
-    @institution.name = pending_invite.institution_name
-    render action: 'new'
+    pending_invite = PendingInstitutionInvite.where(invited_user_id: current_user,  status: 'pending').last
+    unless pending_invite.nil?
+      @institution = current_user.institutions.new
+      @institution.kind = pending_invite.institution_kind
+      @institution.name = pending_invite.institution_name
+      render action: 'new'
+    else
+      no_data_allowed
+    end
   end
 
   def accept_pending_invite

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -1,6 +1,6 @@
 class InstitutionsController < ApplicationController
   before_filter :load_institutions
-  skip_before_filter :check_no_institution!, only: [:new, :create, :pending_approval]
+  skip_before_filter :check_no_institution!, only: [:new, :create, :pending_approval, :new_from_invite_data]
   skip_before_action :ensure_context, except: [:no_data_allowed]
 
   def index
@@ -96,6 +96,14 @@ class InstitutionsController < ApplicationController
     home = after_sign_in_path_for(current_user)
 
     redirect_to home if home != no_data_allowed_institutions_path
+  end
+
+  def new_from_invite_data
+    pending_invite = PendingInstitutionInvite.find_by(invited_user_id: current_user)
+    @institution = current_user.institutions.new
+    @institution.kind = pending_invite.institution_kind
+    @institution.name = pending_invite.institution_name
+    render action: 'new'
   end
 
   private

--- a/app/models/pending_institution_invite.rb
+++ b/app/models/pending_institution_invite.rb
@@ -4,13 +4,16 @@ class PendingInstitutionInvite < ActiveRecord::Base
   belongs_to :invited_by_user, :class_name => 'User'
 
   institution_kinds = %w(institution manufacturer health_organization)
+  statuses = %w(pending accepted)
 
   validates_presence_of :invited_user
   validates_presence_of :invited_by_user
   validates_presence_of :institution_name
   validates_presence_of :institution_kind
+  validates_presence_of :status
 
   validates_inclusion_of :institution_kind, in: institution_kinds
+  validates_inclusion_of :status, in: statuses
 
   def self.user_has_pending_invites?(user)
     where(invited_user_id: user).count > 0

--- a/app/models/pending_institution_invite.rb
+++ b/app/models/pending_institution_invite.rb
@@ -10,6 +10,5 @@ class PendingInstitutionInvite < ActiveRecord::Base
   validates_presence_of :institution_name
   validates_presence_of :institution_kind
 
-  validates_presence_of :institution_kind
   validates_inclusion_of :institution_kind, in: institution_kinds
 end

--- a/app/models/pending_institution_invite.rb
+++ b/app/models/pending_institution_invite.rb
@@ -16,7 +16,7 @@ class PendingInstitutionInvite < ActiveRecord::Base
   validates_inclusion_of :status, in: statuses
 
   def self.user_has_pending_invites?(user)
-    where(invited_user_id: user).count > 0
+    where(invited_user_id: user,  status: 'pending').count > 0
   end
 
 end

--- a/app/models/pending_institution_invite.rb
+++ b/app/models/pending_institution_invite.rb
@@ -11,4 +11,9 @@ class PendingInstitutionInvite < ActiveRecord::Base
   validates_presence_of :institution_kind
 
   validates_inclusion_of :institution_kind, in: institution_kinds
+
+  def self.user_has_pending_invites?(user)
+    where(invited_user_id: user).count > 0
+  end
+
 end

--- a/app/views/institutions/_form.haml
+++ b/app/views/institutions/_form.haml
@@ -1,7 +1,7 @@
 = form_for(@institution) do |f|
   = validation_errors @institution
   - if @institution.new_record?
-    .row.centered.institution-container
+    .row.centered.institution-container{:class => ("active" unless @institution.kind.blank?)}
       .col
         = f.radio_button :kind, "health_organization", checked: @institution.kind == "health_organization", class: 'institution'
         .institution-option

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     collection do
       get :pending_approval
       get :no_data_allowed
+      get :new_from_invite_data
     end
   end
 

--- a/db/migrate/20211216160348_create_pending_institution_invites.rb
+++ b/db/migrate/20211216160348_create_pending_institution_invites.rb
@@ -5,6 +5,7 @@ class CreatePendingInstitutionInvites < ActiveRecord::Migration
       t.references :invited_by_user, index: true
       t.string :institution_name
       t.string :institution_kind, default: 'institution'
+      t.string :status, default: 'pending'
       t.timestamps null: false
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -449,6 +449,7 @@ ActiveRecord::Schema.define(version: 20211217160437) do
     t.integer  "invited_by_user_id", limit: 4
     t.string   "institution_name",   limit: 255
     t.string   "institution_kind",   limit: 255, default: "institution"
+    t.string   "status",             limit: 255, default: "pending"
     t.datetime "created_at",                                             null: false
     t.datetime "updated_at",                                             null: false
   end


### PR DESCRIPTION
Fixes: #1359 

-Deleted repeated validation 
-Created new endpoint to redirect user to new institution form with saved data from pending invites

## New institution screen with already filled data
![Screen Shot 2022-01-04 at 22 02 45](https://user-images.githubusercontent.com/23437283/148144386-31c913fd-5009-4e2b-985d-6ce18513c8ea.png)
 