### PR TITLE
GHA: optimize CI runs

### DIFF
--- a/.github/actions/docker-cache/action.yml
+++ b/.github/actions/docker-cache/action.yml
@@ -1,0 +1,37 @@
+name: Docker cache
+
+inputs:
+  docker-images:
+    default: ""
+
+  version:
+    default: "v0"
+
+outputs:
+  cache-hit:
+    value: ${{ steps.docker-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/cache@v2
+      id: docker-cache
+      with:
+        path: tmp/docker
+        key: Docker-${{ inputs.version }}-${{ hashFiles('Dockerfile*', 'docker-compose*') }}
+        restore-keys: |
+          Docker-${{ inputs.version }}-
+
+    - name: Load Docker image
+      if: steps.docker-cache.outputs.cache-hit == 'true'
+      run: |
+        docker load < tmp/docker/docker_images.tar
+      shell: bash
+
+    - name: Build Docker image
+      if: steps.docker-cache.outputs.cache-hit != 'true'
+      run: |
+        docker-compose build
+        docker save ${{ inputs.docker-images }} > tmp/docker/docker_images.tar
+      shell: bash

--- a/.github/actions/gems-cache/action.yml
+++ b/.github/actions/gems-cache/action.yml
@@ -1,0 +1,28 @@
+name: Gems cache
+
+inputs:
+  version:
+    default: "v0"
+
+outputs:
+  cache-hit:
+    value: ${{ steps.gems-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/cache@v2
+      id: gems-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ inputs.version }}-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-${{ inputs.version }}-${{ hashFiles('.ruby-version') }}-
+          ${{ runner.os }}-gems-
+
+    - name: Install gems
+      if: steps.gems-cache.outputs.cache-hit != 'true'
+      run: |
+        docker-compose run --rm --no-deps $COMPOSE_DEFAULT_SERVICE bash -c "bundle install --jobs 4 --retry 3 && bundle clean --force"
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,27 +11,63 @@ on:
     branches:
       - "**:**"
 
+env:
+  DOCKER_COMPOSE: docker-compose -f docker-compose.yml -f docker-compose.ci.yml
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set environment up
+      - uses: actions/cache@v2
+        id: docker-cache
+        with:
+          path: tmp/docker
+          key: Docker-v2-${{ hashFiles('Dockerfile-dev', 'docker-compose.yml', '/docker-compose.ci.yml') }}
+          restore-keys: |
+            Docker-v2-
+
+      - name: Load Docker image
+        if: steps.docker-cache.outputs.cache-hit == 'true'
         run: |
-          docker-compose build
-          docker-compose run --rm -e RAILS_ENV=test web bundle install
-          docker-compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
-          docker-compose up -d db elasticsearch redis sshd csv_watch ftp_monitor sidekiq
+          docker load < tmp/docker/docker_images.tar
+
+      - name: Build Docker image
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: |
+          $DOCKER_COMPOSE build
+          docker save cdx_web cdx_csv_watch cdx_ftp_monitor cdx_sidekiq > tmp/docker/docker_images.tar
+
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-
+            ${{ runner.os }}-gems-
+
+      - name: Install dependencies
+        run: |
+          $DOCKER_COMPOSE run --rm --no-deps -e RAILS_ENV=test web bundle install --jobs 4
+          $DOCKER_COMPOSE run --rm --no-deps -e RAILS_ENV=test web bundle clean --force
+
+      - name: Setup databases
+        run: |
+          $DOCKER_COMPOSE up -d db elasticsearch redis
+          $DOCKER_COMPOSE run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
+
+      - name: Start services
+        run: $DOCKER_COMPOSE up -d sshd csv_watch ftp_monitor sidekiq
 
       - name: Run specs
-        run: docker-compose run --rm -e RAILS_ENV=test web bundle exec rspec
+        run: $DOCKER_COMPOSE run --rm -e RAILS_ENV=test web bundle exec rspec
 
-      - name: Run integration specs (rspec+capybara)
-        run: docker-compose run --rm -e RAILS_ENV=test web bundle exec rspec spec/features/**
+      - name: Run integration specs (rspec + capybara)
+        run: $DOCKER_COMPOSE run --rm -e RAILS_ENV=test web bundle exec rspec spec/features/**
 
       - name: Run integration specs (cucumber)
-        run: docker-compose run --rm -e RAILS_ENV=test web bundle exec cucumber
+        run: $DOCKER_COMPOSE run --rm -e RAILS_ENV=test web bundle exec cucumber
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,66 +12,59 @@ on:
       - "**:**"
 
 env:
-  DOCKER_COMPOSE: docker-compose -f docker-compose.yml -f docker-compose.ci.yml
+  COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml
+  COMPOSE_DEFAULT_SERVICE: web
 
 jobs:
-  test:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        id: docker-cache
+      - uses: ./.github/actions/docker-cache
         with:
-          path: tmp/docker
-          key: Docker-v2-${{ hashFiles('Dockerfile-dev', 'docker-compose.yml', '/docker-compose.ci.yml') }}
-          restore-keys: |
-            Docker-v2-
+          docker-images: cdx_web cdx_csv_watch cdx_ftp_monitor cdx_sidekiq
+      - uses: ./.github/actions/gems-cache
 
-      - name: Load Docker image
-        if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: |
-          docker load < tmp/docker/docker_images.tar
-
-      - name: Build Docker image
-        if: steps.docker-cache.outputs.cache-hit != 'true'
-        run: |
-          $DOCKER_COMPOSE build
-          docker save cdx_web cdx_csv_watch cdx_ftp_monitor cdx_sidekiq > tmp/docker/docker_images.tar
-
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-
-            ${{ runner.os }}-gems-
-
-      - name: Install dependencies
-        run: |
-          $DOCKER_COMPOSE run --rm --no-deps -e RAILS_ENV=test web bundle install --jobs 4
-          $DOCKER_COMPOSE run --rm --no-deps -e RAILS_ENV=test web bundle clean --force
+  unit_tests:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/docker-cache
+      - uses: ./.github/actions/gems-cache
 
       - name: Setup databases
         run: |
-          $DOCKER_COMPOSE up -d db elasticsearch redis
-          $DOCKER_COMPOSE run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
-
-      - name: Start services
-        run: $DOCKER_COMPOSE up -d sshd csv_watch ftp_monitor sidekiq
+          docker-compose up -d db elasticsearch redis
+          docker-compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
 
       - name: Run specs
-        run: $DOCKER_COMPOSE run --rm -e RAILS_ENV=test web bundle exec rspec
+        run: docker-compose run --rm -e RAILS_ENV=test web bundle exec rspec
 
-      - name: Run integration specs (rspec + capybara)
-        run: $DOCKER_COMPOSE run --rm -e RAILS_ENV=test web bundle exec rspec spec/features/**
+  integration_tests:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/docker-cache
+      - uses: ./.github/actions/gems-cache
 
-      - name: Run integration specs (cucumber)
-        run: $DOCKER_COMPOSE run --rm -e RAILS_ENV=test web bundle exec cucumber
+      - name: Setup databases
+        run: |
+          docker-compose up -d db elasticsearch redis
+          docker-compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
+
+      - name: Run specs (capybara)
+        run: docker-compose run --rm -e RAILS_ENV=test web bundle exec rspec spec/features/**
+
+      - name: Run specs (cucumber)
+        run: docker-compose run --rm -e RAILS_ENV=test web bundle exec cucumber
 
   build:
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - unit_tests
+      - integration_tests
     if: contains('refs/heads/main', github.ref) || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/preview/') || startsWith(github.ref, 'refs/tags/')
 
     env:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,18 @@
+version: "2.0"
+
+services:
+  web:
+    volumes:
+      - ./vendor/bundle:/usr/local/bundle
+
+  csv_watch:
+    volumes:
+      - ./vendor/bundle:/usr/local/bundle
+
+  ftp_monitor:
+    volumes:
+      - ./vendor/bundle:/usr/local/bundle
+
+  sidekiq:
+    volumes:
+      - ./vendor/bundle:/usr/local/bundle


### PR DESCRIPTION
There was room to optimize the CI run-time, by caching the docker images and ruby gem dependencies across workflows, and... running the integration tests in parallel to the unit tests.

Based on the other spec rework branches, so please review the last 2 commits that change the YAML files under `/.github` :)