### PR TITLE
Add `SampleTransfer`

### DIFF
--- a/app/assets/stylesheets/_batches.scss
+++ b/app/assets/stylesheets/_batches.scss
@@ -158,6 +158,19 @@
       font-weight: bold;
     }
   }
+
+  .tab-transfer {
+    background-color: white;
+    margin-bottom: 10px;
+    font-size: 30px;
+    color: rgba(0, 0, 0, 0.4);
+    padding: 15px 20px;
+    &.selected {
+      padding: 0px 10px;
+      color: black;
+      font-weight: bold;
+    }
+  }
 }
 
 .solid-line {

--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -360,3 +360,7 @@ a[title="Back"] {
     padding-top: 10px;
   }
 }
+
+.faded {
+  color: $gray3;
+}

--- a/app/assets/stylesheets/_sprites.scss
+++ b/app/assets/stylesheets/_sprites.scss
@@ -351,6 +351,9 @@
 .icon-sample:before {
   content: "\e93b";
 }
+.icon-transfer:before {
+  content: "\e95e";
+}
 .icon-send:before {
   content: "\e95c";
 }

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -3,6 +3,7 @@ class SampleTransfersController < ApplicationController
     @sample_transfers = SampleTransfer
       .within(@navigation_context.institution)
       .includes(:receiver_institution, :sender_institution, sample: [:sample_identifiers])
+      .ordered_by_creation
 
     @sample_transfers = @sample_transfers.joins(sample: :sample_identifiers).where("sample_identifiers.uuid LIKE concat('%', ?, '%')", params[:sample_id]) unless params[:sample_id].blank?
     @sample_transfers = @sample_transfers.joins(sample: :batch).where("batches.batch_number LIKE concat('%', ?, '%')", params[:batch_number]) unless params[:batch_number].blank?

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -1,0 +1,15 @@
+class SampleTransfersController < ApplicationController
+  def index
+    @sample_transfers = SampleTransfer
+      .within(@navigation_context.institution)
+      .includes(:receiver_institution, :sender_institution, sample: [:sample_identifiers])
+
+    @sample_transfers = @sample_transfers.joins(sample: :sample_identifiers).where("sample_identifiers.uuid LIKE concat('%', ?, '%')", params[:sample_id]) unless params[:sample_id].blank?
+    @sample_transfers = @sample_transfers.joins(sample: :batch).where("batches.batch_number LIKE concat('%', ?, '%')", params[:batch_number]) unless params[:batch_number].blank?
+    @sample_transfers = @sample_transfers.joins(:sample).where("samples.isolate_name LIKE concat('%', ?, '%')", params[:isolate_name]) unless params[:isolate_name].blank?
+    @sample_transfers = @sample_transfers.joins(:sample).where("samples.specimen_role = ?", params[:specimen_role]) unless params[:specimen_role].blank?
+
+    @sample_transfers = perform_pagination(@sample_transfers)
+    @sample_transfers = @sample_transfers.map { |t| SampleTransferPresenter.new(t, @navigation_context) }
+  end
+end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -216,6 +216,13 @@ class SamplesController < ApplicationController
       samples.each do |to_transfer|
         raise "User not authorized for transferring Samples " unless authorize_resource?(to_transfer, UPDATE_SAMPLE)
 
+        transfer = SampleTransfer.new(
+          sample: to_transfer,
+          receiver_institution: new_owner,
+        )
+        transfer.confirm
+        transfer.save!
+
         unless to_transfer.batch.nil?
           if params["includes_qc_info"] == "true"
             qc_info = create_qc_info(to_transfer)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -13,6 +13,7 @@ class Sample < ActiveRecord::Base
 
   has_many :sample_identifiers, inverse_of: :sample, dependent: :destroy
   has_many :test_results, through: :sample_identifiers
+  has_many :sample_transfers, dependent: :destroy
 
   has_many :assay_attachments, dependent: :destroy
   accepts_nested_attributes_for :assay_attachments, allow_destroy: true

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -1,0 +1,36 @@
+class SampleTransfer < ActiveRecord::Base
+  belongs_to :sample
+  belongs_to :sender_institution, class_name: "Institution"
+  belongs_to :receiver_institution, class_name: "Institution"
+
+  validates_presence_of :sample
+  validates_presence_of :sender_institution
+  validates_presence_of :receiver_institution
+
+  after_initialize do
+    self.sender_institution ||= sample.try &:institution
+  end
+
+  scope :within, ->(institution) {
+          where("sender_institution_id = ? OR receiver_institution_id = ?", institution.id, institution.id)
+        }
+
+  def confirm
+    if confirmed?
+      self.errors.add(:confirmed_at, "Already confirmed.")
+      false
+    else
+      self.confirmed_at = Time.now
+      true
+    end
+  end
+
+  def confirm!
+    confirm
+    save!
+  end
+
+  def confirmed?
+    !!confirmed_at
+  end
+end

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -15,6 +15,10 @@ class SampleTransfer < ActiveRecord::Base
           where("sender_institution_id = ? OR receiver_institution_id = ?", institution.id, institution.id)
         }
 
+  scope :ordered_by_creation, -> {
+          order(created_at: :desc)
+        }
+
   def confirm
     if confirmed?
       self.errors.add(:confirmed_at, "Already confirmed.")

--- a/app/presenters/sample_transfer_presenter.rb
+++ b/app/presenters/sample_transfer_presenter.rb
@@ -1,0 +1,44 @@
+class SampleTransferPresenter
+  attr_reader :transfer, :context, :current_user
+
+  def initialize(transfer, context)
+    @transfer = transfer
+    @context = context
+  end
+
+  delegate :sample, :confirmed_at, :confirmed?, to: :transfer
+
+  def receiver?
+    context.institution == transfer.receiver_institution
+  end
+
+  def sender?
+    context.institution == transfer.sender_institution
+  end
+
+  def other_institution
+    if sender?
+      transfer.receiver_institution
+    elsif receiver?
+      transfer.sender_institution
+    else
+      nil
+    end
+  end
+
+  def can_confirm?
+    true
+  end
+
+  def status
+    confirmed? ? "confirmed" : "in-transit"
+  end
+
+  def relation
+    if receiver?
+      "receiver"
+    elsif sender?
+      "sender"
+    end
+  end
+end

--- a/app/presenters/sample_transfer_presenter.rb
+++ b/app/presenters/sample_transfer_presenter.rb
@@ -6,7 +6,8 @@ class SampleTransferPresenter
     @context = context
   end
 
-  delegate :sample, :confirmed_at, :confirmed?, to: :transfer
+  # TODO(Rails 5.1): Use delegate_missing
+  delegate :sample, :confirmed_at, :confirmed?, :created_at, :receiver_institution, :sender_institution, to: :transfer
 
   def receiver?
     context.institution == transfer.receiver_institution

--- a/app/views/batches/index.haml
+++ b/app/views/batches/index.haml
@@ -50,6 +50,8 @@
         .icon-sample.tab-sample{title: "Samples"}
       .selected-icon-tab
         .icon-batch.tab-batch.selected{title: "Batches"}
+      = link_to sample_transfers_path do
+        .icon-transfer.tab-transfer{title: "Transfers"}
 
 = render 'index_js'
 = render 'samples/index_bulk_actions_js'

--- a/app/views/sample_transfers/_filters.haml
+++ b/app/views/sample_transfers/_filters.haml
@@ -1,0 +1,25 @@
+- content_for(:subheader) do
+  .row.center.filters
+    .col.pe-10
+      .row
+        .col
+          %h1
+            Samples
+
+      %form#filters-form{action: sample_transfers_path, "data-auto-submit" => true}
+        %input{type: "hidden", name: "page_size", value: @page_size}
+        .row
+          .filter
+            %label.block{for: "sample_id"} Sample ID
+            %input.input-x-large{type: "text", name: "sample_id", id: "sample_id", value: params["sample_id"], placeholder: "Filter by Sample ID"}
+          .filter
+            %label.block{for: "batch_id"} Batch ID
+            %input.input-x-large{type: "text", name: "batch_number", id: "batch_number", value: params["batch_number"], placeholder: "Filter by batch ID"}
+          .filter
+            %label.block{for: "isolate_name"} Isolate Name
+            %input.input-x-large{type: "text", name: "isolate_name", id: "isolate_name", value: params["isolate_name"], placeholder: "Filter by isolate name"}
+          .filter
+            %label.block{for: "specimen_role"} Specimen Role
+            = cdx_select name: "specimen_role", value: params["specimen_role"] do |specimen_role|
+              - specimen_role.item "", "All specimen roles"
+              - specimen_role.items Sample.specimen_roles.map{|item| {id: item[:id], description: item[:description].truncate(30) }}, :id, :description

--- a/app/views/sample_transfers/index.haml
+++ b/app/views/sample_transfers/index.haml
@@ -23,23 +23,25 @@
             %th Status
         - t.tbody do
           - @sample_transfers.each do |transfer|
-            %tr.laboratory-sample-row{class: ("faded" unless transfer.confirmed?)}
+            %tr.laboratory-sample-row{class: ("faded" if transfer.confirmed?)}
               %td= transfer.sample.uuid
               %td= transfer.sample.isolate_name
               %td= transfer.sample.inactivation_method
               %td= transfer.other_institution
-              %td
-                - if confirmed_at = transfer.confirmed_at
-                  = transfer.receiver? ? "Received" : "Sent"
-                  = time_tag confirmed_at, I18n.l(confirmed_at, format: I18n.t("date.formats.long")), title: I18n.l(confirmed_at)
-                - else
+              - if confirmed_at = transfer.confirmed_at
+                %td{title: "#{transfer.receiver_institution} confirmed receipt on #{I18n.l(confirmed_at)}"}
+                  = transfer.receiver? ? "Receipt confirmed on" : "Delivery confirmed on"
+                  = time_tag confirmed_at, I18n.l(confirmed_at, format: I18n.t("date.formats.long"))
+              - else
+                %td{title: "#{transfer.sender_institution} sent on #{I18n.l(transfer.created_at)}, unconfirmed by #{transfer.receiver_institution}"}
                   - if transfer.receiver?
                     - if transfer.can_confirm?
                       %button{disabled: "disabled"} Confirm receipt
                     - else
                       Unconfirmed
                   - else
-                    Pending
+                    Sent on
+                    = time_tag transfer.created_at, I18n.l(transfer.created_at, format: I18n.t("date.formats.long"))
 
       .pagination
         = render 'shared/pagination'

--- a/app/views/sample_transfers/index.haml
+++ b/app/views/sample_transfers/index.haml
@@ -1,0 +1,55 @@
+= render "filters"
+
+.row
+  .col
+    - if @sample_transfers.empty?
+      = empty_data icon: 'icon-outline-test xx-large' do |c|
+        - c.body do
+          %h1 There are no sample transfers
+    - else
+      = cdx_table title: pluralize(@total, "sample transfer") do |t|
+        - t.columns do
+          %col{:width => "20%"}
+          %col{:width => "20%"}
+          %col{:width => "20%"}
+          %col{:width => "20%"}
+          %col{:width => "25%"}
+        - t.thead do
+          %tr
+            %th Sample Id
+            %th Isolate Name
+            %th Inactivation Method
+            %th Transfer
+            %th Status
+        - t.tbody do
+          - @sample_transfers.each do |transfer|
+            %tr.laboratory-sample-row{class: ("faded" unless transfer.confirmed?)}
+              %td= transfer.sample.uuid
+              %td= transfer.sample.isolate_name
+              %td= transfer.sample.inactivation_method
+              %td= transfer.other_institution
+              %td
+                - if confirmed_at = transfer.confirmed_at
+                  = transfer.receiver? ? "Received" : "Sent"
+                  = time_tag confirmed_at, I18n.l(confirmed_at, format: I18n.t("date.formats.long")), title: I18n.l(confirmed_at)
+                - else
+                  - if transfer.receiver?
+                    - if transfer.can_confirm?
+                      %button{disabled: "disabled"} Confirm receipt
+                    - else
+                      Unconfirmed
+                  - else
+                    Pending
+
+      .pagination
+        = render 'shared/pagination'
+
+  .col.pe-1.tab-buttons
+    .tab-separator
+    .icons-group
+      = link_to samples_path do
+        .icon-sample.tab-sample{title: "Samples"}
+      = link_to batches_path do
+        .icon-batch.tab-batch{title: "Batches"}
+      .selected-icon-tab
+        .icon-transfer.tab-transfer.selected{title: "Transfers"}

--- a/app/views/samples/index.haml
+++ b/app/views/samples/index.haml
@@ -56,6 +56,8 @@
         .icon-sample.tab-sample.selected{title: "Samples"}
       = link_to batches_path do
         .icon-batch.tab-batch{title: "Batches"}
+      = link_to sample_transfers_path do
+        .icon-transfer.tab-transfer{title: "Transfers"}
 
 = render 'index_js'
 = render 'index_bulk_actions_js'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
       post 'reprocess'
     end
   end
+  resources :sample_transfers, only: [:index]
   resources :samples do
     member do
       get 'print'

--- a/db/migrate/20220221152647_create_sample_transfers.rb
+++ b/db/migrate/20220221152647_create_sample_transfers.rb
@@ -1,0 +1,16 @@
+class CreateSampleTransfers < ActiveRecord::Migration
+  def change
+    create_table :sample_transfers do |t|
+      t.references :sample
+      t.references :sender_institution
+      t.references :receiver_institution
+      t.datetime :confirmed_at
+
+      t.timestamps null: false
+    end
+    add_index :sample_transfers, :sample_id
+    add_index :sample_transfers, :sender_institution_id
+    add_index :sample_transfers, :receiver_institution_id
+    add_index :sample_transfers, :confirmed_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220222115959) do
+ActiveRecord::Schema.define(version: 20220221152647) do
 
   create_table "alert_condition_results", force: :cascade do |t|
     t.string  "result",   limit: 255
@@ -532,6 +532,20 @@ ActiveRecord::Schema.define(version: 20220222115959) do
   add_index "sample_identifiers", ["entity_id"], name: "index_sample_identifiers_on_entity_id", using: :btree
   add_index "sample_identifiers", ["sample_id"], name: "index_sample_identifiers_on_sample_id", using: :btree
   add_index "sample_identifiers", ["uuid"], name: "index_sample_identifiers_on_uuid", unique: true, using: :btree
+
+  create_table "sample_transfers", force: :cascade do |t|
+    t.integer  "sample_id",               limit: 4
+    t.integer  "sender_institution_id",   limit: 4
+    t.integer  "receiver_institution_id", limit: 4
+    t.datetime "confirmed_at"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+  end
+
+  add_index "sample_transfers", ["confirmed_at"], name: "index_sample_transfers_on_confirmed_at", using: :btree
+  add_index "sample_transfers", ["receiver_institution_id"], name: "index_sample_transfers_on_receiver_institution_id", using: :btree
+  add_index "sample_transfers", ["sample_id"], name: "index_sample_transfers_on_sample_id", using: :btree
+  add_index "sample_transfers", ["sender_institution_id"], name: "index_sample_transfers_on_sender_institution_id", using: :btree
 
   create_table "samples", force: :cascade do |t|
     t.binary   "sensitive_data",   limit: 65535

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220221152647) do
+ActiveRecord::Schema.define(version: 20220222115959) do
 
   create_table "alert_condition_results", force: :cascade do |t|
     t.string  "result",   limit: 255
@@ -538,8 +538,8 @@ ActiveRecord::Schema.define(version: 20220221152647) do
     t.integer  "sender_institution_id",   limit: 4
     t.integer  "receiver_institution_id", limit: 4
     t.datetime "confirmed_at"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
   end
 
   add_index "sample_transfers", ["confirmed_at"], name: "index_sample_transfers_on_confirmed_at", using: :btree

--- a/features/support/page_objects/sample_transfer_page.rb
+++ b/features/support/page_objects/sample_transfer_page.rb
@@ -1,0 +1,21 @@
+class ListSampleTransfersPage < CdxPageBase
+  set_url "/sample_transfers"
+
+  section :filters, "#filters-form" do
+    element :sample_id, :field, "Sample ID"
+    element :batch_number, :field, "Batch Number"
+    element :isolate_name, :field, "Isolate Name"
+    element :specimen_role, :field, "Specimen Role"
+
+    include CdxPageHelper
+
+    def submit
+      root_element.native.send_keys :enter
+      wait_for_submit
+    end
+  end
+
+  def entry(uuid)
+    find("tr", text: uuid)
+  end
+end

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe SampleTransfersController, type: :controller do
       expect(assigns(:sample_transfers)).to be_empty
     end
 
+    it "orders transfers by creation date" do
+      sample_transfers = [
+        SampleTransfer.make!(sender_institution: my_institution, created_at: Time.now - 1.day),
+        SampleTransfer.make!(receiver_institution: my_institution, created_at: Time.now),
+      ]
+      get :index
+      expect(assigns(:sample_transfers).map(&:transfer)).to eq sample_transfers.reverse
+    end
+
     describe "filters" do
       let!(:subject) { SampleTransfer.make!(sender_institution: my_institution, sample: Sample.make!(:filled, batch: Batch.make!, specimen_role: "c")) }
       let!(:other) { SampleTransfer.make!(receiver_institution: my_institution, sample: Sample.make!(:filled, batch: Batch.make!)) }

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+RSpec.describe SampleTransfersController, type: :controller do
+  let!(:my_institution) { Institution.make! }
+  let!(:other_institution) { Institution.make! }
+  let!(:current_user) { my_institution.user }
+  let(:default_params) { { context: my_institution.uuid } }
+
+  describe "GET #index" do
+    before(:each) do
+      sign_in current_user
+    end
+
+    it "includes transfers from and to my institution" do
+      sample_transfers = [
+        SampleTransfer.make!(sender_institution: my_institution),
+        SampleTransfer.make!(receiver_institution: my_institution),
+      ]
+      get :index
+      expect(assigns(:sample_transfers).map(&:transfer)).to eq sample_transfers
+    end
+
+    it "excludes transfers not from or to my institution" do
+      SampleTransfer.make!
+      get :index
+      expect(assigns(:sample_transfers)).to be_empty
+    end
+
+    describe "filters" do
+      let!(:subject) { SampleTransfer.make!(sender_institution: my_institution, sample: Sample.make!(:filled, batch: Batch.make!, specimen_role: "c")) }
+      let!(:other) { SampleTransfer.make!(receiver_institution: my_institution, sample: Sample.make!(:filled, batch: Batch.make!)) }
+
+      it "by sample id" do
+        get :index, sample_id: subject.sample.uuid[0..8]
+        expect(assigns(:sample_transfers).map(&:transfer)).to eq [subject]
+      end
+
+      it "by batch_name" do
+        get :index, batch_number: subject.sample.batch.batch_number
+        expect(assigns(:sample_transfers).map(&:transfer)).to eq [subject]
+      end
+
+      it "by isolate_name" do
+        get :index, isolate_name: subject.sample.isolate_name
+        expect(assigns(:sample_transfers).map(&:transfer)).to eq [subject]
+      end
+
+      it "by specimen_role" do
+        get :index, specimen_role: subject.sample.specimen_role
+        expect(assigns(:sample_transfers).map(&:transfer)).to eq [subject]
+      end
+
+      it "combined" do
+        get :index, sample_id: subject.sample.uuid[0..8], batch_number: subject.sample.batch.batch_number, isolate_name: subject.sample.isolate_name, specimen_role: subject.sample.specimen_role
+        expect(assigns(:sample_transfers).map(&:transfer)).to eq [subject]
+      end
+    end
+  end
+end

--- a/spec/features/sample_transfers_spec.rb
+++ b/spec/features/sample_transfers_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe "sample transfers" do
+  describe "index" do
+    let!(:my_institution) { Institution.make! }
+    let!(:other_institution) { Institution.make! }
+    let!(:current_user) { my_institution.user }
+
+    before(:each) do
+      sign_in(current_user)
+    end
+
+    it "shows status" do
+      in_pending = SampleTransfer.make!(receiver_institution: my_institution)
+      in_confirmed = SampleTransfer.make!(receiver_institution: my_institution, confirmed_at: Time.new(2022, 2, 24, 15, 31))
+      out_pending = SampleTransfer.make!(sender_institution: my_institution)
+      out_confirmed = SampleTransfer.make!(sender_institution: my_institution, confirmed_at: Time.new(2022, 2, 21, 12, 00))
+      unrelated = SampleTransfer.make!
+
+      goto_page ListSampleTransfersPage do |page|
+        expect(page.entry(in_pending.sample.uuid)).to have_content("Confirm receipt")
+        expect(page.entry(in_confirmed.sample.uuid)).to have_content("Received February 24, 2022")
+        expect(page.entry(out_pending.sample.uuid)).to have_content("Pending")
+        expect(page.entry(out_confirmed.sample.uuid)).to have_content("Sent February 21, 2022")
+
+        expect(page).not_to have_content(unrelated.sample.uuid)
+      end
+    end
+
+    it "filters" do
+      subject = SampleTransfer.make!(receiver_institution: my_institution)
+      other = SampleTransfer.make!(receiver_institution: my_institution)
+
+      goto_page ListSampleTransfersPage do |page|
+        page.filters.sample_id.set subject.sample.uuid
+        page.filters.submit
+      end
+
+      expect_page ListSampleTransfersPage do |page|
+        expect(page.entry(subject.sample.uuid))
+
+        expect(page).not_to have_content(other.sample.uuid)
+      end
+    end
+  end
+end

--- a/spec/features/sample_transfers_spec.rb
+++ b/spec/features/sample_transfers_spec.rb
@@ -11,17 +11,17 @@ describe "sample transfers" do
     end
 
     it "shows status" do
-      in_pending = SampleTransfer.make!(receiver_institution: my_institution)
+      in_pending = SampleTransfer.make!(receiver_institution: my_institution, created_at: Time.new(2022, 3, 4))
       in_confirmed = SampleTransfer.make!(receiver_institution: my_institution, confirmed_at: Time.new(2022, 2, 24, 15, 31))
-      out_pending = SampleTransfer.make!(sender_institution: my_institution)
+      out_pending = SampleTransfer.make!(sender_institution: my_institution, created_at: Time.new(2022, 3, 4))
       out_confirmed = SampleTransfer.make!(sender_institution: my_institution, confirmed_at: Time.new(2022, 2, 21, 12, 00))
       unrelated = SampleTransfer.make!
 
       goto_page ListSampleTransfersPage do |page|
         expect(page.entry(in_pending.sample.uuid)).to have_content("Confirm receipt")
-        expect(page.entry(in_confirmed.sample.uuid)).to have_content("Received February 24, 2022")
-        expect(page.entry(out_pending.sample.uuid)).to have_content("Pending")
-        expect(page.entry(out_confirmed.sample.uuid)).to have_content("Sent February 21, 2022")
+        expect(page.entry(in_confirmed.sample.uuid)).to have_content("Receipt confirmed on February 24, 2022")
+        expect(page.entry(out_pending.sample.uuid)).to have_content("Sent on March 04, 2022")
+        expect(page.entry(out_confirmed.sample.uuid)).to have_content("Delivery confirmed on February 21, 2022")
 
         expect(page).not_to have_content(unrelated.sample.uuid)
       end

--- a/spec/models/sample_transfer_spec.rb
+++ b/spec/models/sample_transfer_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe SampleTransfer, type: :model do
+  let(:sample) { Sample.make }
+  let(:sender) { Institution.make }
+  let(:receiver) { Institution.make }
+
+  it "sets sender institution from sample" do
+    expect(SampleTransfer.new(sample: sample).sender_institution).to eq sample.institution
+  end
+
+  it "validates presence of references" do
+    transfer = SampleTransfer.new(sample: sample, receiver_institution: receiver, sender_institution: sender)
+    expect(transfer).to be_valid
+    expect(transfer).to validate_presence_of(:sample)
+    expect(transfer).to validate_presence_of(:receiver_institution)
+    expect(transfer).to validate_presence_of(:sender_institution)
+  end
+
+  describe ".within" do
+    it "selects by sender institution" do
+      transfer = SampleTransfer.make!
+      expect(SampleTransfer.within(transfer.sender_institution)).to match_array [transfer]
+    end
+
+    it "selects by receiver institution" do
+      transfer = SampleTransfer.make!
+      expect(SampleTransfer.within(transfer.receiver_institution)).to match_array [transfer]
+    end
+
+    it "rejects other institution" do
+      SampleTransfer.make!
+      expect(SampleTransfer.within(Institution.make!)).to be_empty
+    end
+  end
+
+  describe "#confirm" do
+    it "sets confirmed_at" do
+      transfer = SampleTransfer.make
+      expect(transfer).not_to be_confirmed
+
+      Timecop.freeze do
+        expect(transfer.confirm).to be true
+        expect(transfer.confirmed_at).to eq Time.now
+      end
+
+      expect(transfer).to be_confirmed
+    end
+
+    it "errors if already confirmed" do
+      transfer = SampleTransfer.make(:confirmed)
+      expect { transfer.confirm }.not_to change { transfer.confirmed_at }
+      expect(transfer.confirm).to be false
+      expect(transfer.errors).to have_key(:confirmed_at)
+    end
+  end
+end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -142,6 +142,16 @@ LoincCode.blueprint do
   component { Faker::Lorem.words(4) }
 end
 
+SampleTransfer.blueprint do
+  sample { Sample.make! }
+  receiver_institution { Institution.make! }
+  sender_institution { object.sample.institution }
+end
+
+SampleTransfer.blueprint(:confirmed) do
+  confirmed_at { Faker::Time.backward }
+end
+
 Batch.blueprint do
   institution { object.encounter.try(:institution) || object.patient.try(:institution) || Institution.make }
   batch_number { '000' }

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -127,8 +127,20 @@ SampleIdentifier.blueprint do
 end
 
 Sample.blueprint do
-  institution { object.encounter.try(:institution) || object.patient.try(:institution) || Institution.make }
+  institution { object.encounter.try(:institution) || object.patient.try(:institution) || Institution.make! }
   patient { object.encounter.try(:patient) }
+end
+
+# FIXME: These properties should probably be part of the main blueprint, but that breaks a number of different existing specs.
+Sample.blueprint(:filled) do
+  institution { object.encounter.try(:institution) || object.patient.try(:institution) || Institution.make! }
+  sample_identifiers { [SampleIdentifier.make!(sample: object)] }
+  isolate_name { Faker::Name.name }
+  specimen_role { "p" }
+end
+
+Sample.blueprint(:batch) do
+  batch { Batch.make! }
 end
 
 AssayAttachment.blueprint do
@@ -143,7 +155,7 @@ LoincCode.blueprint do
 end
 
 SampleTransfer.blueprint do
-  sample { Sample.make! }
+  sample { Sample.make!(:filled) }
   receiver_institution { Institution.make! }
   sender_institution { object.sample.institution }
 end
@@ -153,11 +165,11 @@ SampleTransfer.blueprint(:confirmed) do
 end
 
 Batch.blueprint do
-  institution { object.encounter.try(:institution) || object.patient.try(:institution) || Institution.make }
-  batch_number { '000' }
+  institution { Institution.make }
+  batch_number { "#{sn}" }
   isolate_name { 'ABC.42.DE' }
   date_produced { Time.strptime('01/01/2018', I18n.t('date.input_format.pattern')) }
-  lab_technician { 'Tec.Foo' }
+  lab_technician { "Tec.Foo" }
   specimen_role { 'q' }
   inactivation_method { 'Formaldehyde' }
   volume { 100 }


### PR DESCRIPTION
Resolves #1390

I didn't add test cases for creating `SampleTransfer` entries because this logic will be changed in the next iteration #1389. It makes more sense to add specs then.