### PR TITLE
Add security check to `SampleTransferConfirmModal`

### DIFF
--- a/app/assets/javascripts/sample_transfer_confirm.js.jsx
+++ b/app/assets/javascripts/sample_transfer_confirm.js.jsx
@@ -17,12 +17,12 @@ var SampleTransferConfirm = React.createClass({
 
   render: function() {
     return (<span>
-      <a href="#" className="action" onClick={this.openTransferModal} >
+      <a href="#" className="action" onClick={this.openTransferModal} title="Confirm receipt">
         <div className="icon-check_circle icon-blue" /> Confirm receipt
       </a>
       <Modal ref="transferModal">
         <h1>{this.state.title}</h1>
-        <SampleTransferConfirmModal onFinished={this.closeTransferModal} url={this.props.url} />
+        <SampleTransferConfirmModal onFinished={this.closeTransferModal} url={this.props.url} uuid={this.props.uuid} />
       </Modal>
     </span>);
   }
@@ -57,14 +57,48 @@ var SampleTransferConfirmModal = React.createClass({
     });
   },
 
+  checkUUID: function(event) {
+    let uuidCheck = document.getElementById("uuid_check")
+    let submitButton = document.getElementById("samples-transfer-form-submit")
+
+    let value = uuidCheck.value
+    if(value.length < 4 && value.match(/^[0-9a-f]*$/i)) {
+      // don't show error for incomplete input as long as the format is valid
+      uuidCheck.classList.remove("input-required")
+      submitButton.disabled = true
+      return;
+    }
+
+    let valid = value.toLowerCase() == this.props.uuid.substr(-4);
+
+    if(valid) {
+      uuidCheck.classList.remove("input-required")
+      submitButton.disabled = false
+    } else {
+      uuidCheck.classList.add("input-required")
+      submitButton.disabled = true
+    }
+  },
+
   render: function() {
     return(
       <form onSubmit={this.confirmTransfer}>
         <div className="samples-transfer-modal">
+          <div className="row">
+            <p>Complete the sample ID to confirm receipt.</p>
+          </div>
+          <div className="row">
+            <div className="col pe-3"><label htmlFor="uuid_check">Sample ID</label></div>
+            <div className="col">
+              {this.props.uuid.substr(0, this.props.uuid.length - 4)}
+              <input type="text" id="uuid_check" onChange={this.checkUUID} autoFocus autoComplete="false" size="3" minLength="4" maxLength="4" placeholder="XXXX" required />
+              <span className="error"><div className="icon-error icon-red" /> Invalid sample ID</span>
+            </div>
+          </div>
           <div className="modal-footer">
             <div className="footer-buttons-aligning">
               <div>
-                <button id="samples-transfer-form-submit" className="btn btn-primary" type="submit">Confirm</button>
+                <button id="samples-transfer-form-submit" className="btn btn-primary" type="submit" disabled>Confirm</button>
                 <button className="btn btn-link" type="button" onClick={this.closeModal}>Cancel</button>
               </div>
               <div />

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -468,3 +468,11 @@ label.on {
   display: flex;
   align-items: center;
 }
+
+input + .error {
+  visibility: hidden;
+}
+
+input.input-required + .error {
+  visibility: visible;
+}

--- a/app/views/sample_transfers/index.haml
+++ b/app/views/sample_transfers/index.haml
@@ -36,7 +36,7 @@
                 %td{title: "#{transfer.sender_institution} sent on #{I18n.l(transfer.created_at)}, unconfirmed by #{transfer.receiver_institution}"}
                   - if transfer.receiver?
                     - if can_confirm_transfer?(transfer)
-                      = react_component "SampleTransferConfirm", url: sample_transfer_confirm_path(sample_transfer_id: transfer.transfer)
+                      = react_component "SampleTransferConfirm", url: sample_transfer_confirm_path(sample_transfer_id: transfer.transfer), uuid: transfer.sample.uuid
                     - else
                       Unconfirmed
                   - else

--- a/features/support/page_objects/sample_transfer_page.rb
+++ b/features/support/page_objects/sample_transfer_page.rb
@@ -20,9 +20,11 @@ class ListSampleTransfersPage < CdxPageBase
   end
 
   section :confirm_receipt_modal, ".modal" do
+    element :uuid_check, :field, "Sample ID"
+    element :submit_button, :button, "Confirm"
+
     def submit
-      root_element.native.send_keys :enter
-      wait_for_submit
+      submit_button.click
     end
   end
 end

--- a/spec/features/sample_transfers_spec.rb
+++ b/spec/features/sample_transfers_spec.rb
@@ -80,6 +80,8 @@ describe "sample transfers" do
         page.confirm_receipt_modal.tap do |modal|
           expect(modal).to have_content("Confirm receipt")
 
+          modal.uuid_check.set sample.uuid[-4..-1]
+
           modal.submit
         end
       end
@@ -91,6 +93,49 @@ describe "sample transfers" do
       goto_page ListSamplesPage do |page|
         expect(page).to have_content(sample.uuid)
       end
+    end
+
+    it "verifies sample id" do
+      sample = Sample.make!(:filled, institution: institution_a)
+      transfer = sample.start_transfer_to(institution_b)
+
+      sign_in user_b
+
+      goto_page ListSampleTransfersPage do |page|
+        page.entry(sample.partial_uuid).find_link("Confirm receipt").click
+
+        page.confirm_receipt_modal.tap do |modal|
+          expect(modal).to have_content("Confirm receipt")
+
+          expect(modal).not_to have_content("Invalid sample ID")
+          expect(modal).not_to have_submit_button
+
+          modal.uuid_check.set "a"
+          expect(modal).not_to have_content("Invalid sample ID")
+          expect(modal).not_to have_submit_button
+
+          modal.uuid_check.set "x"
+          expect(modal).to have_content("Invalid sample ID")
+          expect(modal).not_to have_submit_button
+
+          modal.uuid_check.set "xxxx"
+          expect(modal).to have_content("Invalid sample ID")
+          expect(modal).not_to have_submit_button
+
+          modal.uuid_check.set "1111"
+          expect(modal).to have_content("Invalid sample ID")
+          expect(modal).not_to have_submit_button
+
+          modal.uuid_check.set sample.uuid[-4..-1]
+          expect(modal).not_to have_content("Invalid sample ID")
+          expect(modal).to have_submit_button
+
+          modal.submit
+        end
+      end
+
+      transfer.reload
+      expect(transfer).to be_confirmed
     end
   end
 end


### PR DESCRIPTION
Resolves  #1391

The validation happens only client-side for easy integration and quick response. This should be fine for this kind of security mechanism. It sufficiently defends against user mistakes, but a decided malicious agent could easily defeat it by looking at the HTML source.