### PR TITLE
Add parallel_tests to run specs in parallel

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,4 @@
---color --require spec_helper
+--color
+--require spec_helper
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/Dockerfile.selenium
+++ b/Dockerfile.selenium
@@ -12,4 +12,15 @@ RUN apk del curl
 EXPOSE 4444
 EXPOSE 5900
 
-ENTRYPOINT ["geckodriver", "--host", "0.0.0.0"]
+RUN echo "#! /usr/bin/env sh" > /entrypoint.sh && \
+    echo "geckodriver --host 0.0.0.0 -p 4444 &" >> /entrypoint.sh && \
+    echo "geckodriver --host 0.0.0.0 -p 4445 &" >> /entrypoint.sh && \
+    echo "geckodriver --host 0.0.0.0 -p 4446 &" >> /entrypoint.sh && \
+    echo "geckodriver --host 0.0.0.0 -p 4447 &" >> /entrypoint.sh && \
+    echo "geckodriver --host 0.0.0.0 -p 4448 &" >> /entrypoint.sh && \
+    echo "geckodriver --host 0.0.0.0 -p 4449 &" >> /entrypoint.sh && \
+    echo "geckodriver --host 0.0.0.0 -p 4450 &" >> /entrypoint.sh && \
+    echo "geckodriver --host 0.0.0.0 -p 4451" >> /entrypoint.sh && \
+    chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.selenium
+++ b/Dockerfile.selenium
@@ -12,15 +12,4 @@ RUN apk del curl
 EXPOSE 4444
 EXPOSE 5900
 
-RUN echo "#! /usr/bin/env sh" > /entrypoint.sh && \
-    echo "geckodriver --host 0.0.0.0 -p 4444 &" >> /entrypoint.sh && \
-    echo "geckodriver --host 0.0.0.0 -p 4445 &" >> /entrypoint.sh && \
-    echo "geckodriver --host 0.0.0.0 -p 4446 &" >> /entrypoint.sh && \
-    echo "geckodriver --host 0.0.0.0 -p 4447 &" >> /entrypoint.sh && \
-    echo "geckodriver --host 0.0.0.0 -p 4448 &" >> /entrypoint.sh && \
-    echo "geckodriver --host 0.0.0.0 -p 4449 &" >> /entrypoint.sh && \
-    echo "geckodriver --host 0.0.0.0 -p 4450 &" >> /entrypoint.sh && \
-    echo "geckodriver --host 0.0.0.0 -p 4451" >> /entrypoint.sh && \
-    chmod +x /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["geckodriver", "--host", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,7 @@ group :development do
   gem 'listen', '~> 3.0.5' if next?
   gem 'quiet_assets' unless next?
   gem 'spring'
+  gem 'spring-commands-parallel-tests'
   gem 'spring-commands-rspec'
   gem 'spring-watcher-listen', '~> 2.0.0' if next?
   gem 'web-console', '< 4.0' # last version to support ruby 2.2
@@ -122,6 +123,9 @@ group :development, :test do
   gem 'pry-byebug', '< 2.7.0' # last version to support ruby 2.2
   gem 'pry-rescue'
   gem 'pry-stack_explorer'
+
+  gem 'parallel_tests', '~> 2.32.0' # last version to support ruby 2.2
+  gem 'parallel', '~> 1.19.2'       # TODO: remove after upgrading ruby and parallel_tests
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,6 +360,9 @@ GEM
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
     orm_adapter (0.5.0)
+    parallel (1.19.2)
+    parallel_tests (2.32.0)
+      parallel
     paranoia (2.4.2)
       activerecord (>= 4.0, < 6.1)
     premailer (1.11.1)
@@ -501,6 +504,8 @@ GEM
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
+    spring-commands-parallel-tests (1.0.1)
+      spring (>= 0.9.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (2.12.5)
@@ -596,6 +601,8 @@ DEPENDENCIES
   omniauth (~> 1.2)
   omniauth-google-oauth2 (~> 0.2)
   paperclip!
+  parallel (~> 1.19.2)
+  parallel_tests (~> 2.32.0)
   paranoia (<= 2.4.2)
   poirot_rails!
   premailer-rails (< 1.10)
@@ -624,6 +631,7 @@ DEPENDENCIES
   simplecov
   site_prism (~> 2.17)
   spring
+  spring-commands-parallel-tests
   spring-commands-rspec
   sprockets-rails (< 3.3.0)
   therubyracer (~> 0.12)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -368,6 +368,9 @@ GEM
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
     orm_adapter (0.5.0)
+    parallel (1.19.2)
+    parallel_tests (2.32.0)
+      parallel
     paranoia (2.4.2)
       activerecord (>= 4.0, < 6.1)
     premailer (1.11.1)
@@ -518,6 +521,8 @@ GEM
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
+    spring-commands-parallel-tests (1.0.1)
+      spring (>= 0.9.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
@@ -619,6 +624,8 @@ DEPENDENCIES
   omniauth (~> 1.2)
   omniauth-google-oauth2 (~> 0.2)
   paperclip!
+  parallel (~> 1.19.2)
+  parallel_tests (~> 2.32.0)
   paranoia (<= 2.4.2)
   poirot_rails!
   premailer-rails (< 1.10)
@@ -648,6 +655,7 @@ DEPENDENCIES
   simplecov
   site_prism (~> 2.17)
   spring
+  spring-commands-parallel-tests
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   sprockets-rails (< 3.3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ development:
 
 test: &test
   <<: *default
-  database: cdp_test
+  database: cdp_test<%= ENV["TEST_ENV_NUMBER"] %>
 
 production:
   <<: *default

--- a/config/initializers/cdx.rb
+++ b/config/initializers/cdx.rb
@@ -2,7 +2,19 @@ require "cdx/api/elasticsearch"
 
 module Cdx::Api
   def self.index_name
-    "cdx_#{Rails.env}"
+    if Rails.env.test?
+      "cdx_#{Rails.env}#{ENV["TEST_ENV_NUMBER"]}"
+    else
+      "cdx_#{Rails.env}"
+    end
+  end
+
+  def self.mapping_template_name
+    if Rails.env.test?
+      "cdx_tests_template_#{Rails.env}#{ENV["TEST_ENV_NUMBER"]}"
+    else
+      "cdx_tests_template_#{Rails.env}"
+    end
   end
 end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.0'
+version: '2.2'
 
 services:
   base: &base
@@ -34,6 +34,7 @@ services:
     working_dir: /src
     volumes:
       - .:/src # we mount the source to be able to attach fixture files
+    scale: 2
 
   db:
     image: mysql:5.7

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -2,7 +2,7 @@ namespace :elasticsearch do
   desc "Initialize the cdx elasticsearch index template"
   task setup: :environment do
     Cdx::Api.config.log = false
-    Cdx::Api::Elasticsearch::MappingTemplate.new.initialize_template "cdx_tests_template_#{Rails.env}"
+    Cdx::Api::Elasticsearch::MappingTemplate.new.initialize_template Cdx::Api.mapping_template_name
     Cdx::Api.client.indices.delete index: Cdx::Api.index_name, ignore: 404
     Cdx::Api.client.indices.create index: Cdx::Api.index_name
   end

--- a/spec/models/cdx_api_spec.rb
+++ b/spec/models/cdx_api_spec.rb
@@ -929,8 +929,8 @@ describe Cdx::Api, elasticsearch: true do
         Cdx::Fields.test.searchable_fields.concat @extra_fields
 
         # Delete the index and recreate it to make ES grab the new template
-        Cdx::Api.client.indices.delete index: "cdx_test", ignore: 404
-        Cdx::Api.initialize_template "cdx_tests_template_test"
+        Cdx::Api.client.indices.delete index: Cdx::Api.index_name, ignore: 404
+        Cdx::Api.initialize_template Cdx::Api.mapping_template_name
       end
 
       after(:all) do
@@ -944,8 +944,8 @@ describe Cdx::Api, elasticsearch: true do
         end
 
         # Delete the index and recreate it to make ES grab the new template
-        Cdx::Api.client.indices.delete index: "cdx_test", ignore: 404
-        Cdx::Api.initialize_template "cdx_tests_template_test"
+        Cdx::Api.client.indices.delete index: Cdx::Api.index_name, ignore: 404
+        Cdx::Api.initialize_template Cdx::Api.mapping_template_name
       end
 
       it "should allow searching by the new field" do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,12 +8,14 @@ else
   require 'capybara-screenshot/rspec'
 end
 
+test_env_number = (ENV["TEST_ENV_NUMBER"].presence || 1).to_i
+
 # Configure the capybara test server on an IP accessible from the network, so we
 # can use a remote selenium server from another compose service (or the host).
 ENV['SERVER_HOST'] ||= Socket.ip_address_list.find(&:ipv4_private?).ip_address
-ENV['SERVER_PORT'] ||= '4000'
+ENV['SERVER_PORT'] ||= (4000 + test_env_number).to_s
 ENV['HEADLESS'] ||= 'true'
-ENV['SELENIUM_URL'] ||= 'http://selenium:4444/'
+ENV['SELENIUM_URL'] ||= "http://selenium:#{4443 + test_env_number}/"
 
 Capybara.configure do |config|
   config.server = :puma, { Silent: true }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,7 +15,7 @@ test_env_number = (ENV["TEST_ENV_NUMBER"].presence || 1).to_i
 ENV['SERVER_HOST'] ||= Socket.ip_address_list.find(&:ipv4_private?).ip_address
 ENV['SERVER_PORT'] ||= (4000 + test_env_number).to_s
 ENV['HEADLESS'] ||= 'true'
-ENV['SELENIUM_URL'] ||= "http://selenium:#{4443 + test_env_number}/"
+ENV['SELENIUM_URL'] ||= "http://cdx_selenium_#{test_env_number}:4444/"
 
 Capybara.configure do |config|
   config.server = :puma, { Silent: true }

--- a/spec/support/elasticsearch_context.rb
+++ b/spec/support/elasticsearch_context.rb
@@ -2,12 +2,12 @@ shared_context "elasticsearch", elasticsearch: true do
 
   before(:each) do
     Cdx::Api.client.indices.delete index: Cdx::Api.index_name, ignore: 404
-    
+
     Cdx::Api.client.indices.delete index: Cdx::Api.index_name, type: '.percolator', ignore: 404
-   
-                              
-    Cdx::Api.client.indices.delete_template name: "cdx_tests_template_test*", ignore: 404
-    Cdx::Api::Elasticsearch::MappingTemplate.new.initialize_template "cdx_tests_template_test"
+
+
+    Cdx::Api.client.indices.delete_template name: Cdx::Api.mapping_template_name, ignore: 404
+    Cdx::Api::Elasticsearch::MappingTemplate.new.initialize_template Cdx::Api.mapping_template_name
     Cdx::Api.client.indices.create index: Cdx::Api.index_name,
                                    body: {
                                     settings: {


### PR DESCRIPTION
Installs [parallel_tests](https://github.com/grosser/parallel_tests/tree/v2.32.0) to allow running specs in parallel. You may run the following commands (where `4` can be replaced with how many processes you really want):

```console
$ rake parallel:setup[4]
$ parallel_rspec -n 4 spec --exclude-pattern spec/features
$ parallel_rspec -n 4 spec/features
$ parallel_cucumber features/ -n 4
```

NOTE: test runs seems to go slower and slower as we repeat them. Re-creating the databases with `rake parallel:drop[4]` followed by `rake parallel:setup[4]` fixes the issue. I guess this is MySQL struggling?

NOTE: you'll have to rebuild the `selenium` image because we now start 8 geckodriver to be able to drive many firefox instances in parallel :grin: 

NOTE: parallel_tests will save logs of each run to optimize the distribution of specs in the different runners!