### PR TITLE
Allow sample transfers with ellipsis shown in Samples table

### DIFF
--- a/app/views/samples/_index_bulk_actions_js.haml
+++ b/app/views/samples/_index_bulk_actions_js.haml
@@ -49,7 +49,7 @@
     return $.map(samples, function(sample) {
       var checkboxInput = $(sample).find('input[name="sample_ids[]"]');
       if(checkboxInput.is(':checked')) {
-        var uuid = $(sample).children('#sample_uuid').text();
+        var uuid = $(sample).children('#sample_uuid').attr('value');
         var isolateName = $(sample).children('#sample_isolate_name').text();
         return {uuid, isolateName};
       }

--- a/app/views/samples/_index_bulk_actions_js.haml
+++ b/app/views/samples/_index_bulk_actions_js.haml
@@ -49,7 +49,7 @@
     return $.map(samples, function(sample) {
       var checkboxInput = $(sample).find('input[name="sample_ids[]"]');
       if(checkboxInput.is(':checked')) {
-        var uuid = $(sample).children('#sample_uuid').attr('value');
+        var uuid = $(sample).children('#sample_uuid').data("uuid");
         var isolateName = $(sample).children('#sample_isolate_name').text();
         return {uuid, isolateName};
       }

--- a/app/views/samples/index.haml
+++ b/app/views/samples/index.haml
@@ -43,7 +43,7 @@
                 %td
                   =check_box_tag 'sample_ids[]', sample.id, false, { id: "sample_ids.#{sample.id}" }
                   %label.row{for: "sample_ids.#{sample.id}"}
-                %td{id: 'sample_uuid', value: sample.uuid}= short_uuid_with_title sample.uuid
+                %td{id: 'sample_uuid', data: {uuid: sample.uuid}}= short_uuid_with_title sample.uuid
                 %td{id: 'sample_isolate_name'}= sample.isolate_name
                 %td= sample.inactivation_method
                 %td= sample.specimen_role_description

--- a/app/views/samples/index.haml
+++ b/app/views/samples/index.haml
@@ -43,7 +43,7 @@
                 %td
                   =check_box_tag 'sample_ids[]', sample.id, false, { id: "sample_ids.#{sample.id}" }
                   %label.row{for: "sample_ids.#{sample.id}"}
-                %td{id: 'sample_uuid'}= short_uuid_with_title sample.uuid
+                %td{id: 'sample_uuid', value: sample.uuid}= short_uuid_with_title sample.uuid
                 %td{id: 'sample_isolate_name'}= sample.isolate_name
                 %td= sample.inactivation_method
                 %td= sample.specimen_role_description


### PR DESCRIPTION
Solves #1547. Since we start to show the middle ellipsis in the table of samples:

![image](https://user-images.githubusercontent.com/13782680/158998310-1700d6e8-60f5-4dc6-b47c-f578f580fe29.png)

This text was used to fulfill the sample transfers UUIDs.

Now its taking the value attribute of the samples and its working back:

![image](https://user-images.githubusercontent.com/13782680/158996204-4819890f-3b75-4262-ab02-677ed294ea48.png)

**Note:** There was not a failure from the server side, the operation appeared to be successful (not like in #1529 that there is a server error but no message is shown). A check of an existing uuid should be added in the sample transfers? a missing "foreign key"? 
