### PR TITLE
Add fasta files as supported files for AssayFiles

### DIFF
--- a/config/initializers/paperclip_defaults.rb
+++ b/config/initializers/paperclip_defaults.rb
@@ -11,3 +11,7 @@ if s3_bucket = ENV['PAPERCLIP_S3_BUCKET'].presence
   paperclip_defaults[:s3_host_name] = ENV['PAPERCLIP_S3_HOST_NAME'].presence
   Rails.application.config.paperclip_defaults = paperclip_defaults
 end
+
+Paperclip.options[:content_type_mappings] = {
+  fa: %w(text/plain application/octet-stream)
+}


### PR DESCRIPTION
-Fixes: #1446 

Root cause: For security reasons, `Paperclip` gem does a file type validation before creating the AssayFile model (detailed info [here](https://github.com/thoughtbot/paperclip/blob/main/README.md#security-validations) and [here](https://thoughtbot.com/blog/prevent-spoofing-with-paperclip)). Since `.fa` files are not supported, the model was not being saved thus making the AssayAttachment to be rendered without an AssayFile and preventing it to be downloaded. 

## Before this fix, when attaching .fa files:
![Screen Shot 2022-02-08 at 17 47 35](https://user-images.githubusercontent.com/23437283/153072949-3c9477ab-afc8-4135-80a9-273e7ddc842b.png)

## After this fix
![Screen Shot 2022-02-08 at 17 46 55](https://user-images.githubusercontent.com/23437283/153072861-ffa69e3d-520c-46ce-9077-72e5a4411f92.png)

