### PR TITLE
Fix: tiny optimizations quick wins

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -18,6 +18,16 @@ class BatchesController < ApplicationController
     @batches = perform_pagination(@batches)
   end
 
+  def edit_or_show
+    batch = Batch.find(params[:id])
+
+    if has_access?(batch, UPDATE_BATCH)
+      redirect_to edit_batch_path(batch)
+    else
+      redirect_to batch_path(batch)
+    end
+  end
+
   def show
     batch = Batch.find(params[:id])
     @batch_form = BatchForm.for(batch)

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -25,6 +25,16 @@ class SamplesController < ApplicationController
       .preload(:batch, :sample_identifiers)
   end
 
+  def edit_or_show
+    sample = Sample.find(params[:id])
+
+    if has_access?(sample, UPDATE_SAMPLE)
+      redirect_to edit_sample_path(sample)
+    else
+      redirect_to sample_path(sample)
+    end
+  end
+
   def show
     sample = Sample.find(params[:id])
     @sample_form = SampleForm.for(sample)

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -22,6 +22,7 @@ class SamplesController < ApplicationController
       .map { |uuid, name| { value: uuid, label: name } }
 
     @samples = perform_pagination(@samples)
+      .preload(:batch, :sample_identifiers)
   end
 
   def show

--- a/app/views/batches/index.haml
+++ b/app/views/batches/index.haml
@@ -30,7 +30,7 @@
               %th Lab Technician
           - t.tbody do
             - @batches.each do |batch|
-              %tr.laboratory-sample-row{data: {href: has_access?(batch, Policy::Actions::UPDATE_BATCH) ? edit_batch_path(batch) : batch_path(batch)}}
+              %tr.laboratory-sample-row{data: {href: edit_or_show_batch_path(batch)}}
                 %td
                   =check_box_tag 'batch_ids[]', batch.id, false, { id: "batch_ids.#{batch.id}" }
                   %label.row{for: "batch_ids.#{batch.id}"}

--- a/app/views/samples/index.haml
+++ b/app/views/samples/index.haml
@@ -39,7 +39,7 @@
               %th Production Date
           - t.tbody do
             - @samples.each do |sample|
-              %tr.laboratory-sample-row{data: { hasQcReference: sample.batch.nil? ? false.to_s : sample.batch.has_qc_sample?.to_s, is_qc: sample.is_quality_control?.to_s, href: has_access?(sample, Policy::Actions::UPDATE_SAMPLE) ? edit_sample_path(sample) : sample_path(sample)}}
+              %tr.laboratory-sample-row{data: { hasQcReference: sample.batch.nil? ? false.to_s : sample.batch.has_qc_sample?.to_s, is_qc: sample.is_quality_control?.to_s, href: edit_or_show_sample_path(sample)}}
                 %td
                   =check_box_tag 'sample_ids[]', sample.id, false, { id: "sample_ids.#{sample.id}" }
                   %label.row{for: "sample_ids.#{sample.id}"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,7 @@ Rails.application.routes.draw do
   end
   resources :batches do
     member do
+      get 'edit_or_show'
       post 'add_sample'
     end
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
   resources :samples do
     member do
       get 'print'
+      get 'edit_or_show'
     end
     collection do
       get 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'print' }, action: :bulk_print

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -85,12 +85,12 @@ RSpec.describe BatchesController, type: :controller do
   context "edit_or_show" do
     let!(:batch) { Batch.make! institution: institution }
 
-    it "redirects to edit when user has UPDATE_SAMPLE permission" do
+    it "redirects to edit when user has UPDATE_BATCH permission" do
       get :edit_or_show, id: batch.id
       expect(response).to redirect_to(edit_batch_path(batch))
     end
 
-    it "redirects to show when user doesn't have UPDATE_SAMPLE permission" do
+    it "redirects to show when user doesn't have UPDATE_BATCH permission" do
       sign_in other_user
 
       get :edit_or_show, id: batch.id

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe BatchesController, type: :controller do
     end
   end
 
+  context "edit_or_show" do
+    let!(:batch) { Batch.make! institution: institution }
+
+    it "redirects to edit when user has UPDATE_SAMPLE permission" do
+      get :edit_or_show, id: batch.id
+      expect(response).to redirect_to(edit_batch_path(batch))
+    end
+
+    it "redirects to show when user doesn't have UPDATE_SAMPLE permission" do
+      sign_in other_user
+
+      get :edit_or_show, id: batch.id
+      expect(response).to redirect_to(batch_path(batch))
+    end
+  end
+
   context "show" do
     let!(:batch) { Batch.make! institution: institution }
 

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -84,6 +84,26 @@ RSpec.describe SamplesController, type: :controller do
     end
   end
 
+  context "edit_or_show" do
+    let!(:sample) do
+      Sample.make! institution: institution, sample_identifiers: [
+        SampleIdentifier.make!(uuid: '01234567-8ce1-a0c8-ac1b-58bed3633e88'),
+      ]
+    end
+
+    it "redirects to edit when user has UPDATE_SAMPLE permission" do
+      get :edit_or_show, id: sample.id
+      expect(response).to redirect_to(edit_sample_path(sample))
+    end
+
+    it "redirects to show when user doesn't have UPDATE_SAMPLE permission" do
+      sign_in other_user
+
+      get :edit_or_show, id: sample.id
+      expect(response).to redirect_to(sample_path(sample))
+    end
+  end
+
   context "show" do
     let!(:sample) do
       Sample.make! institution: institution, sample_identifiers: [SampleIdentifier.make!(uuid: '01234567-8ce1-a0c8-ac1b-58bed3633e88')]


### PR DESCRIPTION
While trying out a pull request, I noticed lots of repeated SQL requests in the Rails' log, so I went to add a few simple optimizations to heavily reduce the number of SQL requests in `samples#index` and `batches#show`.

With a list of 10 samples, this replaces 20 SQL requests for 2 requests just by preloading the `:batch` and `:sample_identifiers` associations (a one line optimization), and removes 20 other SQL requests by delaying the access check into an intermediary action (`edit_or_show`) that will only check the permission for one sample on demand.

This is a total of 38 less SQL requests each time we render a list of samples :tada: 

The same `edit_or_show` action was added to batches, with the same result. There was no association to preload so we only removed 20 requests in total :shrug: 

**We can certainly do the same in other controllers!**