### PR TITLE
Implement sample transfer workflow with confirming receipt

### DIFF
--- a/app/assets/javascripts/sample_transfer.js.jsx
+++ b/app/assets/javascripts/sample_transfer.js.jsx
@@ -51,8 +51,8 @@ var SampleTransferModal = React.createClass({
       samples: this.state.selectedSamples.map((sample) => sample.uuid)
     }
     $.ajax({
-      url: '/samples/transfer',
-      method: 'GET',
+      url: '/sample_transfers',
+      method: 'POST',
       data: data,
       success: function () {
         this.closeModal();

--- a/app/assets/javascripts/sample_transfer_confirm.js.jsx
+++ b/app/assets/javascripts/sample_transfer_confirm.js.jsx
@@ -1,0 +1,77 @@
+var SampleTransferConfirm = React.createClass({
+
+  getInitialState: function() {
+    return {
+      title: 'Confirm receipt'
+    };
+  },
+
+  openTransferModal: function(event) {
+    this.refs.transferModal.show();
+    event.preventDefault();
+  },
+
+  closeTransferModal: function() {
+    this.refs.transferModal.hide();
+  },
+
+  render: function() {
+    return (<span>
+      <a href="#" className="action" onClick={this.openTransferModal} >
+        <div className="icon-check_circle icon-blue" /> Confirm receipt
+      </a>
+      <Modal ref="transferModal">
+        <h1>{this.state.title}</h1>
+        <SampleTransferConfirmModal onFinished={this.closeTransferModal} url={this.props.url} />
+      </Modal>
+    </span>);
+  }
+});
+
+var SampleTransferConfirmModal = React.createClass({
+  getInitialState: function() {
+    return {
+    };
+  },
+
+  closeModal: function(event) {
+    if(event) {
+      event.preventDefault();
+    }
+
+    this.props.onFinished();
+  },
+
+  confirmTransfer: function(event) {
+    if(event) {
+      event.preventDefault();
+    }
+
+    $.ajax({
+      url: this.props.url,
+      method: 'PATCH',
+      success: function () {
+        this.closeModal();
+        window.location.reload(true); // reload page to update users table
+      }.bind(this)
+    });
+  },
+
+  render: function() {
+    return(
+      <form onSubmit={this.confirmTransfer}>
+        <div className="samples-transfer-modal">
+          <div className="modal-footer">
+            <div className="footer-buttons-aligning">
+              <div>
+                <button id="samples-transfer-form-submit" className="btn btn-primary" type="submit">Confirm</button>
+                <button className="btn btn-link" type="button" onClick={this.closeModal}>Cancel</button>
+              </div>
+              <div />
+            </div>
+          </div>
+        </div>
+      </form>
+    )
+  },
+});

--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -29,6 +29,10 @@ h4 {
 }
 a {
   color: $blue;
+
+  html &.action {
+    color: $blue;
+  }
 }
 hr {
   border: none;

--- a/app/assets/stylesheets/_sprites.scss
+++ b/app/assets/stylesheets/_sprites.scss
@@ -357,7 +357,9 @@
 .icon-send:before {
   content: "\e95c";
 }
-
+.icon-check_circle:before {
+  content: "\e95d";
+}
 
 
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,24 +53,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  #TODO: refactor authorize_resource and authorize_resource? as both share almost the same code
-  def authorize_resource?(resource, action)
-    if has_access?(resource, action)
-      check_access(resource, action)
-    else
-      false
-    end
-  end
-
-  #TODO: refactor authorize_resource and authorize_resource? as both share almost the same code
-  def authorize_resource?(resource, action)
-    if has_access?(resource, action)
-      check_access(resource, action)
-    else
-      false
-    end
-  end
-
   def authorize_resources(resources, action)
     resources.all? { | resource | authorize_resource(resource, action) }
   end
@@ -211,9 +193,11 @@ class ApplicationController < ActionController::Base
   end
 
   def log_authorization_warn(resource, action)
-    resource_name =
-      if resource.is_a? Class
+    resource_name = case resource
+      when Class
         "#{resource} class"
+      when Hash
+        "#{resource[:resource_type].camelize} (id=#{resource[:resource_id]})"
       else
         "#{resource.class} (id=#{resource.id})"
       end

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -31,12 +31,7 @@ class SampleTransfersController < ApplicationController
   end
 
   def confirm
-    transfer = SampleTransfer.find(params[:sample_transfer_id])
-
-    unless transfer.receiver_institution == @navigation_context.institution
-      render json: { status: "error" }, status: :not_found
-      return
-    end
+    transfer = SampleTransfer.with_receiver(@navigation_context.institution).find(params[:sample_transfer_id])
 
     resource = {
       resource_type: "sample",

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -46,7 +46,12 @@ class SampleTransfersController < ApplicationController
       return
     end
 
-    transfer.confirm_and_apply!
+    unless transfer.confirm_and_apply
+      flash[:error] = "Sample transfer has already been confirmed"
+
+      render json: { status: "error" }, status: :bad_request
+      return
+    end
 
     flash[:success] = "Sample has been confirmed."
 

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -30,6 +30,16 @@ class SampleTransfersController < ApplicationController
     end
   end
 
+  def confirm
+    transfer = SampleTransfer.find(params[:sample_transfer_id])
+
+    transfer.confirm_and_apply!
+
+    flash[:success] = "Sample has been confirmed."
+
+    render json: { status: :ok }
+  end
+
   private
 
   def create_transfer(new_owner, samples)

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -17,17 +17,18 @@ class SampleTransfersController < ApplicationController
   def create
     new_owner = Institution.find_by(uuid: params["institution_id"])
     if new_owner.nil?
-      flash[:notice] = "Destination Institution does not exists"
+      flash[:error] = "Destination Institution does not exists"
+      render json: { status: :error }, status: 404
     else
       begin
         change_ownership(new_owner)
-        flash[:notice] = "All samples has been transferred successfully."
+        flash[:success] = "All samples have been transferred successfully."
+        render json: { status: :ok }
       rescue
-        flash[:notice] = "Samples transfer failed."
+        flash[:error] = "Samples transfer failed."
+        render json: { status: :error }, status: 500
       end
     end
-
-    render json: { status: :ok }
   end
 
   private

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -38,25 +38,14 @@ class SampleTransfersController < ApplicationController
       samples.each do |to_transfer|
         raise "User not authorized for transferring Samples " unless authorize_resource?(to_transfer, UPDATE_SAMPLE)
 
-        transfer = SampleTransfer.new(
-          sample: to_transfer,
-          receiver_institution: new_owner,
-        )
-        transfer.confirm
-        transfer.save!
-
         unless to_transfer.batch.nil?
           if params["includes_qc_info"] == "true"
             qc_info = create_qc_info(to_transfer)
             to_transfer.qc_info_id = qc_info.id if qc_info
-            to_transfer.old_batch_number = to_transfer.batch.batch_number
           end
         end
 
-        to_transfer.batch_id = nil
-        to_transfer.site_id = nil
-        to_transfer.institution = new_owner
-        to_transfer.save!
+        to_transfer.start_transfer_to(new_owner)
       end
     end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -5,7 +5,7 @@ class SamplesController < ApplicationController
     @can_create = has_access?(@navigation_context.institution, CREATE_INSTITUTION_SAMPLE)
 
     @samples = Sample.where(institution: @navigation_context.institution)
-    @samples = check_access(@samples, READ_SAMPLE).order('created_at DESC')
+    @samples = check_access(@samples, READ_SAMPLE).order("created_at DESC")
 
     @samples = @samples.within(@navigation_context.entity, @navigation_context.exclude_subsites)
 
@@ -18,7 +18,7 @@ class SamplesController < ApplicationController
       .where()
       .not(uuid: @navigation_context.institution.uuid)
       .pluck(:uuid, :name)
-      .map{|uuid, name| {value: uuid, label: name}}
+      .map { |uuid, name| { value: uuid, label: name } }
 
     @samples = perform_pagination(@samples)
   end
@@ -28,7 +28,7 @@ class SamplesController < ApplicationController
     @sample_form = SampleForm.for(sample)
     return unless authorize_resource(sample, READ_SAMPLE)
 
-    @view_helper = view_helper({save_back_path: true})
+    @view_helper = view_helper({ save_back_path: true })
 
     @show_barcode_preview = true
     @show_print_action = true
@@ -36,7 +36,7 @@ class SamplesController < ApplicationController
     @can_delete = false
     @can_update = false
 
-    render action: 'edit'
+    render action: "edit"
   end
 
   def new
@@ -45,13 +45,13 @@ class SamplesController < ApplicationController
     sample = Sample.new({
       institution: @navigation_context.institution,
       site: @navigation_context.site,
-      sample_identifiers: [SampleIdentifier.new({uuid: session[:creating_sample_uuid]})]
+      sample_identifiers: [SampleIdentifier.new({ uuid: session[:creating_sample_uuid] })],
     })
 
     @sample_form = SampleForm.for(sample)
     prepare_for_institution_and_authorize(@sample_form, CREATE_INSTITUTION_SAMPLE)
 
-    @view_helper = view_helper({save_back_path: true})
+    @view_helper = view_helper({ save_back_path: true })
     @show_barcode_preview = false
     @can_update = true
   end
@@ -62,24 +62,24 @@ class SamplesController < ApplicationController
 
     uuid = session[:creating_sample_uuid]
     if uuid.blank?
-      redirect_to new_sample_path, notice: 'There was an error creating the sample'
+      redirect_to new_sample_path, notice: "There was an error creating the sample"
       return
     end
 
     sample = Sample.new(sample_params.merge({
       institution: institution,
       site: @navigation_context.site,
-      sample_identifiers: [SampleIdentifier.new({uuid: uuid})]
+      sample_identifiers: [SampleIdentifier.new({ uuid: uuid })],
     }))
     @sample_form = SampleForm.for(sample)
 
     if @sample_form.save
       session.delete(:creating_sample_uuid)
-      redirect_to samples_path, notice: 'Sample was successfully created.'
+      redirect_to samples_path, notice: "Sample was successfully created."
     else
       @view_helper = view_helper
       @can_update = true
-      render action: 'new'
+      render action: "new"
     end
   end
 
@@ -90,20 +90,20 @@ class SamplesController < ApplicationController
     @show_print_action = false
 
     render pdf: "cdx_sample_#{@sample.uuid}",
-      template: 'samples/barcode.pdf',
-      layout: 'layouts/pdf.html',
+      template: "samples/barcode.pdf",
+      layout: "layouts/pdf.html",
       locals: { :sample => @sample },
       margin: { top: 0, bottom: 0, left: 0, right: 0 },
-      page_width: '1in',
-      page_height: '1in',
-      show_as_html: params.key?('debug')
+      page_width: "1in",
+      page_height: "1in",
+      show_as_html: params.key?("debug")
   end
 
   def bulk_print
     sample_ids = params[:sample_ids]
 
     if sample_ids.blank?
-      redirect_to samples_path, notice: 'Select at least one sample to print.'
+      redirect_to samples_path, notice: "Select at least one sample to print."
       return
     end
 
@@ -111,24 +111,24 @@ class SamplesController < ApplicationController
     return unless authorize_resources(samples, READ_SAMPLE)
 
     sample_strings = samples.map do |sample|
-      render_to_string template: 'samples/barcode.pdf',
-        layout: 'layouts/pdf.html',
-        locals: {:sample => sample}
+      render_to_string template: "samples/barcode.pdf",
+        layout: "layouts/pdf.html",
+        locals: { :sample => sample }
     end
 
     options = {
       margin: { top: 0, bottom: 0, left: 0, right: 0 },
-      page_width: '1in',
-      page_height: '1in'
+      page_width: "1in",
+      page_height: "1in",
     }
 
     begin
       pdf_file = MultipagePdfRenderer.combine(sample_strings, options)
-      pdf_filename = "cdx_samples_#{samples.size}_#{DateTime.now.strftime('%Y%m%d-%H%M')}.pdf"
+      pdf_filename = "cdx_samples_#{samples.size}_#{DateTime.now.strftime("%Y%m%d-%H%M")}.pdf"
 
-      send_data pdf_file, type: 'application/pdf', filename: pdf_filename
+      send_data pdf_file, type: "application/pdf", filename: pdf_filename
     rescue
-      redirect_to samples_path, notice: 'There was an error creating the print file.'
+      redirect_to samples_path, notice: "There was an error creating the print file."
     end
   end
 
@@ -137,7 +137,7 @@ class SamplesController < ApplicationController
     @sample_form = SampleForm.for(sample)
     return unless authorize_resource(sample, UPDATE_SAMPLE)
 
-    @view_helper = view_helper({save_back_path: true})
+    @view_helper = view_helper({ save_back_path: true })
 
     @show_barcode_preview = true
     @show_print_action = true
@@ -153,16 +153,16 @@ class SamplesController < ApplicationController
 
     params = sample_params
     unless user_can_delete_notes(params["notes_attributes"] || [])
-      redirect_to edit_sample_path(sample.id), notice: 'Update failed: Notes can only be deleted by their authors'
+      redirect_to edit_sample_path(sample.id), notice: "Update failed: Notes can only be deleted by their authors"
       return
     end
 
     if @sample_form.update(sample_params)
-      redirect_to back_path, notice: 'Sample was successfully updated.'
+      redirect_to back_path, notice: "Sample was successfully updated."
     else
       @view_helper = view_helper
       @can_update = true
-      render action: 'edit'
+      render action: "edit"
     end
   end
 
@@ -172,14 +172,14 @@ class SamplesController < ApplicationController
 
     @sample.destroy
 
-    redirect_to samples_path, notice: 'Sample was successfully deleted.'
+    redirect_to samples_path, notice: "Sample was successfully deleted."
   end
 
   def bulk_destroy
     sample_ids = params[:sample_ids]
 
     if sample_ids.blank?
-      redirect_to samples_path, notice: 'Select at least one sample to destroy.'
+      redirect_to samples_path, notice: "Select at least one sample to destroy."
       return
     end
 
@@ -188,65 +188,10 @@ class SamplesController < ApplicationController
 
     samples.destroy_all
 
-    redirect_to samples_path, notice: 'Samples were successfully deleted.'
-  end
-
-  def transfer
-    new_owner = Institution.find_by(uuid: params["institution_id"])
-
-    if new_owner.nil?
-      flash[:notice] = "Destination Institution does not exists"
-    else
-      begin
-        change_ownership(new_owner)
-        flash[:notice] = "All samples has been transferred successfully."
-      rescue
-        flash[:notice] = "Samples transfer failed."
-      end
-    end
-
-    render json: {status: :ok}
+    redirect_to samples_path, notice: "Samples were successfully deleted."
   end
 
   private
-
-  def change_ownership(new_owner)
-    samples = Sample.joins(:sample_identifiers).where("sample_identifiers.uuid": params["samples"])
-    Sample.transaction do
-      samples.each do |to_transfer|
-        raise "User not authorized for transferring Samples " unless authorize_resource?(to_transfer, UPDATE_SAMPLE)
-
-        transfer = SampleTransfer.new(
-          sample: to_transfer,
-          receiver_institution: new_owner,
-        )
-        transfer.confirm
-        transfer.save!
-
-        unless to_transfer.batch.nil?
-          if params["includes_qc_info"] == "true"
-            qc_info = create_qc_info(to_transfer)
-            to_transfer.qc_info_id = qc_info.id if qc_info
-            to_transfer.old_batch_number = to_transfer.batch.batch_number
-          end
-        end
-        to_transfer.batch_id = nil
-        to_transfer.site_id = nil
-        to_transfer.institution = new_owner
-        to_transfer.save!
-      end
-    end
-  end
-
-  def create_qc_info(sample)
-    sample_qc = sample.batch.qc_sample
-    return if sample_qc.nil?
-
-    qc_info = QcInfo.find_or_duplicate_from(sample_qc)
-    qc_info.samples << sample
-    qc_info.save!
-    qc_info
-  end
 
   def sample_params
     sample_params = params.require(:sample).permit(
@@ -256,7 +201,7 @@ class SamplesController < ApplicationController
       :isolate_name,
       :inactivation_method,
       :volume,
-      assay_attachments_attributes: [ :id, :loinc_code_id, :result, :assay_file_id, :_destroy ],
+      assay_attachments_attributes: [:id, :loinc_code_id, :result, :assay_file_id, :_destroy],
       notes_attributes: [:id, :description, :updated_at, :user_id, :_destroy],
     )
 
@@ -281,5 +226,4 @@ class SamplesController < ApplicationController
       .find(notes_id_to_destroy)
       .all? { |db_note| db_note.user_id == current_user.id }
   end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,21 @@
 module ApplicationHelper
   include Policy::Actions
 
-  def has_access?(resource, action)
-    Policy.can? action, resource, current_user
+  #TODO: refactor authorize_resource and authorize_resource? as both share almost the same code
+  def authorize_resource?(resource, action, user = nil)
+    if has_access?(resource, action, user)
+      check_access(resource, action, user)
+    else
+      false
+    end
   end
 
-  def check_access(resource, action)
-    Policy.authorize action, resource, current_user
+  def has_access?(resource, action, user = nil)
+    Policy.can? action, resource, user || current_user
+  end
+
+  def check_access(resource, action, user = nil)
+    Policy.authorize action, resource, user || current_user
   end
 
   def has_access_to_patients_index?

--- a/app/models/computed_policy.rb
+++ b/app/models/computed_policy.rb
@@ -33,7 +33,7 @@ class ComputedPolicy < ActiveRecord::Base
   end
 
   def self.authorize(action, resource, user, opts={})
-    return resource.kind_of?(Resource)\
+    return resource.kind_of?(Resource) || resource.kind_of?(Hash)\
       ? authorize_instance(action, resource, user, opts)\
       : authorize_scope(action, resource, user, opts)
   end

--- a/app/models/concerns/site_contained.rb
+++ b/app/models/concerns/site_contained.rb
@@ -8,7 +8,6 @@ module SiteContained
     belongs_to :institution
     belongs_to :site, -> { with_deleted }
 
-    validates_presence_of :institution
     validate :same_institution_of_site
     before_save :set_site_prefix
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -23,6 +23,7 @@ class Device < ActiveRecord::Base
   attr_reader :plain_secret_key
 
   validates_uniqueness_of :uuid
+  validates_presence_of :institution
   validates_presence_of :name
   validates_presence_of :serial_number
   validates_presence_of :device_model

--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -12,6 +12,7 @@ class Encounter < ActiveRecord::Base
 
   belongs_to :patient
 
+  validates_presence_of :institution
   validates_presence_of :site, if: Proc.new { |encounter| encounter.institution && !encounter.institution.kind_manufacturer? }
 
   validate :validate_patient

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -11,6 +11,7 @@ class Role < ActiveRecord::Base
 
   attr_accessor :definition
 
+  validates_presence_of :institution
   validates_presence_of :name
   validates_presence_of :policy
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -67,6 +67,10 @@ class Sample < ActiveRecord::Base
     uuids.sort.first
   end
 
+  def partial_uuid
+    uuid.to_s[0..-5]
+  end
+
   def entity_ids
     self.sample_identifiers.map(&:entity_id)
   end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -85,4 +85,16 @@ class Sample < ActiveRecord::Base
   def has_entity_id?
     entity_ids.compact.any?
   end
+
+  def start_transfer_to(new_owner)
+    transfer = SampleTransfer.create!(
+      sample: self,
+      receiver_institution: new_owner,
+    )
+
+    self.old_batch_number = batch.batch_number unless batch.nil?
+    update!(batch: nil, site: nil, institution: nil)
+
+    transfer
+  end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -23,7 +23,6 @@ class Sample < ActiveRecord::Base
   accepts_nested_attributes_for :notes, allow_destroy: true
   validates_associated :notes, message: "are invalid"
 
-  validates_presence_of :institution
   validate :validate_encounter
   validate :validate_patient
 

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -34,6 +34,11 @@ class SampleTransfer < ActiveRecord::Base
     save!
   end
 
+  def confirm_and_apply!
+    sample.update!(institution: receiver_institution)
+    confirm!
+  end
+
   def confirmed?
     !!confirmed_at
   end

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -15,6 +15,10 @@ class SampleTransfer < ActiveRecord::Base
           where("sender_institution_id = ? OR receiver_institution_id = ?", institution.id, institution.id)
         }
 
+  scope :with_receiver, ->(institution) {
+          where(receiver_institution_id: institution.id)
+        }
+
   scope :ordered_by_creation, -> {
           order(created_at: :desc)
         }

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -25,7 +25,6 @@ class SampleTransfer < ActiveRecord::Base
 
   def confirm
     if confirmed?
-      self.errors.add(:confirmed_at, "Already confirmed.")
       false
     else
       self.confirmed_at = Time.now
@@ -34,13 +33,28 @@ class SampleTransfer < ActiveRecord::Base
   end
 
   def confirm!
-    confirm
-    save!
+    if confirm
+      save!
+    else
+      raise ActiveRecord::RecordNotSaved.new("Sample transfer has already been confirmed.")
+    end
+  end
+
+  def confirm_and_apply
+    if confirm
+      save!
+      sample.update!(institution: receiver_institution)
+      true
+    else
+      false
+    end
   end
 
   def confirm_and_apply!
-    sample.update!(institution: receiver_institution)
     confirm!
+    sample.update!(institution: receiver_institution)
+
+    nil
   end
 
   def confirmed?

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -20,6 +20,7 @@ class TestResult < ActiveRecord::Base
 
   has_many :alert_histories
 
+  validates_presence_of :institution
   validates_presence_of :device
   # validates_uniqueness_of :test_id, scope: :device_id, allow_nil: true
   validate :same_patient_in_sample

--- a/app/presenters/sample_transfer_presenter.rb
+++ b/app/presenters/sample_transfer_presenter.rb
@@ -42,4 +42,12 @@ class SampleTransferPresenter
       "sender"
     end
   end
+
+  def sample_uuid
+    if confirmed?
+      sample.uuid
+    else
+      sample.partial_uuid + "XXXX"
+    end
+  end
 end

--- a/app/presenters/sample_transfer_presenter.rb
+++ b/app/presenters/sample_transfer_presenter.rb
@@ -27,10 +27,6 @@ class SampleTransferPresenter
     end
   end
 
-  def can_confirm?
-    true
-  end
-
   def status
     confirmed? ? "confirmed" : "in-transit"
   end

--- a/app/views/sample_transfers/_filters.haml
+++ b/app/views/sample_transfers/_filters.haml
@@ -4,7 +4,7 @@
       .row
         .col
           %h1
-            Samples
+            Sample Transfers
 
       %form#filters-form{action: sample_transfers_path, "data-auto-submit" => true}
         %input{type: "hidden", name: "page_size", value: @page_size}

--- a/app/views/sample_transfers/index.haml
+++ b/app/views/sample_transfers/index.haml
@@ -35,7 +35,7 @@
               - else
                 %td{title: "#{transfer.sender_institution} sent on #{I18n.l(transfer.created_at)}, unconfirmed by #{transfer.receiver_institution}"}
                   - if transfer.receiver?
-                    - if transfer.can_confirm?
+                    - if can_confirm_transfer?(transfer)
                       = react_component "SampleTransferConfirm", url: sample_transfer_confirm_path(sample_transfer_id: transfer.transfer)
                     - else
                       Unconfirmed

--- a/app/views/sample_transfers/index.haml
+++ b/app/views/sample_transfers/index.haml
@@ -36,7 +36,7 @@
                 %td{title: "#{transfer.sender_institution} sent on #{I18n.l(transfer.created_at)}, unconfirmed by #{transfer.receiver_institution}"}
                   - if transfer.receiver?
                     - if transfer.can_confirm?
-                      %button{disabled: "disabled"} Confirm receipt
+                      = react_component "SampleTransferConfirm", url: sample_transfer_confirm_path(sample_transfer_id: transfer.transfer)
                     - else
                       Unconfirmed
                   - else

--- a/app/views/sample_transfers/index.haml
+++ b/app/views/sample_transfers/index.haml
@@ -24,7 +24,7 @@
         - t.tbody do
           - @sample_transfers.each do |transfer|
             %tr.laboratory-sample-row{class: ("faded" if transfer.confirmed?)}
-              %td= transfer.sample.uuid
+              %td= transfer.sample_uuid
               %td= transfer.sample.isolate_name
               %td= transfer.sample.inactivation_method
               %td= transfer.other_institution

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,7 @@ Rails.application.routes.draw do
       post 'reprocess'
     end
   end
-  resources :sample_transfers, only: [:index]
+  resources :sample_transfers, only: [:create, :index]
   resources :samples do
     member do
       get 'print'
@@ -111,7 +111,6 @@ Rails.application.routes.draw do
     collection do
       get 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'print' }, action: :bulk_print
       get 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'destroy' }, action: :bulk_destroy
-      get 'transfer'
     end
   end
   resources :batches do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,9 @@ Rails.application.routes.draw do
       post 'reprocess'
     end
   end
-  resources :sample_transfers, only: [:create, :index]
+  resources :sample_transfers, only: [:create, :index] do
+    patch "confirm"
+  end
   resources :samples do
     member do
       get 'print'

--- a/features/support/page_objects/samples_page.rb
+++ b/features/support/page_objects/samples_page.rb
@@ -1,5 +1,5 @@
-class ListSampleTransfersPage < CdxPageBase
-  set_url "/sample_transfers"
+class ListSamplesPage < CdxPageBase
+  set_url "/samples"
 
   section :filters, "#filters-form" do
     element :sample_id, :field, "Sample ID"
@@ -19,7 +19,13 @@ class ListSampleTransfersPage < CdxPageBase
     find("tr", text: uuid)
   end
 
-  section :confirm_receipt_modal, ".modal" do
+  section :actions, ".table-actions" do
+    element :bulk_transfer, :link, "#bulk_transfer"
+  end
+
+  section :bulk_transfer_modal, ".modal" do
+    element :institution, :field, "Institution"
+
     def submit
       root_element.native.send_keys :enter
       wait_for_submit

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -152,5 +152,19 @@ RSpec.describe SampleTransfersController, type: :controller do
       sample.reload
       expect(sample.institution).to be_nil
     end
+
+    it "verifies transfer is unconfirmed" do
+      sample = Sample.make
+      transfer = sample.start_transfer_to(my_institution)
+      transfer.confirm_and_apply!
+      transfer.confirmed_at = original_confirmed_at = Time.now.change(usec: 0) - 1.hour
+      transfer.save!
+
+      patch :confirm, sample_transfer_id: transfer.id
+      expect(response).to be_bad_request
+
+      transfer.reload
+      expect(transfer.confirmed_at).to eq original_confirmed_at
+    end
   end
 end

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -100,4 +100,25 @@ RSpec.describe SampleTransfersController, type: :controller do
       expect(transfers.any?(&:confirmed?)).to be false
     end
   end
+
+  describe "PATCH #confirm" do
+    before(:each) do
+      sign_in current_user
+    end
+
+    it "confirms" do
+      sample = Sample.make!(institution: other_institution)
+      transfer = sample.start_transfer_to(my_institution)
+
+      Timecop.freeze do
+        patch :confirm, sample_transfer_id: transfer.id
+
+        transfer.reload
+        expect(transfer.confirmed_at).to eq Time.now.change(usec: 0) # account for DB time field granularity
+      end
+
+      sample.reload
+      expect(sample.institution).to eq my_institution
+    end
+  end
 end

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -11,28 +11,19 @@ RSpec.describe SampleTransfersController, type: :controller do
       sign_in current_user
     end
 
-    it "includes transfers from and to my institution" do
-      sample_transfers = [
-        SampleTransfer.make!(sender_institution: my_institution),
-        SampleTransfer.make!(receiver_institution: my_institution),
-      ]
-      get :index
-      expect(assigns(:sample_transfers).map(&:transfer)).to eq sample_transfers
-    end
-
-    it "excludes transfers not from or to my institution" do
-      SampleTransfer.make!
-      get :index
-      expect(assigns(:sample_transfers)).to be_empty
-    end
-
-    it "orders transfers by creation date" do
+    it "includes transfers from and to my institution (ordered by creation date)" do
       sample_transfers = [
         SampleTransfer.make!(sender_institution: my_institution, created_at: Time.now - 1.day),
         SampleTransfer.make!(receiver_institution: my_institution, created_at: Time.now),
       ]
       get :index
       expect(assigns(:sample_transfers).map(&:transfer)).to eq sample_transfers.reverse
+    end
+
+    it "excludes transfers not from or to my institution" do
+      SampleTransfer.make!
+      get :index
+      expect(assigns(:sample_transfers)).to be_empty
     end
 
     describe "filters" do

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -142,8 +142,9 @@ RSpec.describe SampleTransfersController, type: :controller do
       sample = Sample.make!
       transfer = sample.start_transfer_to(other_institution)
 
-      patch :confirm, sample_transfer_id: transfer.id
-      expect(response).to be_not_found
+      expect {
+        patch :confirm, sample_transfer_id: transfer.id
+      }.to raise_error(ActiveRecord::RecordNotFound)
 
       transfer.reload
       expect(transfer).not_to be_confirmed

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe SamplesController, type: :controller do
       expect(response).to be_success
       expect(assigns(:samples).count).to eq(2)
     end
+
+    it "excludes samples in transit" do
+      sample = Sample.make(institution: institution)
+      SampleTransfer.make(sample: sample)
+      sample.update_attribute("institution", nil)
+
+      get :index
+      expect(assigns(:samples)).to be_empty
+    end
   end
 
   context "show" do

--- a/spec/features/sample_transfers_spec.rb
+++ b/spec/features/sample_transfers_spec.rb
@@ -18,12 +18,12 @@ describe "sample transfers" do
       unrelated = SampleTransfer.make!
 
       goto_page ListSampleTransfersPage do |page|
-        expect(page.entry(in_pending.sample.uuid)).to have_content("Confirm receipt")
+        expect(page.entry(in_pending.sample.partial_uuid)).to have_content("Confirm receipt")
         expect(page.entry(in_confirmed.sample.uuid)).to have_content("Receipt confirmed on February 24, 2022")
-        expect(page.entry(out_pending.sample.uuid)).to have_content("Sent on March 04, 2022")
+        expect(page.entry(out_pending.sample.partial_uuid)).to have_content("Sent on March 04, 2022")
         expect(page.entry(out_confirmed.sample.uuid)).to have_content("Delivery confirmed on February 21, 2022")
 
-        expect(page).not_to have_content(unrelated.sample.uuid)
+        expect(page).not_to have_content(unrelated.sample.partial_uuid)
       end
     end
 
@@ -37,9 +37,9 @@ describe "sample transfers" do
       end
 
       expect_page ListSampleTransfersPage do |page|
-        expect(page.entry(subject.sample.uuid))
+        expect(page.entry(subject.sample.partial_uuid))
 
-        expect(page).not_to have_content(other.sample.uuid)
+        expect(page).not_to have_content(other.sample.partial_uuid)
       end
     end
   end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -157,7 +157,7 @@ end
 SampleTransfer.blueprint do
   sample { Sample.make!(:filled) }
   receiver_institution { Institution.make! }
-  sender_institution { object.sample.institution }
+  sender_institution { object.sample.institution || Institution.make! }
 end
 
 SampleTransfer.blueprint(:confirmed) do


### PR DESCRIPTION
Resolves #1389

The confirmation action is currently unrestricted. I'm not sure about the policy requirements for that.