### PR TITLE
Add batch_number to samples form

### DIFF
--- a/app/models/sample_form.rb
+++ b/app/models/sample_form.rb
@@ -5,6 +5,7 @@ class SampleForm
     [ :institution,
       :site,
       :uuid,
+      :batch,
       :date_produced,
       :lab_technician,
       :specimen_role,

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -9,6 +9,12 @@
           = f.label :uuid
         .col
           .value= f.object.uuid
+      - unless f.object.batch.nil?
+        .row
+          .col.pe-4
+            = f.label :batch_id
+          .col
+            .value= f.object.batch.batch_number
 
       .row
         .col.pe-4


### PR DESCRIPTION
Fixes: #1424 

## Before this PR, Samples Form didn't have the batch_number field
<img width="1376" alt="Screen Shot 2022-01-26 at 10 53 19" src="https://user-images.githubusercontent.com/23437283/151175472-d8b246bc-0fe8-4b8a-bc43-d4590dd14f59.png">

## Added the Batch field in the Samples Form

<img width="1376" alt="Screen Shot 2022-01-26 at 10 54 32" src="https://user-images.githubusercontent.com/23437283/151175740-3bcfde4c-f485-4a3c-815b-ae0eea97a1dc.png">


