### PR TITLE
Fix trivial typos

### DIFF
--- a/app/views/home/settings.html.haml
+++ b/app/views/home/settings.html.haml
@@ -13,7 +13,7 @@
         %br
         %br
         Check
-        = link_to "alert messages sent", alert_messages_path
+        = link_to "alert messages", alert_messages_path
         sent about registered
         = link_to "incidents", incidents_path
 

--- a/app/views/incidents/index.html.haml
+++ b/app/views/incidents/index.html.haml
@@ -5,7 +5,7 @@
     - if @incidents.empty?
       = empty_data title: "No incidents", icon: 'icon-outline-alert xx-large' do |c|
         - c.body do
-          %h1 There are incidents on this site
+          %h1 There are no incidents on this site
           %p Create alert groups in order to keep your team notified on current events
     - else
       = cdx_table title: pluralize(@total, "Incident") do |t|


### PR DESCRIPTION
Closes #1062 and closes #1066.

In order to reach the pages with typos:
- #1062
Settings link in the top navigation menu

- #1066 
Settings link in the top navigation menu and then the `incidents` link in the Alerts box.

### Before merging this PR
![image](https://user-images.githubusercontent.com/25181052/153057358-192d6364-7388-4934-a6cb-ce8e0ba2d27c.png)
![image](https://user-images.githubusercontent.com/25181052/153057414-ace139c5-12af-4838-a4c5-09fe8ec8a669.png)

### After merging this PR
![image](https://user-images.githubusercontent.com/25181052/153057484-4864332a-3b54-49bb-9aab-252af246ba83.png)
![image](https://user-images.githubusercontent.com/25181052/153057566-861ebcc8-4d2b-4bea-8e95-226a282f95f1.png)
