### PR TITLE
Allow Samples and Batches editing when save fails

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -61,6 +61,7 @@ class BatchesController < ApplicationController
     if @batch_form.create
       redirect_to batches_path, notice: 'Batch was successfully created.'
     else
+      @can_update = true
       @can_edit_sample_quantity = true
       render action: 'new'
     end
@@ -84,6 +85,7 @@ class BatchesController < ApplicationController
     if @batch_form.update(batch_params, remove_samples_params)
       redirect_to batches_path, notice: 'Batch was successfully updated.'
     else
+      @can_update = true
       render action: 'edit'
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -71,6 +71,7 @@ class SamplesController < ApplicationController
       redirect_to samples_path, notice: 'Sample was successfully created.'
     else
       @view_helper = view_helper
+      @can_update = true
       render action: 'new'
     end
   end
@@ -153,6 +154,7 @@ class SamplesController < ApplicationController
       redirect_to back_path, notice: 'Sample was successfully updated.'
     else
       @view_helper = view_helper
+      @can_update = true
       render action: 'edit'
     end
   end


### PR DESCRIPTION
- Fixes: #1442 

-Added `can_update` instance variable when create and update actions fails, since they need the variable needs to be set again before render to allow the user to edit the form.


Here's a list of the actions in the controller and the value that `can_update` needs to have in each one.


List of actions / can_update value

Index -> does not need can_update
New -> true
Show -> false
Create/sucess -> does not need can_update since it redirects to index
Create/failure -> true
Edit -> true
Update/sucess -> does not need can_update since it redirects to index
Update/failure -> true
Print -> does not need can_update
Bulk_print -> does not need can_update
destroy -> does not need can_update
Bulk_destroy -> does not need can_update
