### PR TITLE
Show no qc info warning and/or checkbox based selected samples

### DIFF
--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -38,19 +38,19 @@ var SampleTransferModal = React.createClass({
   },
 
   showQcWarningCheckbox: function(selectedSamples) {
-    const hasQc = selectedSamples.filter((sample) => sample.existsQcReference === true).length
-    if(selectedSamples.length > 0 && selectedSamples.length === hasQc) {
+    const haveQc = selectedSamples.filter((sample) => sample.existsQcReference === true).length
+    if(selectedSamples.length > 0 && selectedSamples.length === haveQc) {
       return this.includeQcInfoCheckbox()
     }
     else {
-      if (hasQc === 0) {
+      if (haveQc === 0) {
         return this.qcInfoMessage()
       }
       else {
         return (
           <span>
             {this.includeQcInfoCheckbox()}
-            {this.qcInfoMessage(selectedSamples.length - hasQc)}
+            {this.qcInfoMessage(selectedSamples.length - haveQc)}
           </span>
         )
       }

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -39,22 +39,13 @@ var SampleTransferModal = React.createClass({
 
   showQcWarningCheckbox: function(selectedSamples) {
     const haveQc = selectedSamples.filter((sample) => sample.existsQcReference === true).length
-    if(selectedSamples.length > 0 && selectedSamples.length === haveQc) {
-      return this.includeQcInfoCheckbox()
-    }
-    else {
-      if (haveQc === 0) {
-        return this.qcInfoMessage()
-      }
-      else {
-        return (
-          <span>
-            {this.includeQcInfoCheckbox()}
-            {this.qcInfoMessage(selectedSamples.length - haveQc)}
-          </span>
-        )
-      }
-    }
+    const missingQuantity = selectedSamples.length - haveQc
+    return (
+      <div>
+        {haveQc > 0 && this.includeQcInfoCheckbox()}
+        {missingQuantity > 0 && this.qcInfoMessage(missingQuantity, selectedSamples)}
+      </div>
+    )
   },
 
   closeModal: function(event) {
@@ -117,12 +108,11 @@ var SampleTransferModal = React.createClass({
     )
   },
 
-  qcInfoMessage: function(quantity) {
+  qcInfoMessage: function(missingQuantity, selectedSamples) {
     let infoMessage = "There is no Quality Control (QC) info available for these samples"
-    if(quantity > 0) {
-      infoMessage = `There is no Quality Control (QC) info available for ${quantity} ${quantity === 1? 'sample' : 'samples'}`
+    if(missingQuantity > 0 && missingQuantity != selectedSamples.length) {
+      infoMessage = `There is no Quality Control (QC) info available for ${missingQuantity} ${missingQuantity === 1? 'sample' : 'samples'}`
     }
-
     return (
       <div className="col icon-info-outline icon-gray table-info" style={{padding: '0 10px'}}>
         <div className="notification-text">{infoMessage}</div>

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -109,13 +109,15 @@ var SampleTransferModal = React.createClass({
   },
 
   qcInfoMessage: function(missingQuantity, selectedSamples) {
-    let infoMessage = "There is no Quality Control (QC) info available for these samples"
-    if(missingQuantity > 0 && missingQuantity != selectedSamples.length) {
-      infoMessage = `There is no Quality Control (QC) info available for ${missingQuantity} ${missingQuantity === 1? 'sample' : 'samples'}`
-    }
+    const infoMessage = (missingQuantity > 0 && missingQuantity != selectedSamples.length)
+      ? `There is no Quality Control (QC) info available for ${missingQuantity} ${missingQuantity === 1 ? 'sample' : 'samples'}`
+      : "There is no Quality Control (QC) info available for these samples"
+
     return (
-      <div className="col icon-info-outline icon-gray table-info" style={{padding: '0 10px'}}>
-        <div className="notification-text">{infoMessage}</div>
+      <div className="row">
+        <div className="col icon-info-outline icon-gray qc-info-message">
+          <div className="notification-text">{infoMessage}</div>
+        </div>
       </div>
     )
   },
@@ -129,7 +131,7 @@ var SampleTransferModal = React.createClass({
 
   includeQcInfoCheckbox: function () {
     return (<div className="row">
-      <div className="col pe-3" style={{padding: '10px 10px 0px 10px'}}>
+      <div className="col pe-3 qc-info-checkbox">
         <input id="include-qc-check" type="checkbox" checked={this.state.includeQcInfo} onChange={this.toggleQcInfo}/>
         <label htmlFor="include-qc-check">Include a copy of the QC data</label>
       </div>

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -29,11 +29,32 @@ var SampleTransfer = React.createClass({
 
 var SampleTransferModal = React.createClass({
   getInitialState: function() {
+
     return {
       institutionId: null,
       includeQcInfo: false,
-      selectedSamples: selectedSamplesIds(),
+      selectedSamples: selectedSamplesIds()
     };
+  },
+
+  showQcWarningCheckbox: function(selectedSamples) {
+    const hasQc = selectedSamples.filter((sample) => sample.existsQcReference === true).length
+    if(selectedSamples.length > 0 && selectedSamples.length === hasQc) {
+      return this.includeQcInfoCheckbox()
+    }
+    else {
+      if (hasQc === 0) {
+        return this.qcInfoMessage()
+      }
+      else {
+        return (
+          <span>
+            {this.includeQcInfoCheckbox()}
+            {this.qcInfoMessage(selectedSamples.length - hasQc)}
+          </span>
+        )
+      }
+    }
   },
 
   closeModal: function(event) {
@@ -96,6 +117,19 @@ var SampleTransferModal = React.createClass({
     )
   },
 
+  qcInfoMessage: function(quantity) {
+    let infoMessage = "There is no Quality Control (QC) info available for these samples"
+    if(quantity > 0) {
+      infoMessage = `There is no Quality Control (QC) info available for ${quantity} ${quantity === 1? 'sample' : 'samples'}`
+    }
+
+    return (
+      <div className="col icon-info-outline icon-gray table-info" style={{padding: '0 10px'}}>
+        <div className="notification-text">{infoMessage}</div>
+      </div>
+    )
+  },
+
   toggleQcInfo: function() {
     var oldValue = this.state.includeQcInfo;
     this.setState({
@@ -103,7 +137,16 @@ var SampleTransferModal = React.createClass({
     });
   },
 
-  render: function() {
+  includeQcInfoCheckbox: function () {
+    return (<div className="row">
+      <div className="col pe-3" style={{padding: '10px 10px 0px 10px'}}>
+        <input id="include-qc-check" type="checkbox" checked={this.state.includeQcInfo} onChange={this.toggleQcInfo}/>
+        <label htmlFor="include-qc-check">Include a copy of the QC data</label>
+      </div>
+    </div>)
+
+
+  }, render: function() {
     return(
       <div className="samples-transfer-modal">
         <div className="row">
@@ -116,12 +159,7 @@ var SampleTransferModal = React.createClass({
           <div className="col pe-3"><label>Institution</label></div>
           <div className="col"><CdxSelect name="institution" items={this.props.institutions} value={this.state.institutionId} onChange={this.changeInstitution} /></div>
         </div>
-        <div className="row">
-          <div className="col pe-3">
-            <input id="include-qc-check" type="checkbox" checked={this.state.includeQcInfo} onChange={this.toggleQcInfo} />
-            <label htmlFor="include-qc-check">Include a copy of the QC data</label>
-          </div>
-        </div>
+        {this.showQcWarningCheckbox(this.state.selectedSamples)}
         <div className="modal-footer">
           <div className="footer-buttons-aligning">
             <div>

--- a/app/assets/stylesheets/_sample_transfer_modal.scss
+++ b/app/assets/stylesheets/_sample_transfer_modal.scss
@@ -1,0 +1,9 @@
+.qc-info-message {
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+}
+
+.qc-info-checkbox {
+  padding: 10px 10px 0px 10px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,3 +38,4 @@
 @import "sample_assays";
 @import "notes";
 @import "user_institution_invites_modal";
+@import "sample_transfer_modal";

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -37,6 +37,10 @@ class Batch < ActiveRecord::Base
     self.samples.select {|sample| sample.is_quality_control?}.first
   end
 
+  def has_qc_sample?
+    self.qc_sample.present?
+  end
+
   private
 
   def isolate_name_batch_number_combination_create

--- a/app/views/samples/_index_bulk_actions_js.haml
+++ b/app/views/samples/_index_bulk_actions_js.haml
@@ -51,7 +51,8 @@
       if(checkboxInput.is(':checked')) {
         var uuid = $(sample).children('#sample_uuid').text();
         var isolateName = $(sample).children('#sample_isolate_name').text();
-        return {uuid, isolateName};
+        var existsQcReference = $(sample).data().hasqcreference
+        return {uuid, isolateName, existsQcReference};
       }
      })
   }

--- a/app/views/samples/index.haml
+++ b/app/views/samples/index.haml
@@ -39,7 +39,7 @@
               %th Production Date
           - t.tbody do
             - @samples.each do |sample|
-              %tr.laboratory-sample-row{data: {is_qc: sample.is_quality_control?.to_s, href: has_access?(sample, Policy::Actions::UPDATE_SAMPLE) ? edit_sample_path(sample) : sample_path(sample)}}
+              %tr.laboratory-sample-row{data: { hasQcReference: sample.batch.nil? ? false.to_s : sample.batch.has_qc_sample?.to_s, is_qc: sample.is_quality_control?.to_s, href: has_access?(sample, Policy::Actions::UPDATE_SAMPLE) ? edit_sample_path(sample) : sample_path(sample)}}
                 %td
                   =check_box_tag 'sample_ids[]', sample.id, false, { id: "sample_ids.#{sample.id}" }
                   %label.row{for: "sample_ids.#{sample.id}"}


### PR DESCRIPTION
Fixes: #1484 

## All selected samples have a QC Sample from their batches, only show "include qc info checkbox"

![Screen Shot 2022-03-14 at 23 19 52](https://user-images.githubusercontent.com/23437283/158292928-6df1750e-f0e5-4946-8bf1-086bf0cd530c.png)

![Screen Shot 2022-03-14 at 23 20 16](https://user-images.githubusercontent.com/23437283/158292967-24c98ec0-8492-48fb-94e5-a495c1e4c64a.png)

## All selected samples don't have a QC Sample from their batches, only show warning

![Screen Shot 2022-03-14 at 23 21 55](https://user-images.githubusercontent.com/23437283/158293158-e80ae59d-ecdb-4e87-9583-19ddb36279ab.png)

![Screen Shot 2022-03-14 at 23 22 24](https://user-images.githubusercontent.com/23437283/158293197-3a76519b-6afe-4d1d-ae1d-b69e20ef554a.png)

## A combination of both cases shows checkbox and warning (with different messages)

![Screen Shot 2022-03-14 at 23 23 56](https://user-images.githubusercontent.com/23437283/158293367-f5ed4f07-fdb5-46b4-86d5-2fa48f0a60e4.png)


