### PR TITLE
Merge institutions#new_from_invite_data into institutions#new

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,8 +67,8 @@ class ApplicationController < ActionController::Base
       if has_access?(Institution, CREATE_INSTITUTION)
         pending_institution_invite_id = session[:pending_invite_id] || pending_institution_invite_id_from_url()
         pending_invite = PendingInstitutionInvite.find(pending_institution_invite_id) if pending_institution_invite_id
-        if pending_invite and pending_invite.is_pending?
-          redirect_to new_from_invite_data_institutions_path(pending_institution_invite_id: pending_institution_invite_id)
+        if pending_invite and pending_invite.pending?
+          redirect_to new_institution_path(pending_institution_invite_id: pending_institution_invite_id)
           return
         else
           redirect_to new_institution_path
@@ -135,8 +135,8 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource_or_scope)
     pending_invite_id = pending_institution_invite_id_from_url
-    if session[:user_return_to] == new_from_invite_data_institutions_path(pending_institution_invite_id: pending_invite_id) and has_access_to_institutions_create?
-      new_from_invite_data_institutions_path(pending_institution_invite_id: pending_invite_id)
+    if session[:user_return_to] == new_institution_path(pending_institution_invite_id: pending_invite_id) and has_access_to_institutions_create?
+      new_institution_path(pending_institution_invite_id: pending_invite_id)
     elsif has_access?(TestResult, Policy::Actions::MEDICAL_DASHBOARD)
       dashboard_path
     elsif has_access_to_sites_index?

--- a/app/models/pending_institution_invite.rb
+++ b/app/models/pending_institution_invite.rb
@@ -18,8 +18,24 @@ class PendingInstitutionInvite < ActiveRecord::Base
     where(invited_user_email: user.email,  status: 'pending').count > 0
   end
 
-  def is_pending?
+  def pending?
     status == 'pending'
   end
 
+  def accepted?
+    status == 'accepted'
+  end
+
+  def accept!
+    self.status = 'accepted'
+    save!
+  end
+
+  def to_institution_params
+    {
+      kind: institution_kind,
+      name: institution_name,
+      pending_institution_invite: self,
+    }
+  end
 end

--- a/app/views/invitation_mailer/create_institution_message.html.erb
+++ b/app/views/invitation_mailer/create_institution_message.html.erb
@@ -5,12 +5,12 @@
   Please follow the instructions to complete the signup
 </p>
 
-<p><%= link_to "Create Institution", new_from_invite_data_institutions_url(:pending_institution_invite_id => @pending_institution_invite_id), class: "btn-primary" %></p>
+<p><%= link_to "Create Institution", new_institution_url(:pending_institution_invite_id => @pending_institution_invite_id), class: "btn-primary" %></p>
 
 <% content_for :footer do %>
   <p class="footer">
     Link not working? Paste this into your browser:
-    <%= link_to new_from_invite_data_institutions_url(:pending_institution_invite_id => @pending_institution_invite_id), new_from_invite_data_institutions_url(:pending_institution_invite_id => @pending_institution_invite_id) %>
+    <%= link_to new_institution_url(:pending_institution_invite_id => @pending_institution_invite_id), new_institution_url(:pending_institution_invite_id => @pending_institution_invite_id) %>
   </p>
   <p class="footer"><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>
 <% end %>

--- a/features/support/page_objects/institution_page.rb
+++ b/features/support/page_objects/institution_page.rb
@@ -1,5 +1,5 @@
 class InstitutionNewFromInvitePage < CdxPageBase
-  set_url '/institutions/new_from_invite_data{?query*}'
+  set_url '/institutions/new{?query*}'
 
   element :name, :field, "Name"
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -123,7 +123,7 @@ describe UsersController, type: :controller do
       expect(invite.invited_by_user).to eq user
       expect(invite.institution_name).to eq "New Institution"
       expect(invite.institution_kind).to eq "institution"
-      expect(invite).to be_is_pending
+      expect(invite).to be_pending
     end
 
     it "fails for empty institution name and kind" do

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe InvitationMailer, type: :mailer do
     mail = InvitationMailer.create_institution_message(existing_user, current_user, invite, "custom message")
 
     html = Nokogiri::HTML(mail.body.to_s)
-    assert_link(html, new_from_invite_data_institutions_url(:pending_institution_invite_id => invite.id))
+    assert_link(html, new_institution_url(:pending_institution_invite_id => invite.id))
     body = html.content
     expect(body).to include("custom message")
     expect(body).to include(invite.institution_name)


### PR DESCRIPTION
Refactor of pending institution invite in institutions controller. Properly takes care of pending and accepted invites (or no invite), with an error flash message when the invitate has already been accepted, and a redirection when the invite can't be found.

closes #1467 