### PR TITLE
Allow access to qc_info when an a associated sample is authorized

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
     if has_access?(resource, action)
       check_access(resource, action)
     else
-      forbid_access(action, resource)
+      forbid_access(resource, action)
     end
   end
 
@@ -82,7 +82,7 @@ class ApplicationController < ActionController::Base
   # filters/authorize navigation_context institutions by action. Assign calls resource.institution= if action is allowed
   def prepare_for_institution_and_authorize(resource, action)
     if authorize_resource(@navigation_context.institution, action).blank?
-      forbid_access(action, resource)
+      forbid_access(resource, action)
     else
       resource.institution = @navigation_context.institution
     end
@@ -202,7 +202,7 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def forbid_access(action, resource)
+  def forbid_access(resource, action)
     log_authorization_warn resource, action
     head :forbidden
     nil

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,9 +47,7 @@ class ApplicationController < ActionController::Base
     if has_access?(resource, action)
       check_access(resource, action)
     else
-      log_authorization_warn resource, action
-      head :forbidden
-      nil
+      forbid_access(action, resource)
     end
   end
 
@@ -84,9 +82,7 @@ class ApplicationController < ActionController::Base
   # filters/authorize navigation_context institutions by action. Assign calls resource.institution= if action is allowed
   def prepare_for_institution_and_authorize(resource, action)
     if authorize_resource(@navigation_context.institution, action).blank?
-      log_authorization_warn resource, action
-      head :forbidden
-      nil
+      forbid_access(action, resource)
     else
       resource.institution = @navigation_context.institution
     end
@@ -205,6 +201,12 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def forbid_access(action, resource)
+    log_authorization_warn resource, action
+    head :forbidden
+    nil
+  end
 
   def pending_institution_invite_id_from_url
     url = session[:user_return_to] || request.original_url

--- a/app/controllers/qc_infos_controller.rb
+++ b/app/controllers/qc_infos_controller.rb
@@ -5,9 +5,17 @@ class QcInfosController < ApplicationController
     @qc_info = QcInfo.find(params[:id])
     @view_helper = view_helper({save_back_path: true})
 
-    return unless authorize_resource(@qc_info.samples.first, READ_SAMPLE)
+    authorize_qc_info
     @can_delete = false
     @can_update = false
+  end
+
+  private
+
+  def authorize_qc_info
+    has_access = @qc_info.samples.any? { |sample| has_access?(sample, READ_SAMPLE) }
+    forbid_access(@qc_info.samples.first, READ_SAMPLE) unless has_access
+    has_access
   end
 
 end


### PR DESCRIPTION
Fixes: #1530 

-Little refactor on application_helper.
-Allow access to QC Info when the user is authorized to access an associated sample