### PR TITLE
GHA: optimize workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - "**"
+
+  pull_request:
+    branches:
+      - "**:**"
 
 jobs:
   test:
@@ -14,16 +23,20 @@ jobs:
           docker-compose run --rm -e RAILS_ENV=test web bundle install
           docker-compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
           docker-compose up -d db elasticsearch redis sshd csv_watch ftp_monitor sidekiq
+
       - name: Run specs
         run: docker-compose run --rm -e RAILS_ENV=test web bundle exec rake
+
   build:
-    needs: test
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    needs: test
+    if: contains('refs/heads/main', github.ref) || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/preview/') || startsWith(github.ref, 'refs/tags/')
+
     env:
       DOCKER_REPOSITORY: 'instedd/cdx'
       DOCKER_USER: ${{ secrets.DOCKER_USER }}
       DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Build image & push to Docker Hub


### PR DESCRIPTION
Avoid running the workflow twice, once for a push and another one for a pull request.

Also avoids building the docker image until we are on a branch or tag for which we want to build an image (main, preview/, release/ or we pushed a release tag).