### PR TITLE
Cancel transfer sample now cancels the transfer

### DIFF
--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -159,7 +159,7 @@ var SampleTransferModal = React.createClass({
           <div className="modal-footer">
             <div className="footer-buttons-aligning">
               <div>
-                <button className="btn btn-link" onClick={this.closeModal}>Cancel</button>
+                <button className="btn btn-link" onClick={this.props.onFinished}>Cancel</button>
                 <button className="btn btn-primary" type="submit">Transfer</button>
               </div>
             </div>


### PR DESCRIPTION
Based on what closeModal function do in other modals, now in transfer samples when cancel is pressed the function `this.props.onFinished` is called.