### PR TITLE
Remove broken badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-[![Stories in Ready](https://badge.waffle.io/instedd/cdx.png?label=ready&title=Ready)](https://waffle.io/instedd/cdx)
-[![Build Status](https://travis-ci.org/instedd/cdx.svg?branch=master)](https://travis-ci.org/instedd/cdx)
-[![Dependency Status](https://gemnasium.com/instedd/cdx.svg)](https://gemnasium.com/instedd/cdx)
-
 # CDX
 
 Reference implementation for the Connected Diagnostics API (http://dxapi.org/)


### PR DESCRIPTION
All these badges are broken because the services are no longer available or we don't user it anymore.

We could consider adding new working badges, but removing the old ones is a good idea anyways.