### PR TITLE
Transfer samples with batches

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,12 +44,19 @@ class ApplicationController < ActionController::Base
   end
 
   def authorize_resource(resource, action)
+    unless authorize_resource?(resource, action)
+      log_authorization_warn resource, action
+      head :forbidden
+      return nil
+    end
+    true
+  end
+
+  def authorize_resource?(resource, action)
     if has_access?(resource, action)
       check_access(resource, action)
     else
-      log_authorization_warn resource, action
-      head :forbidden
-      nil
+      false
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,14 +44,16 @@ class ApplicationController < ActionController::Base
   end
 
   def authorize_resource(resource, action)
-    unless authorize_resource?(resource, action)
+    if has_access?(resource, action)
+      check_access(resource, action)
+    else
       log_authorization_warn resource, action
       head :forbidden
-      return nil
+      nil
     end
-    true
   end
 
+  #TODO: refactor authorize_resource and authorize_resource? as both share almost the same code
   def authorize_resource?(resource, action)
     if has_access?(resource, action)
       check_access(resource, action)

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -213,11 +213,10 @@ class SamplesController < ApplicationController
     Sample.transaction do
       samples.each do |to_transfer|
         raise "User not authorized for transferring Samples " unless authorize_resource?(to_transfer, UPDATE_SAMPLE)
-        if to_transfer.batch_id.nil?
-          to_transfer.site_id = nil
-          to_transfer.institution = new_owner
-          to_transfer.save!
-        end
+        to_transfer.batch_id = nil
+        to_transfer.site_id = nil
+        to_transfer.institution = new_owner
+        to_transfer.save!
       end
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -9,7 +9,7 @@ class SamplesController < ApplicationController
     @samples = @samples.within(@navigation_context.entity, @navigation_context.exclude_subsites)
 
     @samples = @samples.joins(:sample_identifiers).where("sample_identifiers.uuid LIKE concat('%', ?, '%')", params[:sample_id]) unless params[:sample_id].blank?
-    @samples = @samples.joins(:batch).where("batches.batch_number LIKE concat('%', ?, '%')", params[:batch_number]) unless params[:batch_number].blank?
+    @samples = @samples.joins("LEFT JOIN batches ON batches.id = samples.batch_id").where("batches.batch_number LIKE concat('%', ?, '%') OR samples.old_batch_number LIKE concat('%', ?, '%')", params[:batch_number], params[:batch_number]) unless params[:batch_number].blank?
     @samples = @samples.where("isolate_name LIKE concat('%', ?, '%')", params[:isolate_name]) unless params[:isolate_name].blank?
     @samples = @samples.where("specimen_role = ?", params[:specimen_role]) unless params[:specimen_role].blank?
 
@@ -213,6 +213,7 @@ class SamplesController < ApplicationController
     Sample.transaction do
       samples.each do |to_transfer|
         raise "User not authorized for transferring Samples " unless authorize_resource?(to_transfer, UPDATE_SAMPLE)
+        to_transfer.old_batch_number = to_transfer.batch.batch_number unless to_transfer.batch.nil?
         to_transfer.batch_id = nil
         to_transfer.site_id = nil
         to_transfer.institution = new_owner

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -31,6 +31,7 @@ class Sample < ActiveRecord::Base
 
   attribute_field :isolate_name, copy: true
   attribute_field :specimen_role, copy: true
+  attribute_field :old_batch_number, copy: true
   attribute_field :date_produced,
                   :lab_technician,
                   :inactivation_method,

--- a/app/views/samples/_index_js.haml
+++ b/app/views/samples/_index_js.haml
@@ -5,7 +5,6 @@
 
   function actionsId() {
     return [
-      "bulk_transfer",
       "bulk_print",
       "bulk_destroy",
       "bulk_transfer"

--- a/app/views/samples/_index_js.haml
+++ b/app/views/samples/_index_js.haml
@@ -5,6 +5,7 @@
 
   function actionsId() {
     return [
+      "bulk_transfer",
       "bulk_print",
       "bulk_destroy",
       "bulk_transfer"

--- a/db/migrate/20220216134506_add_old_batch_number_to_samples.rb
+++ b/db/migrate/20220216134506_add_old_batch_number_to_samples.rb
@@ -1,0 +1,5 @@
+class AddOldBatchNumberToSamples < ActiveRecord::Migration
+  def change
+    add_column :samples, :old_batch_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220114191523) do
+ActiveRecord::Schema.define(version: 20220216134506) do
 
   create_table "alert_condition_results", force: :cascade do |t|
     t.string  "result",   limit: 255
@@ -515,21 +515,22 @@ ActiveRecord::Schema.define(version: 20220114191523) do
   add_index "sample_identifiers", ["uuid"], name: "index_sample_identifiers_on_uuid", unique: true, using: :btree
 
   create_table "samples", force: :cascade do |t|
-    t.binary   "sensitive_data", limit: 65535
-    t.integer  "institution_id", limit: 4
-    t.text     "custom_fields",  limit: 65535
-    t.text     "core_fields",    limit: 65535
+    t.binary   "sensitive_data",   limit: 65535
+    t.integer  "institution_id",   limit: 4
+    t.text     "custom_fields",    limit: 65535
+    t.text     "core_fields",      limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "patient_id",     limit: 4
-    t.integer  "encounter_id",   limit: 4
-    t.boolean  "is_phantom",                   default: true
+    t.integer  "patient_id",       limit: 4
+    t.integer  "encounter_id",     limit: 4
+    t.boolean  "is_phantom",                     default: true
     t.datetime "deleted_at"
-    t.integer  "batch_id",       limit: 4
-    t.string   "isolate_name",   limit: 255
-    t.integer  "site_id",        limit: 4
-    t.string   "site_prefix",    limit: 255
-    t.string   "specimen_role",  limit: 255
+    t.integer  "batch_id",         limit: 4
+    t.string   "isolate_name",     limit: 255
+    t.integer  "site_id",          limit: 4
+    t.string   "site_prefix",      limit: 255
+    t.string   "specimen_role",    limit: 255
+    t.string   "old_batch_number", limit: 255
   end
 
   add_index "samples", ["batch_id"], name: "index_samples_on_batch_id", using: :btree

--- a/deps/cdx_core/lib/config/fields.yml
+++ b/deps/cdx_core/lib/config/fields.yml
@@ -39,6 +39,8 @@ entities:
       volume:
         type: float
       lab_technician:
+      old_batch_number:
+        searchable: true
   batch: &BATCH
     fields:
       batch_number:

--- a/spec/models/cdx_api_elasticsearch_mapping_template_spec.rb
+++ b/spec/models/cdx_api_elasticsearch_mapping_template_spec.rb
@@ -49,6 +49,10 @@ describe "Cdx::Api::Elasticsearch::MappingTemplate" do
                 "type"=>"string",
                 "index"=>"not_analyzed"
               },
+              "old_batch_number"=> {
+              "type"=>"string",
+              "index"=>"not_analyzed"
+              },
               "custom_fields" => {
                 "type" => "object"
               }

--- a/spec/models/cdx_spec.rb
+++ b/spec/models/cdx_spec.rb
@@ -34,6 +34,7 @@ describe Cdx do
       "sample.inactivation_method",
       "sample.volume",
       "sample.lab_technician",
+      "sample.old_batch_number",
       "test.assays.result",
       "test.assays.name",
       "test.assays.condition",

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -75,7 +75,7 @@ describe Subscriber, elasticsearch: true do
       expect(response["site"].keys).to match_array(["uuid", "name", "path"])
       expect(response["location"].keys).to match_array(["id", "parents", "admin_levels", "lat", "lng"])
       expect(response["patient"].keys).to match_array(["gender"])
-      expect(response["sample"].keys).to match_array(["uuid", "id", "type", "collection_date", "specimen_role", "isolate_name", "date_produced", "inactivation_method", "volume", "lab_technician"])
+      expect(response["sample"].keys).to match_array(["uuid", "id", "type", "collection_date", "specimen_role", "isolate_name", "date_produced", "inactivation_method", "volume", "lab_technician", "old_batch_number"])
       expect(response["test"].keys).to match_array(["id", "uuid", "start_time", "end_time", "reported_time", "updated_time", "error_code", "error_description", "name", "status", "assays", "type", "site_user"])
       expect(response["institution"]["name"]).to eq(institution.name)
       expect(response["site"]["name"]).to eq(site.name)


### PR DESCRIPTION
Fixes: #1388 

-Allow samples that belong to a batch to be transferred
-Add old_batch_number to samples to able to filter by batch_number (from Batch model) and old_batch_number

