### PR TITLE
Improve validation errors for assay attachments

### DIFF
--- a/app/models/assay_attachment.rb
+++ b/app/models/assay_attachment.rb
@@ -7,6 +7,7 @@ class AssayAttachment < ActiveRecord::Base
   after_save :assign_assay_file
 
   validate :presence_assay_file_or_result
+  validates_presence_of :loinc_code
 
   def assign_assay_file
     unless assay_file.nil?

--- a/app/models/assay_attachment.rb
+++ b/app/models/assay_attachment.rb
@@ -8,6 +8,7 @@ class AssayAttachment < ActiveRecord::Base
 
   validate :presence_assay_file_or_result
   validates_presence_of :loinc_code
+  validates_associated :assay_file
 
   def assign_assay_file
     unless assay_file.nil?

--- a/app/models/assay_attachment.rb
+++ b/app/models/assay_attachment.rb
@@ -7,7 +7,6 @@ class AssayAttachment < ActiveRecord::Base
   after_save :assign_assay_file
 
   validate :presence_assay_file_or_result
-  validates_presence_of :loinc_code
   validates_associated :assay_file
 
   def assign_assay_file

--- a/app/models/assay_attachment.rb
+++ b/app/models/assay_attachment.rb
@@ -19,6 +19,7 @@ class AssayAttachment < ActiveRecord::Base
   def presence_assay_file_or_result
     unless result.present? or assay_file.present?
       errors.add(:result, "must contain a file or a result")
+      errors.add(:assay_file, "must contain a file or a result")
     end
   end
 

--- a/app/views/samples/_form_assays.haml
+++ b/app/views/samples/_form_assays.haml
@@ -22,10 +22,10 @@
               .info
                 .row
                   .col.pe-1
-                    = ay.label :loinc_code, 'LOINC'
+                    = ay.label :loinc_code, 'LOINC', class: ('input-required' if ay.object.errors.include?(:loinc_code))
                   .col.pe-8
                     .loinc_inputs
-                      = text_field_tag :loinc_code_component, loinc_code_description(ay.object.loinc_code), { class: 'loinc_input'}
+                      = text_field_tag :loinc_code_component, loinc_code_description(ay.object.loinc_code), { class: "loinc_input#{" input-required" if ay.object.errors.include?(:loinc_code)}" }
                       = ay.hidden_field :loinc_code_id, { class: 'loinc_input_hidden'}
                 .row
                   - if ay.object.errors.include?(:result) or ay.object.errors.include?(:assay_file)

--- a/app/views/samples/_form_assays.haml
+++ b/app/views/samples/_form_assays.haml
@@ -28,24 +28,18 @@
                       = text_field_tag :loinc_code_component, loinc_code_description(ay.object.loinc_code), { class: "loinc_input#{" input-required" if ay.object.errors.include?(:loinc_code)}" }
                       = ay.hidden_field :loinc_code_id, { class: 'loinc_input_hidden'}
                 .row
-                  - if ay.object.errors.include?(:result) or ay.object.errors.include?(:assay_file)
-                    .col.pe-1
-                      = ay.label :result, {class: 'input-required'}
-                    .col.pe-8
-                      = ay.text_field :result, {class: 'input-required'}
-                  - else
-                    .col.pe-1
-                      = ay.label :result
-                    .col.pe-8
-                      = ay.text_field :result
+                  .col.pe-1
+                    = ay.label :result, class: ('input-required' if ay.object.errors.include?(:result))
+                  .col.pe-8
+                    = ay.text_field :result, class: ('input-required' if ay.object.errors.include?(:result))
                 %div
                   = ay.hidden_field :assay_file_id, value: ay.object.assay_file_id
 
-              - if ay.object.errors.include?(:assay_file) or ay.object.errors.include?(:result)
+              - if ay.object.errors.include?(:assay_file)
                 .file
                   .picture-container.picture-required
                     .icon-alert.icon-red
-                    = "The file can’t exceed 10 MB"
+                    = ay.object.errors[:assay_file].join(" - ")
               - else
                 - if ay.object.assay_file.nil?
                   .file.is-hidden

--- a/spec/models/assay_attachment_spec.rb
+++ b/spec/models/assay_attachment_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe AssayAttachment do
-  it "validates presence of loinc_code" do
-    expect(AssayAttachment.new).to validate_presence_of(:loinc_code)
-  end
-
   it "validates presence of result or file" do
     attachment = AssayAttachment.make_unsaved(result: nil, assay_file: nil)
     attachment.validate

--- a/spec/models/assay_attachment_spec.rb
+++ b/spec/models/assay_attachment_spec.rb
@@ -4,4 +4,14 @@ describe AssayAttachment do
   it "validates presence of loinc_code" do
     expect(AssayAttachment.new).to validate_presence_of(:loinc_code)
   end
+
+  it "validates presence of result or file" do
+    attachment = AssayAttachment.make_unsaved(result: nil, assay_file: nil)
+    attachment.validate
+    expect(attachment.errors).to have_key(:result)
+    expect(attachment.errors).to have_key(:assay_file)
+    attachment.result = "foo bar"
+    attachment.validate
+    expect(attachment.errors).to be_empty
+  end
 end

--- a/spec/models/assay_attachment_spec.rb
+++ b/spec/models/assay_attachment_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe AssayAttachment do
+  it "validates presence of loinc_code" do
+    expect(AssayAttachment.new).to validate_presence_of(:loinc_code)
+  end
+end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -139,6 +139,17 @@ Sample.blueprint do
   patient { object.encounter.try(:patient) }
 end
 
+AssayAttachment.blueprint do
+  loinc_code { LoincCode.make }
+  sample { Sample.make }
+  result { Faker::Lorem.words(10) }
+end
+
+LoincCode.blueprint do
+  loinc_number { "10000-#{Sham.sn}" }
+  component { Faker::Lorem.words(4) }
+end
+
 Batch.blueprint do
   institution { object.encounter.try(:institution) || object.patient.try(:institution) || Institution.make }
   batch_number { '000' }


### PR DESCRIPTION
This resolves part of #1456. Nice error messages related to assay files are not yet resolved, pending a revisit of the feature.