### PR TITLE
Fix 404 when inviting institutions with an email that belongs to a user that already exists

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -112,11 +112,11 @@ class UsersController < ApplicationController
   private
 
   def send_institution_invite(institution_data, user)
-    unless user.persisted?
-      mark_as_invited(user)
-      InvitationMailer.invite_institution_message(user, @pending_invite, @message).deliver_now
+    if user.persisted?
+      InvitationMailer.create_institution_message(user, current_user, @pending_invite, @message).deliver_now
     else
-      InvitationMailer.create_institution_message(user, @pending_invite, @message).deliver_now
+      mark_as_invited(user)
+      InvitationMailer.invite_institution_message(user, current_user, @pending_invite, @message).deliver_now
     end
   end
 

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -8,8 +8,9 @@ class InvitationMailer < ApplicationMailer
     mail(:to => @user.email, :subject => "Invitation to Connected Diagnostics")
   end
 
-  def invite_institution_message(user, pending_invite, message)
+  def invite_institution_message(user, invitation_sender, pending_invite, message)
     @user = user
+    @invitation_sender = invitation_sender
     @institution_name = pending_invite.institution_name
     @pending_institution_invite_id = pending_invite.id
     @token = user.raw_invitation_token
@@ -18,8 +19,9 @@ class InvitationMailer < ApplicationMailer
     mail(:to => @user.email, :subject => "Invitation to Connected Diagnostics")
   end
 
-  def create_institution_message(user, pending_invite, message)
+  def create_institution_message(user, invitation_sender, pending_invite, message)
     @user = user
+    @invitation_sender = invitation_sender
     @institution_name = pending_invite.institution_name
     @pending_institution_invite_id = pending_invite.id
     @message = message

--- a/app/views/invitation_mailer/create_institution_message.html.erb
+++ b/app/views/invitation_mailer/create_institution_message.html.erb
@@ -1,4 +1,4 @@
-<h1><%= "#{User.find(@user.invited_by_id).full_name} has invited you to join #{@institution_name} as an administrator" %></h2>
+<h1><%= "#{@invitation_sender.full_name} has invited you to join #{@institution_name} as an administrator" %></h2>
 
 <p class="custom-message">
   <%= @message %><br />

--- a/app/views/invitation_mailer/invite_institution_message.html.erb
+++ b/app/views/invitation_mailer/invite_institution_message.html.erb
@@ -1,4 +1,4 @@
-<h1><%= "#{User.find(@user.invited_by_id).full_name} has invited you to join #{@institution_name} as an administrator" %></h2>
+<h1><%= "#{@invitation_sender.full_name} has invited you to join #{@institution_name} as an administrator" %></h2>
 
 <p class="custom-message">
   <%= @message %><br />


### PR DESCRIPTION
Related #1418

When the user already exists in the db, the `invited_by_id` attribute is `nil` (see `UsersController#send_institution_invite` and `UsersController#mark_as_invited`) and this lead to an error when trying to send the email (the sender could not be found)
