### PR TITLE
Success message on transfer samples

### DIFF
--- a/app/assets/javascripts/components/flash_snackbar.js.jsx
+++ b/app/assets/javascripts/components/flash_snackbar.js.jsx
@@ -1,0 +1,33 @@
+var FlashSnackbar = React.createClass({
+  componentDidMount: function() {
+    var flashn = $(".flash-snackbar");
+    flashn.delay(3000).fadeOut(300);
+      $(".close-notification").click(function(){
+      flashn.hide();
+    });
+  },
+  render: function() {
+    return (
+        <div className="flash flash-snackbar">
+            <div className={"icon "+this.props.icon} />
+            <div className="flash-snackbar-message" > 
+                <span className="flash-snackbar-line1">{this.props.line1}</span> <br />
+                <span className="flash-snackbar-line2">{this.props.line2}</span>
+            </div>
+            <a className='close-notification'>x</a>
+        </div>
+    )
+  }
+});
+
+var SampleTransferSuccessSnackbar = React.createClass({
+  render: function() {
+    return (
+      <FlashSnackbar 
+        icon="icon-send" 
+        line1="Samples transferred successfully"
+        line2={String(this.props.samplesCount)+" sample"+(this.props.samplesCount===1?'':'s')+" transferred to "+this.props.institution}
+      />
+    )
+  }
+});

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -56,13 +56,6 @@ var SampleTransferModal = React.createClass({
     this.props.onFinished();
   },
 
-  successSnackbar : function(data) {
-    React.render(<SampleTransferSuccessSnackbar 
-      samplesCount={data.samples.length} 
-      institution={this.props.institutions.filter(e => e.value===data.institution_id)[0].label} 
-    />, document.getElementById("snackbar"));
-  },
-
 
   transferSamples: function() {
     const data = {
@@ -80,7 +73,11 @@ var SampleTransferModal = React.createClass({
         data: data,
         success: function () {
           this.closeModal();
-          this.successSnackbar(data);
+          React.render(
+            <SampleTransferSuccessSnackbar 
+              samplesCount={data.samples.length} 
+              institution={this.props.institutions.filter(e => e.value===data.institution_id)[0].label} 
+            />, document.getElementById("snackbar"));
           data.samples.forEach(element => {
             $('tr:has(td[data-uuid="'+element+'"])').remove()
           });          

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -56,6 +56,14 @@ var SampleTransferModal = React.createClass({
     this.props.onFinished();
   },
 
+  successSnackbar : function(data) {
+    React.render(<SampleTransferSuccessSnackbar 
+      samplesCount={data.samples.length} 
+      institution={this.props.institutions.filter(e => e.value===data.institution_id)[0].label} 
+    />, document.getElementById("snackbar"));
+  },
+
+
   transferSamples: function() {
     const data = {
       institution_id: this.state.institutionId,
@@ -72,7 +80,10 @@ var SampleTransferModal = React.createClass({
         data: data,
         success: function () {
           this.closeModal();
-          window.location.reload(true); // reload page to update users table
+          this.successSnackbar(data);
+          data.samples.forEach(element => {
+            $('tr:has(td[data-uuid="'+element+'"])').remove()
+          });          
         }.bind(this)
       });
     }

--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -308,6 +308,33 @@ a[title="Back"] {
   position: inherit;
 }
 
+.flash-snackbar{
+  display:flex;
+  align-items: center;
+  padding: 14px 6px;
+
+  .icon{
+    display: flex;
+    width: 48px;
+    height: 48px;
+    font-size: 30px;
+    border-radius: 50%;
+    background-color: black;
+    color: white;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .flash-snackbar-message{
+    margin-left:10px; 
+    margin-right:5px;
+
+    .flash-snackbar-line2{
+      font-weight: normal;
+    }
+  }
+}
+
 .explore-link {
   background: image-url('ic-search-blue.png') no-repeat left 2px;
   font-family: "Titillium Web", sans-serif;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,6 +70,13 @@ module ApplicationHelper
     I18n.localize(value, locale: current_user.locale, format: I18n.t('date.input_format.pattern'))
   end
 
+  def snackbar
+    res = content_tag :div, id: "snackbar" do 
+      '' 
+    end
+    res
+  end
+
   def flash_message
     res = nil
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,6 +13,7 @@
         = render "shared/header_nav"
 
       .content.row
+        = snackbar
         = flash_message
         .col.px-3#context_side_bar{"data-context-react-props": {context: @navigation_context.try(:to_hash) || {}}.to_json}
         .col


### PR DESCRIPTION
Close #1528.

**For this issue I took advantage to learn more about rails and react then:** 
- @diegoliberman maybe I should change some of the hours to the learning keyword.
- I'm suggesting @ysbaddaden and @straight-shoota both as reviewers since I'm not confident this is a good solution and all your input will be welcome. 

On successful sample transfers now a success message is displayed

![image](https://user-images.githubusercontent.com/13782680/159994497-bb3908fc-d9d3-4989-bd1e-bfc4736ad297.png)

Based on the [mockup](https://projects.invisionapp.com/d/main#/console/4103589/461729949/preview) of successful transfer samples, but also taking into account that there is a whole set of [snackbars](https://projects.invisionapp.com/d/main#/console/4103589/123213438/preview) that will be displayed I've created the _FlashSnackbar_ component, and its "child" component _SampleTransferSuccessSnackbar_. 

The snackbar name was taken from the Jony's mockups. It works like the flash notice but has a different design, then I've duplicated what is for flash notice for the snackbar (this wont work on redirect_to+:notice actions, all the messages now will look like these snackbars in the future and then it will replace them?)

_FlashSnackbar_ 

It takes the icon and the message's lines as parameters and display them with the proper style.

_SampleTransferSuccessSnackbar_

Creates a FlashSnackbar displaying the proper message with the number of transferred samples and the institution as parameters. 

@straight-shoota I didn't replaced the ajax call, I think I will need some pairing on this if you think what is in sample_transfer.js.jsx is a deficient solution. 

