### PR TITLE
Disable send icon according to selected qc samples

### DIFF
--- a/app/views/samples/_index_bulk_actions_js.haml
+++ b/app/views/samples/_index_bulk_actions_js.haml
@@ -2,7 +2,7 @@
   (function() {
     allCheckboxes().on('change', function(e) {
       toggleBulkActions();
-      toggleBulkTransfer($(e.target))
+      toggleBulkTransfer()
     });
 
     // initial bulk actions state
@@ -26,14 +26,12 @@
     });
   }
 
-  function toggleBulkTransfer(checkbox) {
-    var row = checkbox.parents('.laboratory-sample-row')
-    if (checkbox.is(':checked')){
-      if(row.data().isQc){
+  function toggleBulkTransfer() {
+    var areQc = selectedSamplesIds().filter((sample) => sample.isQc === true).length
+    if(areQc > 0){
         $("#bulk_transfer").prop('disabled', true);
         $('#table-notification').css("visibility", "visible");
       }
-    }
     else {
       $('#table-notification').css("visibility", "hidden");
     }
@@ -52,7 +50,8 @@
         var uuid = $(sample).children('#sample_uuid').data("uuid");
         var isolateName = $(sample).children('#sample_isolate_name').text();
         var existsQcReference = $(sample).data().hasqcreference
-        return {uuid, isolateName, existsQcReference};
+        var isQc = $(sample).data().isQc
+        return {uuid, isolateName, existsQcReference, isQc};
       }
      })
   }

--- a/app/views/samples/_index_bulk_actions_js.haml
+++ b/app/views/samples/_index_bulk_actions_js.haml
@@ -27,8 +27,9 @@
   }
 
   function toggleBulkTransfer() {
-    var areQc = selectedSamplesIds().filter((sample) => sample.isQc === true).length
-    if(areQc > 0){
+    debugger;
+    var areQc = selectedSamplesIds().some((sample) => sample.isQc === true)
+    if(areQc){
         $("#bulk_transfer").prop('disabled', true);
         $('#table-notification').css("visibility", "visible");
       }

--- a/app/views/samples/_index_bulk_actions_js.haml
+++ b/app/views/samples/_index_bulk_actions_js.haml
@@ -27,9 +27,7 @@
   }
 
   function toggleBulkTransfer() {
-    debugger;
-    var areQc = selectedSamplesIds().some((sample) => sample.isQc === true)
-    if(areQc){
+    if(selectedSamplesIds().some((sample) => sample.isQc === true)){
         $("#bulk_transfer").prop('disabled', true);
         $('#table-notification').css("visibility", "visible");
       }


### PR DESCRIPTION
Fixes: #1525

Before this fix we were disabling (or not) the icon based on the last row change. This fix checks for all the selected sample list every-time a checkbox change event happens.


Note: branched from #1484 because I'm reusing a modified function from that branch.