### PR TITLE
Fix includes qc_info param when checkbox is checked 

### DIFF
--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -102,13 +102,9 @@ var SampleTransferModal = React.createClass({
   },
 
   toggleQcInfo: function() {
-    var oldValue = this.state.includeQcInfo;
     this.setState({
-      includeQcInfo: !oldValue
+      includeQcInfo: !this.state.includeQcInfo
     });
-
-    var qcChecked = $("#include-qc-check");
-    qcChecked.attr("value", !oldValue);
   },
 
   handleScroll: function(event) {

--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -108,7 +108,7 @@ var SampleTransferModal = React.createClass({
     });
 
     var qcChecked = $("#include-qc-check");
-    qcChecked.attr("value", !qcChecked.is(":checked"));
+    qcChecked.attr("value", !oldValue);
   },
 
   handleScroll: function(event) {


### PR DESCRIPTION
Fix input value when the checkbox is checked to be the correct one and to match the includesQcInfo flag from component state. This way there won't be missmatches from the UI and what should happen in the backend.

refs #1573 