### PR TITLE
Fix filter sample transfers by `old_batch_number`

### DIFF
--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -8,7 +8,7 @@ class SampleTransfersController < ApplicationController
       .ordered_by_creation
 
     @sample_transfers = @sample_transfers.joins(sample: :sample_identifiers).where("sample_identifiers.uuid LIKE concat('%', ?, '%')", params[:sample_id]) unless params[:sample_id].blank?
-    @sample_transfers = @sample_transfers.joins(sample: :batch).where("batches.batch_number LIKE concat('%', ?, '%') OR samples.old_batch_number LIKE concat('%', ?, '%')", params[:batch_number], params[:batch_number]) unless params[:batch_number].blank?
+    @sample_transfers = @sample_transfers.joins(:sample).joins("LEFT JOIN batches ON batches.id = samples.batch_id").where("batches.batch_number LIKE concat('%', ?, '%') OR samples.old_batch_number LIKE concat('%', ?, '%')", params[:batch_number], params[:batch_number]) unless params[:batch_number].blank?
     @sample_transfers = @sample_transfers.joins(:sample).where("samples.isolate_name LIKE concat('%', ?, '%')", params[:isolate_name]) unless params[:isolate_name].blank?
     @sample_transfers = @sample_transfers.joins(:sample).where("samples.specimen_role = ?", params[:specimen_role]) unless params[:specimen_role].blank?
 

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe SampleTransfersController, type: :controller do
       end
 
       it "by old_batch_number" do
-        subject.sample.update(old_batch_number: "12345678")
-        get :index, batch_number: subject.sample.old_batch_number
-        expect(assigns(:sample_transfers).map(&:transfer)).to eq [subject]
+        transfer = SampleTransfer.make!(sender_institution: my_institution, sample: Sample.make!(:filled, specimen_role: "c", old_batch_number: "12345678"))
+        get :index, batch_number: "12345678"
+        expect(assigns(:sample_transfers).map(&:transfer)).to eq [transfer]
       end
 
       it "by isolate_name" do


### PR DESCRIPTION
Fixup for  #1544
I missed to add a left join on `batches` because the relation doesn't exist when `old_batch_number` is set.

The spec was also broken because the default sample has a batch associated and that made the spec pass.

Resolves #1538