### PR TITLE
Introduce TransferPackage + Responsible Person

### DIFF
--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -125,12 +125,12 @@ var SampleTransferModal = React.createClass({
 
   includeQcInfoCheckbox: function () {
     return (<div className="row">
-      <div className="col pe-3 qc-info-checkbox">
+      <div className="col pe-4 qc-info-checkbox">
         <input name="includes_qc_info" id="include-qc-check" type="checkbox" checked={this.state.includeQcInfo} onChange={this.toggleQcInfo}/>
         <label htmlFor="include-qc-check">Include a copy of the QC data</label>
       </div>
     </div>)
-  }, 
+  },
 
   componentDidMount: function() {
     this.setState({ listHeight: this.scrollableElement.getDOMNode().clientHeight });
@@ -141,18 +141,24 @@ var SampleTransferModal = React.createClass({
       <div className="samples-transfer-modal" onScroll={this.handleScroll}>
         <form action="/sample_transfers" method="post">
           <div className="row">
-            <div className="col pe-3"><label>Samples</label></div>
+            <div className="col pe-4"><label>Institution</label></div>
+            <div className="col">
+              <CdxSelect className="institution-select" name="institution_id" items={this.props.institutions} value={this.state.institutionId} onChange={this.changeInstitution} />
+              <span className="error"><div className="icon-error icon-red" /> Institution can't be blank</span>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col pe-4"><label>Responsible Person</label></div>
+            <div className="col">
+              <input type="text" name="recipient" className="input-block"/>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col pe-4"><label>Samples</label></div>
             <div className={`gradients ${this.state.bottomReached ? "bottom" : "" } ${this.state.topReached ? "top" : "" } `}>
               <div className="col samples-list" ref={ (scrollableElement) => { this.scrollableElement = scrollableElement } }>
                 {this.batchSamples()}
               </div>
-            </div>
-          </div>
-          <div className="row">
-            <div className="col pe-3"><label>Institution</label></div>
-            <div className="col">
-              <CdxSelect className="institution-select" name="institution_id" items={this.props.institutions} value={this.state.institutionId} onChange={this.changeInstitution} />
-              <span className="error"><div className="icon-error icon-red" /> Institution can't be blank</span>
             </div>
           </div>
           {this.showQcWarningCheckbox(this.state.selectedSamples)}

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -2,7 +2,7 @@ class SampleTransfersController < ApplicationController
   helper_method :can_confirm_transfer?
   skip_before_filter :verify_authenticity_token, :only => :create
   skip_before_filter :ensure_context, :only => :create
-  
+
   def index
     @sample_transfers = SampleTransfer
       .within(@navigation_context.institution)
@@ -15,7 +15,8 @@ class SampleTransfersController < ApplicationController
     @sample_transfers = @sample_transfers.joins(:sample).where("samples.specimen_role = ?", params[:specimen_role]) unless params[:specimen_role].blank?
 
     @sample_transfers = perform_pagination(@sample_transfers)
-    @sample_transfers = @sample_transfers.map { |t| SampleTransferPresenter.new(t, @navigation_context) }
+      .preload(:transfer_package, :sample, :sender_institution, :receiver_institution)
+      .map { |transfer| SampleTransferPresenter.new(transfer, @navigation_context) }
   end
 
   def create
@@ -68,19 +69,15 @@ class SampleTransfersController < ApplicationController
 
   def create_transfer(new_owner, samples)
     samples = Sample.joins(:sample_identifiers).where("sample_identifiers.uuid": samples)
+
     Sample.transaction do
-      samples.each do |to_transfer|
-        raise "User not authorized for transferring Samples " unless authorize_resource?(to_transfer, UPDATE_SAMPLE)
-        raise "QC Samples can't be transferred" if to_transfer.is_quality_control?
+      package = TransferPackage.sending_to(new_owner, transfer_package_params)
 
-        unless to_transfer.batch.nil?
-          if params["includes_qc_info"] == "true"
-            qc_info = create_qc_info(to_transfer)
-            to_transfer.qc_info_id = qc_info.id if qc_info
-          end
-        end
+      samples.each do |sample|
+        raise "User not authorized for transferring Samples " unless authorize_resource?(sample, UPDATE_SAMPLE)
+        raise "QC Samples can't be transferred" if sample.is_quality_control?
 
-        to_transfer.start_transfer_to(new_owner)
+        package.add!(sample)
       end
     end
 
@@ -91,13 +88,7 @@ class SampleTransfersController < ApplicationController
     false
   end
 
-  def create_qc_info(sample)
-    sample_qc = sample.batch.qc_sample
-    return if sample_qc.nil?
-
-    qc_info = QcInfo.find_or_duplicate_from(sample_qc)
-    qc_info.samples << sample
-    qc_info.save!
-    qc_info
+  def transfer_package_params
+    params.permit(:recipient, :includes_qc_info)
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -85,16 +85,4 @@ class Sample < ActiveRecord::Base
   def has_entity_id?
     entity_ids.compact.any?
   end
-
-  def start_transfer_to(new_owner)
-    transfer = SampleTransfer.create!(
-      sample: self,
-      receiver_institution: new_owner,
-    )
-
-    self.old_batch_number = batch.batch_number unless batch.nil?
-    update!(batch: nil, site: nil, institution: nil)
-
-    transfer
-  end
 end

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -2,7 +2,9 @@ class SampleTransfer < ActiveRecord::Base
   belongs_to :sample
   belongs_to :sender_institution, class_name: "Institution"
   belongs_to :receiver_institution, class_name: "Institution"
+  belongs_to :transfer_package, required: false
 
+  # TODO: remove these after upgrading to Rails 5.0 (belongs_to associations are required by default):
   validates_presence_of :sample
   validates_presence_of :sender_institution
   validates_presence_of :receiver_institution

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -1,0 +1,45 @@
+class TransferPackage < ActiveRecord::Base
+  belongs_to :receiver_institution, class_name: "Institution"
+  has_many :sample_transfers
+
+  after_initialize do
+    self.uuid ||= SecureRandom.uuid
+  end
+
+  def self.sending_to(institution, attributes = nil)
+    create!(attributes) do |package|
+      package.receiver_institution = institution
+    end
+  end
+
+  def add!(sample)
+    transfer = sample_transfers.create!(
+      sample: sample,
+      receiver_institution: receiver_institution,
+    )
+
+    if sample.batch
+      if includes_qc_info && (qc_info = create_qc_info(sample))
+        sample.qc_info = qc_info
+      end
+
+      sample.old_batch_number = sample.batch.batch_number
+    end
+
+    sample.update!(batch: nil, site: nil, institution: nil)
+
+    transfer
+  end
+
+  private
+
+  def create_qc_info(sample)
+    sample_qc = sample.batch.qc_sample
+    return unless sample_qc
+
+    qc_info = QcInfo.find_or_duplicate_from(sample_qc)
+    qc_info.samples << sample
+    qc_info.save!
+    qc_info
+  end
+end

--- a/app/presenters/sample_transfer_presenter.rb
+++ b/app/presenters/sample_transfer_presenter.rb
@@ -7,7 +7,7 @@ class SampleTransferPresenter
   end
 
   # TODO(Rails 5.1): Use delegate_missing
-  delegate :sample, :confirmed_at, :confirmed?, :created_at, :receiver_institution, :sender_institution, to: :transfer
+  delegate :transfer_package, :sample, :confirmed_at, :confirmed?, :created_at, :receiver_institution, :sender_institution, to: :transfer
 
   def receiver?
     context.institution == transfer.receiver_institution
@@ -45,5 +45,9 @@ class SampleTransferPresenter
     else
       sample.partial_uuid + "XXXX"
     end
+  end
+
+  def recipient
+    transfer_package.try(&:recipient)
   end
 end

--- a/app/views/sample_transfers/index.haml
+++ b/app/views/sample_transfers/index.haml
@@ -9,17 +9,19 @@
     - else
       = cdx_table title: pluralize(@total, "sample transfer") do |t|
         - t.columns do
+          %col{:width => "16%"}
+          %col{:width => "16%"}
+          %col{:width => "16%"}
+          %col{:width => "16%"}
+          %col{:width => "16%"}
           %col{:width => "20%"}
-          %col{:width => "20%"}
-          %col{:width => "20%"}
-          %col{:width => "20%"}
-          %col{:width => "25%"}
         - t.thead do
           %tr
             %th Sample Id
             %th Isolate Name
             %th Inactivation Method
-            %th Transfer
+            %th Institution
+            %th Responsible Person
             %th Status
         - t.tbody do
           - @sample_transfers.each do |transfer|
@@ -28,6 +30,7 @@
               %td= transfer.sample.isolate_name
               %td= transfer.sample.inactivation_method
               %td= transfer.other_institution
+              %td= transfer.recipient
               - if confirmed_at = transfer.confirmed_at
                 %td{title: "#{transfer.receiver_institution} confirmed receipt on #{I18n.l(confirmed_at)}"}
                   = transfer.receiver? ? "Receipt confirmed on" : "Delivery confirmed on"

--- a/db/migrate/20220331164557_create_transfer_packages.rb
+++ b/db/migrate/20220331164557_create_transfer_packages.rb
@@ -1,0 +1,19 @@
+class CreateTransferPackages < ActiveRecord::Migration
+  def up
+    create_table :transfer_packages do |t|
+      t.belongs_to :receiver_institution,            null: false
+      t.string     :uuid,                 limit: 36, null: false
+      t.string     :recipient
+      t.boolean    :includes_qc_info, default: false
+    end
+
+    change_table :sample_transfers do |t|
+      t.belongs_to :transfer_package
+    end
+  end
+
+  def down
+    remove_column :sample_transfers, :transfer_package_id
+    drop_table :transfer_packages
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220222115959) do
+ActiveRecord::Schema.define(version: 20220331164557) do
 
   create_table "alert_condition_results", force: :cascade do |t|
     t.string  "result",   limit: 255
@@ -540,6 +540,7 @@ ActiveRecord::Schema.define(version: 20220222115959) do
     t.datetime "confirmed_at"
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
+    t.integer  "transfer_package_id",     limit: 4
   end
 
   add_index "sample_transfers", ["confirmed_at"], name: "index_sample_transfers_on_confirmed_at", using: :btree
@@ -661,6 +662,13 @@ ActiveRecord::Schema.define(version: 20220222115959) do
   add_index "test_results", ["sample_identifier_id"], name: "index_test_results_on_sample_identifier_id", using: :btree
   add_index "test_results", ["site_id"], name: "index_test_results_on_site_id", using: :btree
   add_index "test_results", ["uuid"], name: "index_test_results_on_uuid", using: :btree
+
+  create_table "transfer_packages", force: :cascade do |t|
+    t.integer "receiver_institution_id", limit: 4,                   null: false
+    t.string  "uuid",                    limit: 36,                  null: false
+    t.string  "recipient",               limit: 255
+    t.boolean "includes_qc_info",                    default: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                          limit: 255, default: "",    null: false

--- a/spec/features/sample_transfers_spec.rb
+++ b/spec/features/sample_transfers_spec.rb
@@ -97,7 +97,7 @@ describe "sample transfers" do
 
     it "verifies sample id" do
       sample = Sample.make!(:filled, institution: institution_a)
-      transfer = sample.start_transfer_to(institution_b)
+      transfer = TransferPackage.sending_to(institution_b).add!(sample)
 
       sign_in user_b
 

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -154,6 +154,12 @@ LoincCode.blueprint do
   component { Faker::Lorem.words(4) }
 end
 
+TransferPackage.blueprint do
+  uuid { SecureRandom.uuid }
+  receiver_institution { Institution.make! }
+  recipient { Faker::Name.name }
+end
+
 SampleTransfer.blueprint do
   sample { Sample.make!(:filled) }
   receiver_institution { Institution.make! }


### PR DESCRIPTION
This is an internal refactor and thus totally transparent. It somewhat helps to clean up the `Sample` and `SampleTransfersController` objects by moving the data manipulation into the `TransferPackage` object.

~~All that's left is to add the recipient field and the table column.~~

closes #1572 