### PR TITLE
Configure MySQL to nosync trx and binlogs (development)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
 
   db:
     image: mysql:5.7
+    command: --innodb-flush-method=nosync --innodb-flush-log-at-trx-commit=0 --innodb-flush-log-at-timeout=2700 --sync-binlog=0
     environment:
       MYSQL_ROOT_PASSWORD: root
     volumes:


### PR DESCRIPTION
Configure MySQL to avoid file sync (nosync, no binlog, no trx commit).

Highly unsafe, but fine in development. It helps shove a few minutes off the overall test suites. Let's see how it behaves in GHA.

Maybe we'd like to have an example compose override, instead of making these defaults?