### PR TITLE
Add `TransferPackagesController#find_sample`

### DIFF
--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -1,0 +1,37 @@
+class TransferPackagesController < ApplicationController
+  def find_sample
+    @navigation_context = NavigationContext.new(nil, params[:context])
+
+    uuid = params[:uuid]
+    full_uuid = uuid.size == 36
+    @samples = Sample
+      .within(@navigation_context.entity, @navigation_context.exclude_subsites)
+      .joins(:sample_identifiers).where(
+        (full_uuid ? "sample_identifiers.uuid = ?" : "sample_identifiers.uuid LIKE concat(?, '%')"),
+        uuid
+      )
+      .order("created_at DESC")
+      .limit(5)
+
+    @samples = check_access(@samples, READ_SAMPLE)
+
+    if full_uuid && @samples.any?(&:is_quality_control?)
+      render json: { error: "Sample #{uuid} is a QC sample and can't be transferred." }
+      return
+    end
+
+    render json: { samples: samples_data(@samples) }
+  end
+
+  private
+
+  def samples_data(samples)
+    samples.map { |sample|
+      next if sample.is_quality_control?
+      {
+        uuid: sample.uuid,
+        hasQcReference: sample.has_qc_reference?,
+      }
+    }.compact
+  end
+end

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -6,10 +6,7 @@ class TransferPackagesController < ApplicationController
     full_uuid = uuid.size == 36
     @samples = Sample
       .within(@navigation_context.entity, @navigation_context.exclude_subsites)
-      .joins(:sample_identifiers).where(
-        (full_uuid ? "sample_identifiers.uuid = ?" : "sample_identifiers.uuid LIKE concat(?, '%')"),
-        uuid
-      )
+      .autocomplete(uuid)
       .order("created_at DESC")
       .limit(5)
 

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -12,11 +12,6 @@ class TransferPackagesController < ApplicationController
 
     @samples = check_access(@samples, READ_SAMPLE)
 
-    if full_uuid && @samples.any?(&:is_quality_control?)
-      render json: { error: "Sample #{uuid} is a QC sample and can't be transferred." }
-      return
-    end
-
     render json: { samples: samples_data(@samples) }
   end
 
@@ -24,11 +19,14 @@ class TransferPackagesController < ApplicationController
 
   def samples_data(samples)
     samples.map { |sample|
-      next if sample.is_quality_control?
-      {
+      data = {
         uuid: sample.uuid,
         hasQcReference: sample.has_qc_reference?,
       }
+      if sample.is_quality_control?
+        data[:error] = "Sample #{sample.uuid} is a QC sample and can't be transferred."
+      end
+      data
     }.compact
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -48,6 +48,16 @@ class Sample < ApplicationRecord
     joins(:sample_identifiers).where(sample_identifiers: {uuid: uuids})
   end
 
+  scope :autocomplete, ->(uuid) {
+          if uuid.size == 36
+            # Full UUID
+            find_all_by_any_uuid(uuid)
+          else
+            # Partial UUID
+            joins(:sample_identifiers).where("sample_identifiers.uuid LIKE concat(?, '%')", uuid)
+          end
+        }
+
   def merge(other_sample)
     # Adds all sample_identifiers from other_sample if they have an uuid (ie they have been persisted)
     # or if they contain a new entity_id (ie not already in this sample.sample_identifiers)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,11 @@ Rails.application.routes.draw do
       get 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'destroy' }, action: :bulk_destroy
     end
   end
+  resources :transfer_packages do
+    collection do
+      get "find_sample"
+    end
+  end
   resources :batches do
     member do
       get 'edit_or_show'

--- a/spec/controllers/transfer_packages_controller_spec.rb
+++ b/spec/controllers/transfer_packages_controller_spec.rb
@@ -1,0 +1,128 @@
+require "spec_helper"
+
+RSpec.describe TransferPackagesController, type: :controller do
+  setup_fixtures do
+    @user = User.make!
+    @institution = Institution.make! user: @user
+
+    @other_user = Institution.make!.user
+    @other_institution = Institution.make! user: @other_user
+  end
+
+  let(:default_params) { { context: institution.uuid } }
+
+  describe "GET #find_sample" do
+    let!(:sample) do
+      Sample.make! :filled, institution: institution, sample_identifiers: [SampleIdentifier.make!(uuid: "01234567-1111-a0c8-ac1b-58bed3633e88")]
+    end
+
+    let!(:other_sample) do
+      Sample.make! :filled, institution: institution, created_at: sample.created_at - 1.day, sample_identifiers: [SampleIdentifier.make!(uuid: "01234567-2222-a0c8-ac1b-58bed3633e88")]
+    end
+
+    let!(:other_institution_sample) do
+      Sample.make! :filled, institution: other_institution, sample_identifiers: [SampleIdentifier.make!(uuid: "01234567-9999-a0c8-ac1b-58bed3633e88")]
+    end
+
+    before(:each) { sign_in(user) }
+
+    context "full UUID" do
+      it "finds sample" do
+        get :find_sample, params: { uuid: sample.uuid }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"].map { |s| s["uuid"] }).to eq [sample.uuid]
+      end
+
+      it "empty result when missing" do
+        get :find_sample, params: { uuid: "00000000-1111-2222-3333-444444444444" }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"]).to be_empty
+      end
+
+      it "empty result when inaccessible" do
+        get :find_sample, params: { uuid: other_institution_sample.uuid }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"]).to be_empty
+      end
+
+      it "checks read access" do
+        sign_in other_user
+        get :find_sample, params: { uuid: sample.uuid, context: other_institution.uuid }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"]).to be_empty
+      end
+
+      it "does not include QC sample" do
+        qc_sample = Sample.make! :filled, institution: institution, specimen_role: "q", sample_identifiers: [SampleIdentifier.make!(uuid: "01234567-4444-a0c8-ac1b-58bed3633e88")]
+
+        get :find_sample, params: { uuid: qc_sample.uuid }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"]).to be_nil
+        expect(data["error"]).to eq "Sample 01234567-4444-a0c8-ac1b-58bed3633e88 is a QC sample and can't be transferred."
+      end
+    end
+
+    context "partial" do
+      it "finds single sample" do
+        get :find_sample, params: { uuid: "01234567-1" }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"].map { |s| s["uuid"] }).to eq [sample.uuid]
+      end
+
+      it "finds multiple samples" do
+        get :find_sample, params: { uuid: "01234567" }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"].map { |s| s["uuid"] }).to eq [sample.uuid, other_sample.uuid]
+      end
+
+      it "empty result when missing" do
+        get :find_sample, params: { uuid: "00000000" }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"]).to be_empty
+      end
+
+      it "empty result when inaccessible" do
+        get :find_sample, params: { uuid: "01234567-9999" }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"]).to be_empty
+      end
+
+      it "checks read access" do
+        sign_in other_user
+        get :find_sample, params: { uuid: "01234567", context: other_institution.uuid }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"].map { |s| s["uuid"] }).to eq [other_institution_sample.uuid]
+      end
+
+      it "does not include QC sample" do
+        Sample.make! :filled, institution: institution, specimen_role: "q", sample_identifiers: [SampleIdentifier.make!(uuid: "01234567-4444-a0c8-ac1b-58bed3633e88")]
+
+        get :find_sample, params: { uuid: "01234567" }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["samples"].map { |s| s["uuid"] }).to eq [sample.uuid, other_sample.uuid]
+      end
+    end
+  end
+end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -137,6 +137,7 @@ Sample.blueprint(:filled) do
   sample_identifiers { [SampleIdentifier.make!(sample: object)] }
   isolate_name { Faker::Name.name }
   specimen_role { "p" }
+  date_produced { Faker::Time.backward }
 end
 
 Sample.blueprint(:batch) do


### PR DESCRIPTION
This is a prerequisite feature for #1566. It was easy to extract, so I figured a separate PR makes review easier.

There isn't anything on its own though, except that it provides an API endpoint for querying samples by UUID. The endpoint is located in `TransferPackageController` which will be used for the sample transfer screen as well. Its behaviour is specific to the sample transfer action, that's why it's not in the more generic `SamplesController`.