### PR TITLE
Update redis image to 6.2.6-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - es01:/usr/share/elasticsearch/data
 
   redis:
-    image: redis:6.2.6-alpine
+    image: redis:6.2-alpine
 
   sshd:
     image: instedd/cdx-sync-sshd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - es01:/usr/share/elasticsearch/data
 
   redis:
-    image: redis:3.0.5
+    image: redis:6.2.6-alpine
 
   sshd:
     image: instedd/cdx-sync-sshd


### PR DESCRIPTION
The redis 3.0.5 image is broken for me locally. Not sure what's going on there, but I've been using an override for now. I think it makes much sense to update to a newer version, though. Even several major versions shouldn't be an issue. The basic redis interface is pretty stable and `sidekick`/`redis-rb` don't use anything fancy.

Using alpine for smaller image size (same functionality).