### PR TITLE
Sample transfer modal converted into form and success message shown

### DIFF
--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -133,7 +133,7 @@ var SampleTransferModal = React.createClass({
         <div className="row">
           <div className="col pe-3"><label>Institution</label></div>
           <div className="col">
-            <CdxSelect className="institution-select" name="institution" items={this.props.institutions} value={this.state.institutionId} onChange={this.changeInstitution} />
+            <CdxSelect className="institution-select" name="institution_id" items={this.props.institutions} value={this.state.institutionId} onChange={this.changeInstitution} />
             <span className="error"><div className="icon-error icon-red" /> Institution can't be blank</span>
           </div>
           

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -118,8 +118,9 @@ var SampleTransferModal = React.createClass({
         <label htmlFor="include-qc-check">Include a copy of the QC data</label>
       </div>
     </div>)
-  }
-  , render: function() {
+  }, 
+  
+  render: function() {
     return(
       <div className="samples-transfer-modal">
         <form action="/sample_transfers" method="post">

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -124,33 +124,30 @@ var SampleTransferModal = React.createClass({
     return(
       <div className="samples-transfer-modal">
         <form action="/sample_transfers" method="post">
-        <div className="row">
-          <div className="col pe-3"><label>Samples</label></div>
-          <div className="col">
-            {this.batchSamples()}
-          </div>
-        </div>
-        <div className="row">
-          <div className="col pe-3"><label>Institution</label></div>
-          <div className="col">
-            <CdxSelect className="institution-select" name="institution_id" items={this.props.institutions} value={this.state.institutionId} onChange={this.changeInstitution} />
-            <span className="error"><div className="icon-error icon-red" /> Institution can't be blank</span>
-          </div>
-          
-        </div>
-        {this.showQcWarningCheckbox(this.state.selectedSamples)}
-        <div className="modal-footer">
-          <div className="footer-buttons-aligning">
-            <div>
-              <button className="btn btn-link" onClick={this.closeModal}>Cancel</button>
-              <button className="btn btn-primary" type="submit">Transfer</button>
+          <div className="row">
+            <div className="col pe-3"><label>Samples</label></div>
+            <div className="col">
+              {this.batchSamples()}
             </div>
-            <div />
           </div>
-        </div>
-      </form>
+          <div className="row">
+            <div className="col pe-3"><label>Institution</label></div>
+            <div className="col">
+              <CdxSelect className="institution-select" name="institution_id" items={this.props.institutions} value={this.state.institutionId} onChange={this.changeInstitution} />
+              <span className="error"><div className="icon-error icon-red" /> Institution can't be blank</span>
+            </div>
+          </div>
+          {this.showQcWarningCheckbox(this.state.selectedSamples)}
+          <div className="modal-footer">
+            <div className="footer-buttons-aligning">
+              <div>
+                <button className="btn btn-link" onClick={this.closeModal}>Cancel</button>
+                <button className="btn btn-primary" type="submit">Transfer</button>
+              </div>
+            </div>
+          </div>
+        </form>
       </div>
-
     )
   },
 

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -107,7 +107,7 @@ var SampleTransferModal = React.createClass({
     if ($("#include-qc-check").is(":checked")) {
       $("#include-qc-check").attr("value", "true");
     } else {
-      $("#include-qc-check").attr("value", "fañse");
+      $("#include-qc-check").attr("value", "false");
     }
   },
 

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -104,11 +104,8 @@ var SampleTransferModal = React.createClass({
       includeQcInfo: !oldValue
     });
 
-    if ($("#include-qc-check").is(":checked")) {
-      $("#include-qc-check").attr("value", "true");
-    } else {
-      $("#include-qc-check").attr("value", "false");
-    }
+    var qcChecked = $("#include-qc-check");
+    qcChecked.attr("value", !qcChecked.is(":checked"));
   },
 
   includeQcInfoCheckbox: function () {

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -48,37 +48,6 @@ var SampleTransferModal = React.createClass({
     )
   },
 
-  closeModal: function(event) {
-    if(event) {
-      event.preventDefault();
-    }
-
-    this.props.onFinished();
-  },
-
-  transferSamples: function() {
-    const data = {
-      institution_id: this.state.institutionId,
-      includes_qc_info: this.state.includeQcInfo,
-      samples: this.state.selectedSamples.map((sample) => sample.uuid)
-    }
-    if (data.institution_id == null){
-      $(".institution-select").addClass("input-required");
-    }
-    else{
-      $.ajax({
-        url: '/sample_transfers',
-        method: 'POST',
-        data: data,
-        success: function () {
-          this.closeModal();
-          window.location.reload(true); // reload page to update users table
-        }.bind(this)
-      });
-    }
-
-  },
-
   batchSamples: function() {
     let checkedSamples = this.state.selectedSamples
     const listItems = checkedSamples.map((sample) => this.sampleRow(sample));
@@ -96,6 +65,7 @@ var SampleTransferModal = React.createClass({
     return (
       <div className="col batches-samples">
         <div className="samples-row">
+          <input type="hidden" name="samples[]" value={sampleData.uuid} />
           <div className="samples-item transfer-data">
             { sampleData.uuid.length > 23 ?
               sampleData.uuid.substring(0, 23) + '...' :
@@ -121,6 +91,7 @@ var SampleTransferModal = React.createClass({
     return (
       <div className="row">
         <div className="col icon-info-outline icon-gray qc-info-message">
+          <input type="hidden" name="includes_qc_info" value="false" />
           <div className="notification-text">{infoMessage}</div>
         </div>
       </div>
@@ -132,20 +103,26 @@ var SampleTransferModal = React.createClass({
     this.setState({
       includeQcInfo: !oldValue
     });
+
+    if ($("#include-qc-check").is(":checked")) {
+      $("#include-qc-check").attr("value", "true");
+    } else {
+      $("#include-qc-check").attr("value", "fañse");
+    }
   },
 
   includeQcInfoCheckbox: function () {
     return (<div className="row">
       <div className="col pe-3 qc-info-checkbox">
-        <input id="include-qc-check" type="checkbox" checked={this.state.includeQcInfo} onChange={this.toggleQcInfo}/>
+        <input name="includes_qc_info" id="include-qc-check" type="checkbox" checked={this.state.includeQcInfo} onChange={this.toggleQcInfo}/>
         <label htmlFor="include-qc-check">Include a copy of the QC data</label>
       </div>
     </div>)
-
-
-  }, render: function() {
+  }
+  , render: function() {
     return(
       <div className="samples-transfer-modal">
+        <form action="/sample_transfers" method="post">
         <div className="row">
           <div className="col pe-3"><label>Samples</label></div>
           <div className="col">
@@ -165,11 +142,12 @@ var SampleTransferModal = React.createClass({
           <div className="footer-buttons-aligning">
             <div>
               <button className="btn btn-link" onClick={this.closeModal}>Cancel</button>
-              <button className="btn btn-primary" type="button" onClick={this.transferSamples}>Transfer</button>
+              <button className="btn btn-primary" type="submit">Transfer</button>
             </div>
             <div />
           </div>
         </div>
+      </form>
       </div>
 
     )

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -25,7 +25,8 @@ class SampleTransfersController < ApplicationController
       redirect_to samples_path
     else
       if create_transfer(new_owner, params["samples"])
-        redirect_to samples_path, notice: "All samples have been transferred successfully. "
+        flash[:notice] =  "All samples have been transferred successfully. "
+        redirect_to samples_path, success: "All samples have been transferred successfully. "
       else
         flash[:error] = "Samples transfer failed. "
         redirect_to samples_path

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -21,12 +21,14 @@ class SampleTransfersController < ApplicationController
   def create
     new_owner = Institution.find_by(uuid: params["institution"])
     if new_owner.nil?
-      redirect_to samples_path, notice: "Destination Institution does not exists."
+      flash[:error] = "Destination Institution does not exists."
+      redirect_to samples_path
     else
       if create_transfer(new_owner, params["samples"])
         redirect_to samples_path, notice: "All samples have been transferred successfully. "
       else
-        redirect_to samples_path, notice: "Transfer failed."
+        flash[:error] = "Samples transfer failed. "
+        redirect_to samples_path
       end
     end
   end

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -28,7 +28,7 @@ class SampleTransfersController < ApplicationController
         flash[:notice] =  "All samples have been transferred successfully."
         redirect_to samples_path
       else
-        flash[:error] = "Samples transfer failed. "
+        flash[:error] = "Samples transfer failed."
         redirect_to samples_path
       end
     end

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -25,7 +25,7 @@ class SampleTransfersController < ApplicationController
       redirect_to samples_path
     else
       if create_transfer(new_owner, params["samples"])
-        flash[:notice] =  "All samples have been transferred successfully. "
+        flash[:notice] =  "All samples have been transferred successfully."
         redirect_to samples_path
       else
         flash[:error] = "Samples transfer failed. "

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -26,7 +26,7 @@ class SampleTransfersController < ApplicationController
     else
       if create_transfer(new_owner, params["samples"])
         flash[:notice] =  "All samples have been transferred successfully. "
-        redirect_to samples_path, success: "All samples have been transferred successfully. "
+        redirect_to samples_path
       else
         flash[:error] = "Samples transfer failed. "
         redirect_to samples_path

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -19,7 +19,7 @@ class SampleTransfersController < ApplicationController
   end
 
   def create
-    new_owner = Institution.find_by(uuid: params["institution"])
+    new_owner = Institution.find_by(uuid: params["institution_id"])
     if new_owner.nil?
       flash[:error] = "Destination Institution does not exists."
       redirect_to samples_path

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe SampleTransfersController, type: :controller do
       post :create, institution_id: other_institution.uuid, samples: [sample.uuid]
 
       expect(response).to redirect_to(samples_path)
-      expect(flash.to_h).to eq({ "notice" => "All samples have been transferred successfully. " })
+      expect(flash.to_h).to eq({ "notice" => "All samples have been transferred successfully." })
 
       sample.reload
       expect(sample.site).to be_nil
@@ -94,7 +94,7 @@ RSpec.describe SampleTransfersController, type: :controller do
       post :create, institution_id: other_institution.uuid, samples: samples.map(&:uuid)
 
       expect(response).to redirect_to(samples_path)
-      expect(flash.to_h).to eq({ "notice" => "All samples have been transferred successfully. " })
+      expect(flash.to_h).to eq({ "notice" => "All samples have been transferred successfully." })
 
       samples.each(&:reload)
       expect(samples.map(&:site)).to eq [nil] * 3

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe SampleTransfersController, type: :controller do
 
       post :create, institution_id: other_institution.uuid, samples: [sample.uuid]
 
-      expect(response).to be_success
-      expect(flash.to_h).to eq({ "success" => "All samples have been transferred successfully." })
+      expect(response).to redirect_to(samples_path)
+      expect(flash.to_h).to eq({ "notice" => "All samples have been transferred successfully. " })
 
       sample.reload
       expect(sample.site).to be_nil
@@ -93,8 +93,8 @@ RSpec.describe SampleTransfersController, type: :controller do
 
       post :create, institution_id: other_institution.uuid, samples: samples.map(&:uuid)
 
-      expect(response).to be_success
-      expect(flash.to_h).to eq({ "success" => "All samples have been transferred successfully." })
+      expect(response).to redirect_to(samples_path)
+      expect(flash.to_h).to eq({ "notice" => "All samples have been transferred successfully. " })
 
       samples.each(&:reload)
       expect(samples.map(&:site)).to eq [nil] * 3


### PR DESCRIPTION
Closes #1528.

Samples transfer modal is now an html form and is not making ajax call to create sample transfers.

On success it shows the following notice

![image](https://user-images.githubusercontent.com/13782680/160104640-837bf384-bb25-45dc-9332-d6e83c1351d2.png)

(same on errors, keeping the logic and the messages that were implemented in sample transfers controller create method)

**Note:** I had to add the following in the sample transfers controller (I saw that there is used in other parts of the code but wanted to be sure this is noted since I'm not sure of the consequences): 
```
skip_before_filter :verify_authenticity_token, :only => :create
skip_before_filter :ensure_context, :only => :create
```