### PR TITLE
Fix back button navigation between qc_info and samples

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -139,6 +139,7 @@ class SamplesController < ApplicationController
     return unless authorize_resource(sample, UPDATE_SAMPLE)
 
     @view_helper = view_helper({ save_back_path: true })
+    @view_helper[:back_path] = samples_path unless sample.qc_info.nil?
 
     @show_barcode_preview = true
     @show_print_action = true

--- a/app/views/qc_infos/edit.haml
+++ b/app/views/qc_infos/edit.haml
@@ -4,7 +4,7 @@
       .row
         .col
           %h2
-            = link_to @view_helper[:back_path], class: 'side-link', title: 'Back' do
+            = link_to edit_sample_path(id: params[:sample_id]), class: 'side-link', title: 'Back' do
               = image_tag "arrow-left.png"
             = @qc_info.uuid
 

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -9,7 +9,7 @@
           .col.pe-4
             = f.label :quality_control
           .col
-            = link_to edit_qc_info_path(f.object.qc_info.id), class: 'centered' do
+            = link_to edit_qc_info_path(f.object.qc_info.id, sample_id: f.object.id), class: 'centered' do
               .icon-test.icon-blue
               = "VIEW QC INFO"
 


### PR DESCRIPTION
Fixes: #1536 

- Replace back link un qc_info form to go to its associated sample
- Force back button link in sample form to go to samples index when the sample has an associated qc_info.
Little bit of background for the latter: Since the sample has an associated qc_info, it means that the sample was transferred and thus, it doesn't belong to a batch. Dynamic back button link was created because user can access samples via the Batch form or via the samples index. Since the sample does not belong to a batch, it means that the back button should always point to samples index.