### PR TITLE
Replace custom batch validation with `validate_uniqueness_of`

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -30,7 +30,7 @@ class Batch < ApplicationRecord
   validates_numericality_of :volume, greater_than: 0, message: "value must be greater than 0"
   validates_presence_of :batch_number
   validates_presence_of :isolate_name
-  validates_uniqueness_of :batch_number, scope: :isolate_name
+  validates_uniqueness_of :batch_number, scope: :isolate_name, case_sensitive: false
 
   validates_associated :samples, message: "are invalid"
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -28,9 +28,9 @@ class Batch < ApplicationRecord
   validates_presence_of :volume
   validates_presence_of :lab_technician
   validates_numericality_of :volume, greater_than: 0, message: "value must be greater than 0"
-
-  validate :isolate_name_batch_number_combination_create, on: :create
-  validate :isolate_name_batch_number_combination_update, on: :update
+  validates_presence_of :batch_number
+  validates_presence_of :isolate_name
+  validates_uniqueness_of :batch_number, scope: :isolate_name
 
   validates_associated :samples, message: "are invalid"
 
@@ -39,7 +39,7 @@ class Batch < ApplicationRecord
   }
 
   def qc_sample
-    self.samples.select {|sample| sample.is_quality_control?}.first
+    self.samples.select { |sample| sample.is_quality_control? }.first
   end
 
   def has_qc_sample?
@@ -71,13 +71,13 @@ class Batch < ApplicationRecord
 
   def isolate_name_batch_number_combination_create
     validate_isolate_name_batch_number_combination {
-      [ "#{query} AND id IS NOT NULL" ] + query_params
+      ["#{query} AND id IS NOT NULL"] + query_params
     }
   end
 
   def isolate_name_batch_number_combination_update
     validate_isolate_name_batch_number_combination {
-      [ "#{query} AND id != ?" ] + query_params + [ id ]
+      ["#{query} AND id != ?"] + query_params + [id]
     }
   end
 
@@ -86,7 +86,7 @@ class Batch < ApplicationRecord
   end
 
   def query_params
-    [ isolate_name.downcase, batch_number.downcase ]
+    [isolate_name.downcase, batch_number.downcase]
   end
 
   def validate_isolate_name_batch_number_combination

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -30,7 +30,7 @@ class Batch < ApplicationRecord
   validates_numericality_of :volume, greater_than: 0, message: "value must be greater than 0"
   validates_presence_of :batch_number
   validates_presence_of :isolate_name
-  validates_uniqueness_of :batch_number, scope: :isolate_name, case_sensitive: false
+  validates_uniqueness_of :batch_number, scope: :isolate_name
 
   validates_associated :samples, message: "are invalid"
 
@@ -65,42 +65,5 @@ class Batch < ApplicationRecord
       virus_lineage: virus_lineage,
       **attributes
     )
-  end
-
-  private
-
-  def isolate_name_batch_number_combination_create
-    validate_isolate_name_batch_number_combination {
-      ["#{query} AND id IS NOT NULL"] + query_params
-    }
-  end
-
-  def isolate_name_batch_number_combination_update
-    validate_isolate_name_batch_number_combination {
-      ["#{query} AND id != ?"] + query_params + [id]
-    }
-  end
-
-  def query
-    "LOWER(isolate_name) = ? AND LOWER(batch_number) = ?"
-  end
-
-  def query_params
-    [isolate_name.downcase, batch_number.downcase]
-  end
-
-  def validate_isolate_name_batch_number_combination
-    return unless (present?(:isolate_name) && present?(:batch_number))
-
-    combination_exists = Batch.where(yield).exists?
-    if combination_exists
-      errors.add(:isolate_name, "and Batch Number combination should be unique")
-    end
-  end
-
-  def present?(attr_name)
-    valid = self[attr_name].present?
-    errors.add(attr_name, "can't be blank") unless valid
-    valid
   end
 end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -362,9 +362,25 @@ RSpec.describe BatchesController, type: :controller do
       expect(response).to redirect_to batches_path
     end
 
+    it "should validate batch_number (exists) and isolate_name uniqueness (case insensitive)" do
+      expect {
+        post :create, params: { batch: build_batch_form_plan(batch_number: batch.batch_number.upcase, isolate_name: "DEF.24") }
+      }.to change(institution.batches, :count).by(1)
+
+      expect(response).to redirect_to batches_path
+    end
+
     it "should validate batch_number and isolate_name (exists) uniqueness" do
       expect {
         post :create, params: { batch: build_batch_form_plan(batch_number: '456', isolate_name: batch.isolate_name) }
+      }.to change(institution.batches, :count).by(1)
+
+      expect(response).to redirect_to batches_path
+    end
+
+    it "should validate batch_number and isolate_name (exists) uniqueness (case insensitive)" do
+      expect {
+        post :create, params: { batch: build_batch_form_plan(batch_number: "456", isolate_name: batch.isolate_name.upcase) }
       }.to change(institution.batches, :count).by(1)
 
       expect(response).to redirect_to batches_path


### PR DESCRIPTION
I noticed this complex validation mechanism and I think it can be replaced by `validate_uniqueness_of` with a `scope`. Seems like a nice improvement.

There are no unit tests for the model, but there is a uniqueness spec on the controller which ensures the behaviour is still correct. And I can't see any other relevant difference that would make this validation helper inadequate for this.

Depends on https://github.com/instedd/cdx/issues/1517