### PR TITLE
form fields properly shown in samples

### DIFF
--- a/app/assets/javascripts/components/address.js.jsx
+++ b/app/assets/javascripts/components/address.js.jsx
@@ -85,7 +85,7 @@ var Address = React.createClass({
     }
 
     return <div>
-      <div className="row">
+      <div className="row form-field">
         <div className="col pe-2">
           <label>Address</label>
         </div>
@@ -94,7 +94,7 @@ var Address = React.createClass({
           <div className="warn">{this.state.error}</div>
         </div>
       </div>
-      <div className="row">
+      <div className="row form-field">
         <div className="col pe-2">
           <label>Region</label>
         </div>

--- a/app/assets/javascripts/components/alert_category_select.js.jsx
+++ b/app/assets/javascripts/components/alert_category_select.js.jsx
@@ -207,7 +207,7 @@ var AlertCategorySelect = React.createClass({
 	render: function() {
 		return (
 			<div>
-				<div className="row">
+				<div className="row form-field">
 					<div className="col">
 						<FlashErrorMessages messages={this.state.error_messages} />
 						<form className = "alertForm" id="new_alert" onSubmit = {this.handleAlertSubmit} >

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -90,7 +90,8 @@ label {
 
 .form-field {
   label {
-    line-height: 40px;
+    line-height: 1.6;
+    margin-top: 9px;
   }
 
   .Select-control {

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -88,6 +88,21 @@ label {
   }
 }
 
+.form-field {
+  label {
+    line-height: 40px;
+  }
+
+  .Select-control {
+    padding-bottom: 6px;
+    height: 34px;
+  }
+
+  input:not(.input-small) {
+    margin-top: 5px;
+  }
+}
+
 // Checkboxes ---------------------------------------------------------//
 
 input[type="checkbox"] {

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -98,6 +98,10 @@ label {
     padding-bottom: 6px;
     height: 34px;
   }
+  
+  .value{
+    margin-left: 5px;
+  }
 
   input:not(.input-small) {
     margin-top: 5px;

--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -11,21 +11,6 @@
   &.center {
     @include justify-content(center);
   }
-
-  .form-field {
-    label {
-      line-height: 40px;
-    }
-
-  .Select-control {
-      padding-bottom: 6px;
-      height: 34px;
-    }
-
-    input:not(.input-small) {
-      margin-top: 5px;
-    }
-  }
 }
 
 /* default for even distribution */

--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -108,8 +108,16 @@
     @include flex(0 0 1000px);
   }
 
-  &.display{
+  &.form-field-label label{
     line-height: 40px;
+  }
+
+  &.form-field-value div.value{
+    margin-top: -1px;
+  }
+
+  &.form-field-value input:not(.input-small){
+    margin-top: 5px;
   }
 }
 

--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -108,7 +108,9 @@
     @include flex(0 0 1000px);
   }
 
-
+  &.display{
+    line-height: 40px;
+  }
 }
 
 

--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -11,6 +11,21 @@
   &.center {
     @include justify-content(center);
   }
+
+  .form-field {
+    label {
+      line-height: 40px;
+    }
+
+  .Select-control {
+      padding-bottom: 6px;
+      height: 34px;
+    }
+
+    input:not(.input-small) {
+      margin-top: 5px;
+    }
+  }
 }
 
 /* default for even distribution */
@@ -106,18 +121,6 @@
 
   &.px-10 {
     @include flex(0 0 1000px);
-  }
-
-  &.form-field-label label{
-    line-height: 40px;
-  }
-
-  &.form-field-value div.value{
-    margin-top: -1px;
-  }
-
-  &.form-field-value input:not(.input-small){
-    margin-top: 5px;
   }
 }
 

--- a/app/assets/stylesheets/_react-select.scss
+++ b/app/assets/stylesheets/_react-select.scss
@@ -12,6 +12,7 @@
   display: inline-block;
   vertical-align: middle;
   white-space: nowrap;
+  padding-left: 5px;
 }
 
 .Select-control {
@@ -46,7 +47,7 @@
 
 .Select-placeholder {
   color: #aaaaaa;
-  padding: 8px 52px 8px 0px;
+  padding: 10px 52px 8px 0px;
   position: absolute;
   top: 0;
   left: 0;

--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -4,25 +4,25 @@
 
   .row
     .col
-      .row
+      .row.form-field
         .col.pe-3
           = f.label :batch_id
         .col
           = f.text_field :batch_number, readonly: !@can_update
 
-      .row
+      .row.form-field
         .col.pe-3
           = f.label :date_produced, "production date"
         .col
           = f.text_field :date_produced, placeholder: Batch.date_produced_placeholder, readonly: !@can_update
 
-      .row
+      .row.form-field
         .col.pe-3
           = f.label :lab_technician
         .col
           = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
 
-      .row
+      .row.form-field
         .col.pe-3
           = f.label :specimen_role
         .col
@@ -32,13 +32,13 @@
           - else
             = text_field_tag :specimen_role, Batch.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
 
-      .row
+      .row.form-field
         .col.pe-3
           = f.label :isolate_name
         .col
           = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
 
-      .row
+      .row.form-field
         .col.pe-3
           = f.label :inactivation_method
         .col
@@ -48,7 +48,7 @@
           - else
             = f.text_field :inactivation_method, readonly: true
 
-      .row
+      .row.form-field
         .col.pe-3
           = f.label :volume
         .col
@@ -57,13 +57,13 @@
             .span.unit (μl)
 
       - if @can_edit_sample_quantity
-        .row
+        .row.form-field
           .col.pe-3
             = f.label :samples_quantity
           .col
             = f.number_field :samples_quantity, min: 0, :class => "input-small"
       - else
-        .row
+        .row.form-field
           .col.pe-3
             = f.label :samples
           .col.pe-7

--- a/app/views/devices/_form.haml
+++ b/app/views/devices/_form.haml
@@ -1,13 +1,13 @@
 = form_for(@device) do |f|
   = validation_errors @device
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :institution
     .col
       .value= @navigation_context.institution.name
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :device_model_id
     .col
@@ -15,7 +15,7 @@
         - select.items(@device_models, :id, :full_name)
 
   - if @allow_to_pick_site
-    .row
+    .row.form-field
       .col.pe-2
         = f.label :site
       .col
@@ -25,22 +25,22 @@
   - elsif f.object.new_record?
     = f.hidden_field :site_id
   - else # once created is better to show site name, otherwise user might have read access to many site's device, and we should avoid not showing site name in that scenario
-    .row
+    .row.form-field
       .col.pe-2
         = f.label :site
       .col
         .value= f.object.site.name
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :name
     .col
       = f.text_field :name
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :serial_number
     .col
       = f.text_field :serial_number
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :time_zone
     .col
@@ -48,7 +48,7 @@
         - select.items(ActiveSupport::TimeZone.all, :name, :to_s)
   - if @device.new_record? || @device.device_model.try(:supports_ftp)
     .device-ftp-config{class: ('nodisplay' unless @device.device_model.try(:supports_ftp))}
-      .row
+      .row.form-field
         .col.pe-2= f.label :ftp_hostname, 'FTP'
         .col.pe-2= f.text_field :ftp_hostname, placeholder: 'Hostname'
         .col.pe-2= f.number_field :ftp_port, min: 0, max: 65535, placeholder: 'Port'
@@ -58,7 +58,7 @@
           = f.check_box :ftp_passive
           = f.label :ftp_passive, "&nbsp;".html_safe
         .col.pe-2= f.text_field :ftp_directory, placeholder: 'Folder'
-      .row
+      .row.form-field
         .col.pe-2= f.label :ftp_username, 'Login'
         .col.pe-2= f.text_field :ftp_username, placeholder: 'Username', autocomplete: 'off'
         .col.pe-2= f.password_field :ftp_password, value: @device.ftp_password, placeholder: 'Password', autocomplete: 'off'

--- a/app/views/patients/_form.html.haml
+++ b/app/views/patients/_form.html.haml
@@ -4,32 +4,32 @@
 
   = validation_errors @patient
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :institution
     .col
       .value= f.object.institution
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :name
     .col
       = f.text_field :name, :class => 'input-large'
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :entity_id
     .col
       = f.text_field :entity_id, :class => 'input-large'
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :gender
     .col
       = cdx_select form: f, name: :gender do |select|
         - select.items PatientForm::GENDER_VALUES
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :dob
     .col
@@ -37,13 +37,13 @@
 
   = patient_address_component(@patient)
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :email
     .col
       = f.text_field :email, :class => 'input-large'
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :phone
     .col

--- a/app/views/policies/_form.html.haml
+++ b/app/views/policies/_form.html.haml
@@ -6,12 +6,12 @@
         - @policy.errors.full_messages.each do |msg|
           %li= msg
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :name
     .col
       = f.text_field :name
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :user_id
     .col

--- a/app/views/roles/_form.html.haml
+++ b/app/views/roles/_form.html.haml
@@ -6,21 +6,21 @@
         - @role.errors.full_messages.each do |msg|
           %li= msg
 
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :name
     .col
       = f.text_field :name
 
   - if @accessible_institutions != 1
-    .row
+    .row.form-field
       .col.pe-2
         = f.label :institution_id
       .col
         .value= @institution
 
   - if @role.new_record?
-    .row
+    .row.form-field
       .col.pe-2
         = f.label :site_id
       .col
@@ -28,7 +28,7 @@
           - select.item "", "Choose one"
           - select.items @sites, :id, :name
   - elsif @role.site_id
-    .row
+    .row.form-field
       .col.pe-2
         = f.label :site_id
       .col

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -5,67 +5,67 @@
   .row
     .col
       - unless f.object.qc_info.nil?
-        .row
-          .col.pe-4.form-field-label
+        .row.form-field
+          .col.pe-4
             = f.label :quality_control
-          .col.form-field-value
+          .col
             = link_to edit_qc_info_path(f.object.qc_info.id), class: 'centered' do
               .icon-test.icon-blue
               = "VIEW QC INFO"
 
-      .row
-        .col.pe-4.form-field-label
+      .row.form-field
+        .col.pe-4
           = f.label :uuid
-        .col.form-field-value
+        .col
           .value= f.object.uuid
       - unless f.object.batch.nil?
-        .row
-          .col.pe-4.form-field-label
+        .row.form-field
+          .col.pe-4
             = f.label :batch_id
-          .col.form-field-value
+          .col
             .value= f.object.batch.batch_number
 
-      .row
-        .col.pe-4.form-field-label
+      .row.form-field
+        .col.pe-4
           = f.label :date_produced, "production date"
-        .col.form-field-value
+        .col
           = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
 
-      .row
-        .col.pe-4.form-field-label
+      .row.form-field
+        .col.pe-4
           = f.label :lab_technician
-        .col.form-field-value
+        .col
           = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
 
-      .row
-        .col.pe-4.form-field-label
+      .row.form-field
+        .col.pe-4
           = f.label :specimen_role
-        .col.form-field-value
+        .col
           - if @can_update
             = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
               - select.items Sample.specimen_roles, :id, :description
           - else
             = text_field_tag :specimen_role, Sample.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
-      .row
-        .col.pe-4.form-field-label
+      .row.form-field
+        .col.pe-4
           = f.label :isolate_name
-        .col.form-field-value
+        .col
           = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
 
-      .row
-        .col.pe-4.form-field-label
+      .row.form-field
+        .col.pe-4
           = f.label :inactivation_method
-        .col.form-field-value
+        .col
           - if @can_update
             = cdx_select form: f, name: :inactivation_method, searchable: false do |select|
               - select.items Sample.inactivation_methods
           - else
             = f.text_field :inactivation_method, readonly: true
 
-      .row
-        .col.pe-4.form-field-label
+      .row.form-field
+        .col.pe-4
           = f.label :volume
-        .col.form-field-value
+        .col
           .row.input-unit
             = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
             .span.unit (μl)

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -6,56 +6,56 @@
     .col
       - unless f.object.qc_info.nil?
         .row
-          .col.pe-4.display
+          .col.pe-4.form-field-label
             = f.label :quality_control
-          .col.display
+          .col.form-field-value
             = link_to edit_qc_info_path(f.object.qc_info.id), class: 'centered' do
               .icon-test.icon-blue
               = "VIEW QC INFO"
 
       .row
-        .col.pe-4.display
+        .col.pe-4.form-field-label
           = f.label :uuid
-        .col.display
+        .col.form-field-value
           .value= f.object.uuid
       - unless f.object.batch.nil?
         .row
-          .col.pe-4.display
+          .col.pe-4.form-field-label
             = f.label :batch_id
-          .col.display
+          .col.form-field-value
             .value= f.object.batch.batch_number
 
       .row
-        .col.pe-4.display
+        .col.pe-4.form-field-label
           = f.label :date_produced, "production date"
-        .col.display
+        .col.form-field-value
           = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
 
       .row
-        .col.pe-4.display
+        .col.pe-4.form-field-label
           = f.label :lab_technician
-        .col.display
+        .col.form-field-value
           = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
 
       .row
-        .col.pe-4.display
+        .col.pe-4.form-field-label
           = f.label :specimen_role
-        .col
+        .col.form-field-value
           - if @can_update
             = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
               - select.items Sample.specimen_roles, :id, :description
           - else
             = text_field_tag :specimen_role, Sample.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
       .row
-        .col.pe-4.display
+        .col.pe-4.form-field-label
           = f.label :isolate_name
-        .col.display
+        .col.form-field-value
           = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
 
       .row
-        .col.pe-4.display
+        .col.pe-4.form-field-label
           = f.label :inactivation_method
-        .col
+        .col.form-field-value
           - if @can_update
             = cdx_select form: f, name: :inactivation_method, searchable: false do |select|
               - select.items Sample.inactivation_methods
@@ -63,9 +63,9 @@
             = f.text_field :inactivation_method, readonly: true
 
       .row
-        .col.pe-4.display
+        .col.pe-4.form-field-label
           = f.label :volume
-        .col.display
+        .col.form-field-value
           .row.input-unit
             = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
             .span.unit (μl)

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -6,39 +6,39 @@
     .col
       - unless f.object.qc_info.nil?
         .row
-          .col.pe-4
+          .col.pe-4.display
             = f.label :quality_control
-          .col
+          .col.display
             = link_to edit_qc_info_path(f.object.qc_info.id), class: 'centered' do
               .icon-test.icon-blue
               = "VIEW QC INFO"
 
       .row
-        .col.pe-4
+        .col.pe-4.display
           = f.label :uuid
-        .col
+        .col.display
           .value= f.object.uuid
       - unless f.object.batch.nil?
         .row
-          .col.pe-4
+          .col.pe-4.display
             = f.label :batch_id
-          .col
+          .col.display
             .value= f.object.batch.batch_number
 
       .row
-        .col.pe-4
+        .col.pe-4.display
           = f.label :date_produced, "production date"
-        .col
+        .col.display
           = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
 
       .row
-        .col.pe-4
+        .col.pe-4.display
           = f.label :lab_technician
-        .col
+        .col.display
           = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
 
       .row
-        .col.pe-4
+        .col.pe-4.display
           = f.label :specimen_role
         .col
           - if @can_update
@@ -47,13 +47,13 @@
           - else
             = text_field_tag :specimen_role, Sample.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
       .row
-        .col.pe-4
+        .col.pe-4.display
           = f.label :isolate_name
-        .col
+        .col.display
           = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
 
       .row
-        .col.pe-4
+        .col.pe-4.display
           = f.label :inactivation_method
         .col
           - if @can_update
@@ -63,9 +63,9 @@
             = f.text_field :inactivation_method, readonly: true
 
       .row
-        .col.pe-4
+        .col.pe-4.display
           = f.label :volume
-        .col
+        .col.display
           .row.input-unit
             = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
             .span.unit (μl)

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -1,40 +1,39 @@
 = form_for(@site) do |f|
   = validation_errors @site
 
-  .row
-    .col.pe-6
-      .row
-        .col.pe-4
-          = f.label :institution
-        .col
-          .value= f.object.institution
+  .row.form-field
+    .col.pe-2
+      = f.label :institution
+    .col
+      .value= f.object.institution
 
-      .row
-        .col.pe-4
-          = f.label :name
-        .col
-          = f.text_field :name, :class => 'input-large'
-      - if @site.new_record? || @can_move
-        .row
-          .col.pe-4
-            = f.label :parent
-          .col
-            = cdx_select form: f, name: :parent_id, class: 'input-x-large' do |select|
-              - select.item "", "None"
-              - select.items @sites, :id, :name
-      - elsif @site.parent
-        .row
-          .col.pe-4
-            = f.label :parent
-          .col
-            = @site.parent.name
+  .row.form-field
+    .col.pe-2
+      = f.label :name
+    .col
+      = f.text_field :name, :class => 'input-large'
+  - if @site.new_record? || @can_move
+    .row.form-field
+      .col.pe-2
+        = f.label :parent
+      .col
+        = cdx_select form: f, name: :parent_id, class: 'input-x-large' do |select|
+          - select.item "", "None"
+          - select.items @sites, :id, :name
+  - elsif @site.parent
+    .row
+      .col.pe-4
+        = f.label :parent
+      .col
+        = @site.parent.name
 
     .col.pe-4
       - unless @site.new_record?
         = render 'side'
 
   = site_address_component(@site)
-  .row
+
+  .row.form-field
     .col.pe-2
       = f.label :sample_id_reset_policy, "Sample ID reset policy"
     .col
@@ -42,18 +41,18 @@
         - select.item "yearly", "Yearly"
         - select.item "monthly", "Monthly"
         - select.item "weekly", "Weekly"
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :allows_manual_entry, "Allow manual entry"
     .col
       = f.check_box :allows_manual_entry
       %label{for: 'site_allows_manual_entry'} &nbsp;
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :main_phone_number
     .col
       = f.text_field :main_phone_number, :class => 'input-large'
-  .row
+  .row.form-field
     .col.pe-2
       = f.label :email_address
     .col


### PR DESCRIPTION
Solves #1509: form fields (just for samples, see below) are now accommodated according to the mockup.

[Mockup](https://projects.invisionapp.com/d/main/#/console/4103589/113463974/preview):

![image](https://user-images.githubusercontent.com/13782680/158447285-989e65d1-e26c-4c55-9c6b-ac927a341bbb.png)

Sample form now looks like this:

![image](https://user-images.githubusercontent.com/13782680/158447474-87120e89-2fc0-4969-a592-9e3f6f660155.png)

This is functional but there are things to iterate (@straight-shoota? @devduarte? @ysbaddaden?):

- To make all the fields to have the same line height I've created the **display** class. Cannot apply this property in the **col** class, but then this will have to be implemented in all the forms? Or there is a better solution?
- The **display** name is not a good name, I think of form-col?, col-form?... Just want to check if there is any naming convention for this. 
- While for all the other elements to assign the display class works, if I do it in the cdx_select breaks it... please note that all the "cols" have display class except for _specimen role_ and _inactivation method_. This feels incorrect but I need a hint on how to solve this. 

