### PR TITLE
Add note about missing confirmation link for sample transfer

### DIFF
--- a/app/views/sample_transfers/index.haml
+++ b/app/views/sample_transfers/index.haml
@@ -39,6 +39,7 @@
                       = react_component "SampleTransferConfirm", url: sample_transfer_confirm_path(sample_transfer_id: transfer.transfer), uuid: transfer.sample.uuid
                     - else
                       Unconfirmed
+                      .icon-help.icon-gray{title: "You're not authorized to confirm this transfer."}
                   - else
                     Sent on
                     = time_tag transfer.created_at, I18n.l(transfer.created_at, format: I18n.t("date.formats.long"))


### PR DESCRIPTION
Since there was some confusion about what "Unconfirmed" means in the sample transfer list, I added a help icon next to it with a tooltip message.

![grafik](https://user-images.githubusercontent.com/466378/158194624-975fd052-7119-4283-a425-47ca3392d313.png)

@jkicillof WDYT?
