### PR TITLE
Change invitation flow for persisted users

### DIFF
--- a/app/assets/javascripts/components/admin_invite_form.js.jsx
+++ b/app/assets/javascripts/components/admin_invite_form.js.jsx
@@ -52,10 +52,9 @@ var AdminInviteForm = React.createClass({
   },
 
   setEmail: function(newEmail) {
-    debugger;
-
     if(this.isBlank(newEmail)){
       this.setState({
+        email: newEmail,
         hasEmailError: true,
         sendButtonDisabled: true
       });
@@ -67,11 +66,6 @@ var AdminInviteForm = React.createClass({
       });
 
     }
-
-
-    this.setState({
-      email: newEmail
-    });
   },
 
   toggleMessage: function() {

--- a/app/assets/javascripts/components/admin_invite_form.js.jsx
+++ b/app/assets/javascripts/components/admin_invite_form.js.jsx
@@ -5,7 +5,9 @@ var AdminInviteForm = React.createClass({
       lastName: '',
       email: '',
       includeMessage: false,
-      message: ''
+      message: '',
+      hasEmailError: false,
+      sendButtonDisabled: true
     };
   },
 
@@ -50,6 +52,23 @@ var AdminInviteForm = React.createClass({
   },
 
   setEmail: function(newEmail) {
+    debugger;
+
+    if(this.isBlank(newEmail)){
+      this.setState({
+        hasEmailError: true,
+        sendButtonDisabled: true
+      });
+    } else {
+      this.setState({
+        email: newEmail,
+        hasEmailError: false,
+        sendButtonDisabled: false
+      });
+
+    }
+
+
     this.setState({
       email: newEmail
     });
@@ -60,6 +79,10 @@ var AdminInviteForm = React.createClass({
     this.setState({
       includeMessage: !oldValue
     });
+  },
+
+  isBlank: function(str) {
+    return (!str || /^\s*$/.test(str));
   },
 
   writeMessage: function(event) {
@@ -93,6 +116,13 @@ var AdminInviteForm = React.createClass({
           <div className="col pe-4"><label>Email</label></div>
           <div className="col"><input type="text" onChange={(e)=> {this.setEmail(e.currentTarget.value)}} /></div>
         </div>
+        { this.state.hasEmailError ?
+          <div className="col">
+            <span style={{ color: "red" }}>Required field</span>
+          </div>
+          : null
+        }
+
         <div className="row">
           <div className="col pe-5">
             <input id="message-check" type="checkbox" checked={this.state.includeMessage} onChange={this.toggleMessage} />
@@ -112,7 +142,7 @@ var AdminInviteForm = React.createClass({
               <button className="btn btn-link" onClick={this.cancel}>Cancel</button>
             </div>
             <div>
-              <button className="btn btn-primary" onClick={this.sendInvitation}>Send</button>
+              <button className="btn btn-primary" onClick={this.sendInvitation} disabled={this.state.sendButtonDisabled}>Send</button>
             </div>
           </div>
         </div>

--- a/app/assets/javascripts/components/institution_invite_form.js.jsx
+++ b/app/assets/javascripts/components/institution_invite_form.js.jsx
@@ -1,15 +1,33 @@
 var InstitutionInviteForm = React.createClass({
   getInitialState: function() {
     return {
-      type: null,
-      name: ''
+      type: 'institution',
+      name: '',
+      hasTypeError: false,
+      hasNameError: false,
+      nextButtonDisabled: true
     };
   },
 
   changeType: function(newValue) {
-    this.setState({
-      type: newValue
-    });
+    if(this.isBlank(newValue)){
+      this.setState({
+        hasTypeError: true,
+        nextButtonDisabled: true
+      });
+    } else {
+      this.setState({
+        name: newValue,
+        hasTypeError: false
+      });
+
+      if(!this.isBlank(this.state.name)){
+        this.setState({
+          nextButtonDisabled: false
+        });
+      }
+
+    }
   },
 
   back: function() {
@@ -17,17 +35,38 @@ var InstitutionInviteForm = React.createClass({
   },
 
   next: function() {
-    this.props.adminInviteStep(this.state)
+    if(!this.state.hasTypeError && !this.state.hasNameError){
+      this.props.adminInviteStep(this.state)
+    }
   },
 
   cancel: function() {
     this.props.onFinished()
   },
 
+  isBlank: function(str) {
+    return (!str || /^\s*$/.test(str));
+  },
+
   setName: function(newName) {
-    this.setState({
-      name: newName
-    });
+    if(this.isBlank(newName)){
+      this.setState({
+        hasNameError: true,
+        nextButtonDisabled: true
+      });
+    } else {
+      this.setState({
+        name: newName,
+        hasNameError: false
+      });
+
+      if(!this.isBlank(this.state.type)){
+        this.setState({
+          nextButtonDisabled: false
+        });
+      }
+
+    }
   },
 
   componentDidMount: function() {
@@ -41,10 +80,22 @@ var InstitutionInviteForm = React.createClass({
           <div className="col pe-3"><label>Type</label></div>
           <div className="col"><CdxSelect name="type" items={this.props.types} value={this.state.type} onChange={this.changeType} /></div>
         </div>
+        { this.state.hasTypeError ?
+          <div className="col">
+            <span style={{ color: "red" }}>Required field</span>
+          </div>
+          : null
+        }
         <div className="row">
           <div className="col pe-3"><label>Name</label></div>
-          <div className="col"><input type="text" onChange={(e)=> {this.setName(e.currentTarget.value)}} /></div>
+          <div className="col"><input className="input-large" type="text" onChange={(e)=> {this.setName(e.currentTarget.value)}} /></div>
         </div>
+        { this.state.hasNameError ?
+          <div className="col">
+            <span style={{ color: "red" }}>Required field</span>
+          </div>
+          : null
+        }
         <div className="modal-footer">
           <div className="footer-buttons-aligning">
             <div>
@@ -52,7 +103,7 @@ var InstitutionInviteForm = React.createClass({
             </div>
             <div>
               <button className="btn btn-link" onClick={this.back}>Back</button>
-              <button className="btn btn-primary" onClick={this.next}>Next</button>
+              <button className="btn btn-primary" onClick={this.next} disabled={this.state.nextButtonDisabled}>Next</button>
             </div>
           </div>
         </div>

--- a/app/assets/javascripts/components/institution_invite_form.js.jsx
+++ b/app/assets/javascripts/components/institution_invite_form.js.jsx
@@ -10,24 +10,15 @@ var InstitutionInviteForm = React.createClass({
   },
 
   changeType: function(newValue) {
-    if(this.isBlank(newValue)){
-      this.setState({
-        hasTypeError: true,
-        nextButtonDisabled: true
-      });
-    } else {
-      this.setState({
-        name: newValue,
-        hasTypeError: false
-      });
+    var oldValue = this.state.type
+    var isBlankNewValue = this.isBlank(newValue)
+    var isBlankName = this.isBlank(this.state.name)
 
-      if(!this.isBlank(this.state.name)){
-        this.setState({
-          nextButtonDisabled: false
-        });
-      }
-
-    }
+    this.setState({
+      type: isBlankNewValue ? oldValue : newValue,
+      hasTypeError: isBlankNewValue,
+      nextButtonDisabled: isBlankNewValue || isBlankName
+    })
   },
 
   back: function() {
@@ -49,24 +40,15 @@ var InstitutionInviteForm = React.createClass({
   },
 
   setName: function(newName) {
-    if(this.isBlank(newName)){
-      this.setState({
-        hasNameError: true,
-        nextButtonDisabled: true
-      });
-    } else {
-      this.setState({
-        name: newName,
-        hasNameError: false
-      });
+    var oldValue = this.state.name
+    var isBlankNewName = this.isBlank(newName)
+    var isBlankType = this.isBlank(this.state.type)
 
-      if(!this.isBlank(this.state.type)){
-        this.setState({
-          nextButtonDisabled: false
-        });
-      }
-
-    }
+    this.setState({
+      name: isBlankNewName ? oldValue : newName,
+      hasNameError: isBlankNewName,
+      nextButtonDisabled: isBlankNewName || isBlankType
+    })
   },
 
   componentDidMount: function() {

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -32,9 +32,10 @@ class InstitutionsController < ApplicationController
 
   def create
     inst_params = institution_params
+    pending_invite_id = get_pending_invite_id_from_params(inst_params)
 
-    if inst_params.has_key?(:pending_institution_invite_id)
-      @pending_invite = PendingInstitutionInvite.find_by(id: inst_params["pending_institution_invite_id"])
+    if pending_invite_id
+      @pending_invite = PendingInstitutionInvite.find_by(id: pending_invite_id )
 
       unless @pending_invite and @pending_invite.status == 'pending'
         no_data_allowed
@@ -113,7 +114,7 @@ class InstitutionsController < ApplicationController
   end
 
   def new_from_invite_data
-    pending_institution_invite_id = params["pending_institution_invite_id"]
+    pending_institution_invite_id = get_pending_invite_id_from_params(params)
     pending_invite = PendingInstitutionInvite.find_by(invited_user_email: current_user.email,  id: pending_institution_invite_id, status: 'pending')
     unless pending_invite.nil?
       @institution = current_user.institutions.new
@@ -142,5 +143,9 @@ class InstitutionsController < ApplicationController
 
   def institution_params
     params.require(:institution).permit(:name, :kind, :pending_institution_invite_id)
+  end
+
+  def get_pending_invite_id_from_params(inst_params)
+    (inst_params.has_key?(:pending_institution_invite_id)) ? inst_params["pending_institution_invite_id"] : nil
   end
 end

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -32,11 +32,14 @@ class InstitutionsController < ApplicationController
 
   def create
     inst_params = institution_params
-    @pending_invite = PendingInstitutionInvite.find(inst_params["pending_institution_invite_id"])
 
-    unless @pending_invite and @pending_invite.status == 'pending'
-      no_data_allowed
-      return
+    if inst_params.has_key?(:pending_institution_invite_id)
+      @pending_invite = PendingInstitutionInvite.find_by(id: inst_params["pending_institution_invite_id"])
+
+      unless @pending_invite and @pending_invite.status == 'pending'
+        no_data_allowed
+        return
+      end
     end
 
     @institution = Institution.new(inst_params)

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -2,7 +2,6 @@ class InstitutionsController < ApplicationController
   before_filter :load_institutions
   skip_before_filter :check_no_institution!, only: [:new, :create, :pending_approval, :new_from_invite_data]
   skip_before_action :ensure_context, except: [:no_data_allowed]
-  after_filter :accept_pending_invite, only: [:create]
 
   def index
     @can_create = has_access?(Institution, CREATE_INSTITUTION)
@@ -32,11 +31,15 @@ class InstitutionsController < ApplicationController
   end
 
   def create
-    if PendingInstitutionInvite.where(invited_user_id: current_user,  status: 'accepted').count > 0
+    inst_params = institution_params
+    @pending_invite = PendingInstitutionInvite.find(inst_params["pending_institution_invite_id"])
+
+    unless @pending_invite and @pending_invite.status == 'pending'
       no_data_allowed
       return
     end
-    @institution = Institution.new(institution_params)
+
+    @institution = Institution.new(inst_params)
     @institution.user_id = current_user.id
     return unless authorize_resource(Institution, CREATE_INSTITUTION)
 
@@ -52,6 +55,9 @@ class InstitutionsController < ApplicationController
 
         # This is needed for the next redirect, which will use it
         params[:context] = new_context
+
+        #set pending institution invite as accepted if it is not nil
+        accept_pending_invite unless @pending_invite.nil?
 
         format.html { redirect_to root_path, notice: 'Institution was successfully created.' }
         format.json { render action: 'show', status: :created, location: @institution }
@@ -104,22 +110,24 @@ class InstitutionsController < ApplicationController
   end
 
   def new_from_invite_data
-    pending_invite = PendingInstitutionInvite.where(invited_user_id: current_user,  status: 'pending').last
+    pending_institution_invite_id = params["pending_institution_invite_id"]
+    pending_invite = PendingInstitutionInvite.find_by(invited_user_email: current_user.email,  id: pending_institution_invite_id, status: 'pending')
     unless pending_invite.nil?
       @institution = current_user.institutions.new
       @institution.kind = pending_invite.institution_kind
       @institution.name = pending_invite.institution_name
+      @institution.pending_institution_invite = pending_invite
       render action: 'new'
     else
+      session[:user_return_to] = nil
       no_data_allowed
     end
   end
 
   def accept_pending_invite
-    pending_invite = PendingInstitutionInvite.find_by(invited_user_id: current_user)
-    unless pending_invite.nil?
-      pending_invite.status = 'accepted'
-      pending_invite.save!
+    unless @pending_invite.nil? and current_user.email != @pending_invite.invited_user_email
+      @pending_invite.status = 'accepted'
+      @pending_invite.save!
     end
   end
 
@@ -130,6 +138,6 @@ class InstitutionsController < ApplicationController
   end
 
   def institution_params
-    params.require(:institution).permit(:name, :kind)
+    params.require(:institution).permit(:name, :kind, :pending_institution_invite_id)
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -17,6 +17,12 @@ class Users::InvitationsController < Devise::InvitationsController
     end
   end
 
+  def edit
+    session[:pending_invite_id] = params["pending_institution_invite_id"]
+    super
+  end
+
+
   protected
 
   def update_sanitized_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -144,13 +144,15 @@ class UsersController < ApplicationController
 
   def create_institution_invite
     invited_user_email = params[:user_invite_data]["email"]
-    pending_invite = PendingInstitutionInvite.new
-    pending_invite.invited_user_email = invited_user_email unless invited_user_email.nil?
-    pending_invite.invited_by_user = current_user
-    pending_invite.institution_name = params["institution_data"]["name"]
-    pending_invite.institution_kind = params["institution_data"]["type"]
-    pending_invite.save!
-    @pending_invite = pending_invite
+    unless invited_user_email.nil?
+      pending_invite = PendingInstitutionInvite.new
+      pending_invite.invited_user_email = invited_user_email
+      pending_invite.invited_by_user = current_user
+      pending_invite.institution_name = params["institution_data"]["name"]
+      pending_invite.institution_kind = params["institution_data"]["type"]
+      pending_invite.save!
+      @pending_invite = pending_invite
+    end
   end
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -112,8 +112,12 @@ class UsersController < ApplicationController
   private
 
   def send_institution_invite(institution_data, user)
-    mark_as_invited(user)
-    InvitationMailer.invite_institution_message(user, institution_data["name"], @message).deliver_now
+    unless user.persisted?
+      mark_as_invited(user)
+      InvitationMailer.invite_institution_message(user, institution_data["name"], @message).deliver_now
+    else
+      InvitationMailer.create_institution_message(user, institution_data["name"], @message).deliver_now
+    end
   end
 
   def initialize_user(user_invite_data)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,10 @@ module ApplicationHelper
     has_access?(Institution, Policy::Actions::CREATE_INSTITUTION_SAMPLE) || check_access(Sample, Policy::Actions::READ_SAMPLE).exists?
   end
 
+  def has_access_to_institutions_create?
+    has_access?(Institution, Policy::Actions::CREATE_INSTITUTION)
+  end
+
   def has_access_to_sites_index?
     has_access?(Institution, Policy::Actions::CREATE_INSTITUTION_SITE) || check_access(Site, Policy::Actions::READ_SITE).exists?
   end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -8,18 +8,20 @@ class InvitationMailer < ApplicationMailer
     mail(:to => @user.email, :subject => "Invitation to Connected Diagnostics")
   end
 
-  def invite_institution_message(user, institution_name, message)
+  def invite_institution_message(user, pending_invite, message)
     @user = user
-    @institution_name = institution_name
+    @institution_name = pending_invite.institution_name
+    @pending_institution_invite_id = pending_invite.id
     @token = user.raw_invitation_token
     @message = message
 
     mail(:to => @user.email, :subject => "Invitation to Connected Diagnostics")
   end
 
-  def create_institution_message(user, institution_name, message)
+  def create_institution_message(user, pending_invite, message)
     @user = user
-    @institution_name = institution_name
+    @institution_name = pending_invite.institution_name
+    @pending_institution_invite_id = pending_invite.id
     @message = message
 
     mail(:to => @user.email, :subject => "Invitation to Connected Diagnostics")

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -16,4 +16,13 @@ class InvitationMailer < ApplicationMailer
 
     mail(:to => @user.email, :subject => "Invitation to Connected Diagnostics")
   end
+
+  def create_institution_message(user, institution_name, message)
+    @user = user
+    @institution_name = institution_name
+    @message = message
+
+    mail(:to => @user.email, :subject => "Invitation to Connected Diagnostics")
+  end
+
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -5,6 +5,7 @@ class Institution < ActiveRecord::Base
   KINDS = %w(institution manufacturer health_organization)
 
   belongs_to :user
+  belongs_to :pending_institution_invite
 
   has_many :sites, dependent: :restrict_with_error
   has_many :devices, dependent: :restrict_with_error

--- a/app/models/pending_institution_invite.rb
+++ b/app/models/pending_institution_invite.rb
@@ -1,12 +1,11 @@
 class PendingInstitutionInvite < ActiveRecord::Base
 
-  belongs_to :invited_user, :class_name => 'User'
   belongs_to :invited_by_user, :class_name => 'User'
 
   institution_kinds = %w(institution manufacturer health_organization)
   statuses = %w(pending accepted)
 
-  validates_presence_of :invited_user
+  validates_presence_of :invited_user_email
   validates_presence_of :invited_by_user
   validates_presence_of :institution_name
   validates_presence_of :institution_kind
@@ -16,7 +15,11 @@ class PendingInstitutionInvite < ActiveRecord::Base
   validates_inclusion_of :status, in: statuses
 
   def self.user_has_pending_invites?(user)
-    where(invited_user_id: user,  status: 'pending').count > 0
+    where(invited_user_email: user.email,  status: 'pending').count > 0
+  end
+
+  def is_pending?
+    status == 'pending'
   end
 
 end

--- a/app/views/institutions/_form.haml
+++ b/app/views/institutions/_form.haml
@@ -38,6 +38,7 @@
         = f.label :name, :class => 'block'
       .col
         = f.text_field :name, readonly: @readonly, :class => 'input-block'
+        = f.hidden_field :pending_institution_invite_id
     - if not f.object.new_record?
       .row
         .col.px-1

--- a/app/views/invitation_mailer/create_institution_message.html.erb
+++ b/app/views/invitation_mailer/create_institution_message.html.erb
@@ -1,0 +1,16 @@
+<h1><%= "#{User.find(@user.invited_by_id).full_name} has invited you to join #{@institution_name} as an administrator" %></h2>
+
+<p class="custom-message">
+  <%= @message %><br />
+  Please follow the instructions to complete the signup
+</p>
+
+<p><%= link_to "Create Institution", new_institution_url, class: "btn-primary" %></p>
+
+<% content_for :footer do %>
+  <p class="footer">
+    Link not working? Paste this into your browser:
+    <%= link_to new_institution_url, new_institution_url %>
+  </p>
+  <p class="footer"><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>
+<% end %>

--- a/app/views/invitation_mailer/create_institution_message.html.erb
+++ b/app/views/invitation_mailer/create_institution_message.html.erb
@@ -5,12 +5,12 @@
   Please follow the instructions to complete the signup
 </p>
 
-<p><%= link_to "Create Institution", new_institution_url, class: "btn-primary" %></p>
+<p><%= link_to "Create Institution", new_from_invite_data_institutions_url(:pending_institution_invite_id => @pending_institution_invite_id), class: "btn-primary" %></p>
 
 <% content_for :footer do %>
   <p class="footer">
     Link not working? Paste this into your browser:
-    <%= link_to new_institution_url, new_institution_url %>
+    <%= link_to new_from_invite_data_institutions_url(:pending_institution_invite_id => @pending_institution_invite_id), new_from_invite_data_institutions_url(:pending_institution_invite_id => @pending_institution_invite_id) %>
   </p>
   <p class="footer"><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>
 <% end %>

--- a/app/views/invitation_mailer/invite_institution_message.html.erb
+++ b/app/views/invitation_mailer/invite_institution_message.html.erb
@@ -5,12 +5,12 @@
   Please follow the instructions to complete the signup
 </p>
 
-<p><%= link_to "Create account", accept_invitation_url(@user, :invitation_token => @token), class: "btn-primary" %></p>
+<p><%= link_to "Create account", accept_invitation_url(@user, :invitation_token => @token, :pending_institution_invite_id => @pending_institution_invite_id), class: "btn-primary" %></p>
 
 <% content_for :footer do %>
   <p class="footer">
     Link not working? Paste this into your browser:
-    <%= link_to accept_invitation_url(@user, :invitation_token => @token), accept_invitation_url(@user, :invitation_token => @token) %>
+    <%= link_to accept_invitation_url(@user, :invitation_token => @token, :pending_institution_invite_id => @pending_institution_invite_id), accept_invitation_url(@user, :invitation_token => @token, :pending_institution_invite_id => @pending_institution_invite_id) %>
   </p>
   <p class="footer"><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>
 <% end %>

--- a/db/migrate/20220114191522_create_pending_institution_invites.rb
+++ b/db/migrate/20220114191522_create_pending_institution_invites.rb
@@ -1,7 +1,7 @@
 class CreatePendingInstitutionInvites < ActiveRecord::Migration
   def change
     create_table :pending_institution_invites do |t|
-      t.references :invited_user, index: true
+      t.string :invited_user_email, index: true
       t.references :invited_by_user, index: true
       t.string :institution_name
       t.string :institution_kind, default: 'institution'

--- a/db/migrate/20220114191523_add_pending_institution_invites_to_institutions.rb
+++ b/db/migrate/20220114191523_add_pending_institution_invites_to_institutions.rb
@@ -1,0 +1,5 @@
+class AddPendingInstitutionInvitesToInstitutions < ActiveRecord::Migration
+  def change
+    add_column :institutions, :pending_institution_invite_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20211217160437) do
+ActiveRecord::Schema.define(version: 20220114191523) do
 
   create_table "alert_condition_results", force: :cascade do |t|
     t.string  "result",   limit: 255
@@ -329,12 +329,13 @@ ActiveRecord::Schema.define(version: 20211217160437) do
   end
 
   create_table "institutions", force: :cascade do |t|
-    t.string   "name",       limit: 255
-    t.integer  "user_id",    limit: 4
+    t.string   "name",                          limit: 255
+    t.integer  "user_id",                       limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "uuid",       limit: 255
-    t.string   "kind",       limit: 255, default: "institution"
+    t.string   "uuid",                          limit: 255
+    t.string   "kind",                          limit: 255, default: "institution"
+    t.integer  "pending_institution_invite_id", limit: 4
   end
 
   add_index "institutions", ["user_id"], name: "index_institutions_on_user_id", using: :btree
@@ -445,7 +446,7 @@ ActiveRecord::Schema.define(version: 20211217160437) do
   add_index "patients", ["site_id"], name: "index_patients_on_site_id", using: :btree
 
   create_table "pending_institution_invites", force: :cascade do |t|
-    t.integer  "invited_user_id",    limit: 4
+    t.string   "invited_user_email", limit: 255
     t.integer  "invited_by_user_id", limit: 4
     t.string   "institution_name",   limit: 255
     t.string   "institution_kind",   limit: 255, default: "institution"
@@ -455,7 +456,7 @@ ActiveRecord::Schema.define(version: 20211217160437) do
   end
 
   add_index "pending_institution_invites", ["invited_by_user_id"], name: "index_pending_institution_invites_on_invited_by_user_id", using: :btree
-  add_index "pending_institution_invites", ["invited_user_id"], name: "index_pending_institution_invites_on_invited_user_id", using: :btree
+  add_index "pending_institution_invites", ["invited_user_email"], name: "index_pending_institution_invites_on_invited_user_email", using: :btree
 
   create_table "policies", force: :cascade do |t|
     t.integer  "user_id",    limit: 4


### PR DESCRIPTION
Fixes: #1414 

-Add a different email when inviting an existing user
-Change user reference from user_id to user_email in PendingInstitutionsInvite so we don't need a persisted user to be a valid invite
-Send the PendingInstitutionInvite id to the emails so we can validate later on with the actual invite to avoid multiple institutions creation
-Added some dummy validations to prevent the user from sending problematic data and to give some UI feedback for UX
-Changed the migration version so we don't cause any trouble with table/column dependency


## Before this fix
-The same email was being sent to any kind of user (persisted or not).
<img width="1018" alt="Screen Shot 2022-01-18 at 08 38 29" src="https://user-images.githubusercontent.com/23437283/149930589-17c168e6-f4a9-44ed-a928-d1116578a8dd.png">

## After this fix
-Two types of mails, with different flows, are being sent accordingly. One for New Users
<img width="1018" alt="Screen Shot 2022-01-18 at 08 38 29" src="https://user-images.githubusercontent.com/23437283/149930589-17c168e6-f4a9-44ed-a928-d1116578a8dd.png">

And the other one for persisted users
<img width="1018" alt="Screen Shot 2022-01-18 at 08 42 07" src="https://user-images.githubusercontent.com/23437283/149931132-1eaa7041-f399-4bc3-a53d-9d1f75efcb5f.png">

