### PR TITLE
Fix tableheader element type

### DIFF
--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -12,6 +12,29 @@
       color: $gray4;
     }
 
+    .table-title {
+      font-size: 120%;
+      font-weight: bold;
+      color: $black;
+      vertical-align: middle;
+      display: inline-block;
+      margin-right: 10px;
+      text-transform:none;
+    }
+
+    .table-actions {
+      display: inline-block;
+      vertical-align: middle;
+
+      .btn-link {
+        margin-left: 0px;
+      }
+
+      .btn-icon {
+        color: inherit;
+      }
+    }
+
     th {
       font-weight: 400;
       color: $gray3;
@@ -20,29 +43,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
       padding: 14px 10px;
-
-      .table-title {
-        font-size: 120%;
-        font-weight: bold;
-        color: $black;
-        vertical-align: middle;
-        display: inline-block;
-        margin-right: 10px;
-        text-transform:none;
-      }
-
-      .table-actions {
-        display: inline-block;
-        vertical-align: middle;
-
-        .btn-link {
-          margin-left: 0px;
-        }
-
-        .btn-icon {
-          color: inherit;
-        }
-      }
 
       a {
         color: inherit;

--- a/app/views/components/_cdx_table.html.haml
+++ b/app/views/components/_cdx_table.html.haml
@@ -3,7 +3,7 @@
   %thead
     - if cdx_table[:title] || cdx_table[:actions]
       %tr
-        %th.tableheader{colspan:100}
+        %td.tableheader{colspan:100}
           .table-info
             - if cdx_table[:title]
               .table-title= cdx_table[:title]


### PR DESCRIPTION
This fixes the primary effect of #1542.

Changing tableheader element from `th` to `td` removes some special style properties. The transfer modal does no longer have uppercased text which it inherited from the `th`.

It would probably still be better to mount the modal somewhere else (or do a complete reset somewhere), but this is already a quick and simple fix for the main issue. And it makes sense regardless to use `td` here. The table cell is not a column header.