### PR TITLE
Move receiver and sender institutions from `SampleTransfer` to `TransferPackage`

### DIFF
--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -71,7 +71,7 @@ class SampleTransfersController < ApplicationController
     samples = Sample.find_all_by_any_uuid(sample_uuids)
 
     Sample.transaction do
-      package = TransferPackage.sending_to(new_owner, transfer_package_params)
+      package = TransferPackage.sending_to(samples.first.institution, new_owner, transfer_package_params)
 
       samples.each do |sample|
         raise "User not authorized for transferring Samples " unless authorize_resource?(sample, UPDATE_SAMPLE)

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -71,7 +71,7 @@ class SampleTransfersController < ApplicationController
     samples = Sample.find_all_by_any_uuid(sample_uuids)
 
     Sample.transaction do
-      package = TransferPackage.sending_to(samples.first.institution, new_owner, transfer_package_params)
+      package = TransferPackage.sending(samples.first.institution, new_owner, transfer_package_params)
 
       samples.each do |sample|
         raise "User not authorized for transferring Samples " unless authorize_resource?(sample, UPDATE_SAMPLE)

--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -6,7 +6,7 @@ class SampleTransfersController < ApplicationController
   def index
     @sample_transfers = SampleTransfer
       .within(@navigation_context.institution)
-      .includes(:receiver_institution, :sender_institution, sample: [:sample_identifiers])
+      .includes(transfer_package: [:receiver_institution, :sender_institution], sample: [:sample_identifiers])
       .ordered_by_creation
 
     @sample_transfers = @sample_transfers.joins(sample: :sample_identifiers).where("sample_identifiers.uuid LIKE concat('%', ?, '%')", params[:sample_id]) unless params[:sample_id].blank?
@@ -15,7 +15,7 @@ class SampleTransfersController < ApplicationController
     @sample_transfers = @sample_transfers.joins(:sample).where("samples.specimen_role = ?", params[:specimen_role]) unless params[:specimen_role].blank?
 
     @sample_transfers = perform_pagination(@sample_transfers)
-      .preload(:transfer_package, :sender_institution, :receiver_institution, sample: %i[batch qc_info])
+      .preload(transfer_package: %i[sender_institution receiver_institution], sample: %i[batch qc_info])
       .map { |transfer| SampleTransferPresenter.new(transfer, @navigation_context) }
   end
 

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -2,7 +2,7 @@ class SampleTransfer < ApplicationRecord
   belongs_to :sample
   belongs_to :sender_institution, class_name: "Institution"
   belongs_to :receiver_institution, class_name: "Institution"
-  belongs_to :transfer_package, required: false
+  belongs_to :transfer_package
 
   # TODO: remove these after upgrading to Rails 5.0 (belongs_to associations are required by default):
   validates_presence_of :sample

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -12,16 +12,18 @@ class SampleTransfer < ApplicationRecord
   end
 
   scope :within, ->(institution) {
-          where("sender_institution_id = ? OR receiver_institution_id = ?", institution.id, institution.id)
+          joins(:transfer_package).merge(TransferPackage.within(institution))
         }
 
   scope :with_receiver, ->(institution) {
-          where(receiver_institution_id: institution.id)
+          joins(:transfer_package).merge(TransferPackage.with_receiver(institution))
         }
 
   scope :ordered_by_creation, -> {
           order(created_at: :desc)
         }
+
+  delegate :receiver_institution, :sender_institution, to: :transfer_package
 
   def confirm
     if confirmed?

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -1,15 +1,9 @@
 class SampleTransfer < ApplicationRecord
   belongs_to :sample
-  belongs_to :sender_institution, class_name: "Institution"
-  belongs_to :receiver_institution, class_name: "Institution"
   belongs_to :transfer_package
 
   # TODO: remove these after upgrading to Rails 5.0 (belongs_to associations are required by default):
   validates_presence_of :sample
-
-  after_initialize do
-    self.sender_institution ||= sample.try &:institution
-  end
 
   scope :within, ->(institution) {
           joins(:transfer_package).merge(TransferPackage.within(institution))

--- a/app/models/sample_transfer.rb
+++ b/app/models/sample_transfer.rb
@@ -6,8 +6,6 @@ class SampleTransfer < ApplicationRecord
 
   # TODO: remove these after upgrading to Rails 5.0 (belongs_to associations are required by default):
   validates_presence_of :sample
-  validates_presence_of :sender_institution
-  validates_presence_of :receiver_institution
 
   after_initialize do
     self.sender_institution ||= sample.try &:institution

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -3,13 +3,18 @@ class TransferPackage < ApplicationRecord
   belongs_to :receiver_institution, class_name: "Institution"
   has_many :sample_transfers
 
+  # TODO: remove these after upgrading to Rails 5.0 (belongs_to associations are required by default):
+  validates_presence_of :sender_institution
+  validates_presence_of :receiver_institution
+
   after_initialize do
     self.uuid ||= SecureRandom.uuid
   end
 
-  def self.sending_to(institution, attributes = nil)
+  def self.sending_to(sender, receiver, attributes = nil)
     create!(attributes) do |package|
-      package.receiver_institution = institution
+      package.sender_institution = sender
+      package.receiver_institution = receiver
     end
   end
 

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -21,7 +21,6 @@ class TransferPackage < ApplicationRecord
   def add!(sample)
     transfer = sample_transfers.create!(
       sample: sample,
-      receiver_institution: receiver_institution,
     )
 
     if sample.batch

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -1,4 +1,5 @@
 class TransferPackage < ApplicationRecord
+  belongs_to :sender_institution, class_name: "Institution"
   belongs_to :receiver_institution, class_name: "Institution"
   has_many :sample_transfers
 

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -23,7 +23,7 @@ class TransferPackage < ApplicationRecord
           where(receiver_institution_id: institution.id)
         }
 
-  def self.sending_to(sender, receiver, attributes = nil)
+  def self.sending(sender, receiver, attributes = nil)
     create!(attributes) do |package|
       package.sender_institution = sender
       package.receiver_institution = receiver

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -11,6 +11,18 @@ class TransferPackage < ApplicationRecord
     self.uuid ||= SecureRandom.uuid
   end
 
+  scope :within, ->(institution) {
+          if Rails::VERSION::MAJOR >= 5
+            where(sender_institution_id: institution.id).or(with_receiver(institution))
+          else
+            where(arel_table[:sender_institution_id].eq(institution.id).or(arel_table[:receiver_institution_id].eq(institution.id)))
+          end
+        }
+
+  scope :with_receiver, ->(institution) {
+          where(receiver_institution_id: institution.id)
+        }
+
   def self.sending_to(sender, receiver, attributes = nil)
     create!(attributes) do |package|
       package.sender_institution = sender

--- a/db/migrate/20220408103851_add_sender_institution_to_transfer_packages.rb
+++ b/db/migrate/20220408103851_add_sender_institution_to_transfer_packages.rb
@@ -1,0 +1,20 @@
+class AddSenderInstitutionToTransferPackages < ActiveRecord::Migration
+  def up
+    add_reference :transfer_packages, :sender_institution, null: true
+
+    TransferPackage.reset_column_information
+
+    # Fill sender_institution on existing packages
+    TransferPackage.find_each do |package|
+      package.update_columns(
+        sender_institution_id: package.sample_transfers.take.sender_institution_id,
+      )
+    end
+
+    change_column_null :transfer_packages, :sender_institution_id, false
+  end
+
+  def down
+    remove_reference :transfer_packages, :sender_institution
+  end
+end

--- a/db/migrate/20220412181435_change_sample_transfers_requires_transfer_package.rb
+++ b/db/migrate/20220412181435_change_sample_transfers_requires_transfer_package.rb
@@ -1,0 +1,20 @@
+class ChangeSampleTransfersRequiresTransferPackage < ActiveRecord::Migration
+  def up
+    # Create packages for existing transfers
+    SampleTransfer.where(transfer_package_id: nil).find_each do |transfer|
+      package = TransferPackage.create(
+        sender_institution: transfer.sender_institution,
+        receiver_institution: transfer.receiver_institution,
+      )
+      transfer.update_columns(
+        transfer_package_id: package.id,
+      )
+    end
+
+    change_column_null :sample_transfers, :transfer_package_id, false
+  end
+
+  def down
+    change_column_null :sample_transfers, :transfer_package_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220407173015) do
+ActiveRecord::Schema.define(version: 20220408103851) do
 
   create_table "alert_condition_results", force: :cascade do |t|
     t.string  "result",   limit: 255
@@ -670,6 +670,7 @@ ActiveRecord::Schema.define(version: 20220407173015) do
     t.boolean  "includes_qc_info",                    default: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "sender_institution_id",   limit: 4,                   null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220408103851) do
+ActiveRecord::Schema.define(version: 20220412181435) do
 
   create_table "alert_condition_results", force: :cascade do |t|
     t.string  "result",   limit: 255
@@ -540,7 +540,7 @@ ActiveRecord::Schema.define(version: 20220408103851) do
     t.datetime "confirmed_at"
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
-    t.integer  "transfer_package_id",     limit: 4
+    t.integer  "transfer_package_id",     limit: 4, null: false
   end
 
   add_index "sample_transfers", ["confirmed_at"], name: "index_sample_transfers_on_confirmed_at", using: :btree

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "includes transfers from and to my institution (ordered by creation date)" do
       sample_transfers = [
-        SampleTransfer.make!(sender_institution: my_institution, created_at: Time.now - 1.day),
-        SampleTransfer.make!(receiver_institution: my_institution, created_at: Time.now),
+        SampleTransfer.make!(transfer_package: TransferPackage.make!(sender_institution: my_institution), created_at: Time.now - 1.day),
+        SampleTransfer.make!(transfer_package: TransferPackage.make!(receiver_institution: my_institution), created_at: Time.now),
       ]
       get :index
       expect(assigns(:sample_transfers).map(&:transfer)).to eq sample_transfers.reverse
@@ -28,8 +28,8 @@ RSpec.describe SampleTransfersController, type: :controller do
     end
 
     describe "filters" do
-      let!(:subject) { SampleTransfer.make!(sender_institution: my_institution, sample: Sample.make!(:filled, batch: Batch.make!, specimen_role: "c")) }
-      let!(:other) { SampleTransfer.make!(receiver_institution: my_institution, sample: Sample.make!(:filled, batch: Batch.make!)) }
+      let!(:subject) { SampleTransfer.make!(transfer_package: TransferPackage.make!(sender_institution: my_institution), sample: Sample.make!(:filled, batch: Batch.make!, specimen_role: "c")) }
+      let!(:other) { SampleTransfer.make!(transfer_package: TransferPackage.make!(receiver_institution: my_institution), sample: Sample.make!(:filled, batch: Batch.make!)) }
 
       it "by sample id" do
         get :index, params: { sample_id: subject.sample.uuid[0..8] }
@@ -42,7 +42,7 @@ RSpec.describe SampleTransfersController, type: :controller do
       end
 
       it "by old_batch_number" do
-        transfer = SampleTransfer.make!(sender_institution: my_institution, sample: Sample.make!(:filled, specimen_role: "c", old_batch_number: "12345678"))
+        transfer = SampleTransfer.make!(transfer_package: TransferPackage.make!(sender_institution: my_institution), sample: Sample.make!(:filled, specimen_role: "c", old_batch_number: "12345678"))
         get :index, params: { batch_number: "12345678" }
         expect(assigns(:sample_transfers).map(&:transfer)).to eq [transfer]
       end

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "confirms" do
       sample = Sample.make!
-      transfer = TransferPackage.sending_to(my_institution).add!(sample)
+      transfer = TransferPackage.sending_to(other_institution, my_institution).add!(sample)
 
       Timecop.freeze do
         patch :confirm, params: { sample_transfer_id: transfer.id }
@@ -133,7 +133,7 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "verifies user is authorized" do
       sample = Sample.make!
-      transfer = TransferPackage.sending_to(other_institution).add!(sample)
+      transfer = TransferPackage.sending_to(my_institution, other_institution).add!(sample)
 
       grant other_institution.user, current_user, other_institution, Policy::Actions::READ_INSTITUTION
 
@@ -149,7 +149,7 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "verifies current context is receiver" do
       sample = Sample.make!
-      transfer = TransferPackage.sending_to(other_institution).add!(sample)
+      transfer = TransferPackage.sending_to(my_institution, other_institution).add!(sample)
 
       expect {
         patch :confirm, params: { sample_transfer_id: transfer.id }
@@ -164,7 +164,7 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "verifies transfer is unconfirmed" do
       sample = Sample.make
-      transfer = TransferPackage.sending_to(my_institution).add!(sample)
+      transfer = TransferPackage.sending_to(other_institution, my_institution).add!(sample)
       transfer.confirm_and_apply!
       transfer.confirmed_at = original_confirmed_at = Time.now.change(usec: 0) - 1.hour
       transfer.save!

--- a/spec/controllers/sample_transfers_controller_spec.rb
+++ b/spec/controllers/sample_transfers_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "confirms" do
       sample = Sample.make!
-      transfer = TransferPackage.sending_to(other_institution, my_institution).add!(sample)
+      transfer = TransferPackage.sending(other_institution, my_institution).add!(sample)
 
       Timecop.freeze do
         patch :confirm, params: { sample_transfer_id: transfer.id }
@@ -133,7 +133,7 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "verifies user is authorized" do
       sample = Sample.make!
-      transfer = TransferPackage.sending_to(my_institution, other_institution).add!(sample)
+      transfer = TransferPackage.sending(my_institution, other_institution).add!(sample)
 
       grant other_institution.user, current_user, other_institution, Policy::Actions::READ_INSTITUTION
 
@@ -149,7 +149,7 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "verifies current context is receiver" do
       sample = Sample.make!
-      transfer = TransferPackage.sending_to(my_institution, other_institution).add!(sample)
+      transfer = TransferPackage.sending(my_institution, other_institution).add!(sample)
 
       expect {
         patch :confirm, params: { sample_transfer_id: transfer.id }
@@ -164,7 +164,7 @@ RSpec.describe SampleTransfersController, type: :controller do
 
     it "verifies transfer is unconfirmed" do
       sample = Sample.make
-      transfer = TransferPackage.sending_to(other_institution, my_institution).add!(sample)
+      transfer = TransferPackage.sending(other_institution, my_institution).add!(sample)
       transfer.confirm_and_apply!
       transfer.confirmed_at = original_confirmed_at = Time.now.change(usec: 0) - 1.hour
       transfer.save!

--- a/spec/features/sample_transfers_spec.rb
+++ b/spec/features/sample_transfers_spec.rb
@@ -5,16 +5,18 @@ describe "sample transfers" do
     let!(:my_institution) { Institution.make! }
     let!(:other_institution) { Institution.make! }
     let!(:current_user) { my_institution.user }
+    let!(:receiver_package) { TransferPackage.make receiver_institution: my_institution }
+    let!(:sender_package) { TransferPackage.make sender_institution: my_institution }
 
     before(:each) do
       sign_in(current_user)
     end
 
     it "shows status" do
-      in_pending = SampleTransfer.make!(receiver_institution: my_institution, created_at: Time.new(2022, 3, 4))
-      in_confirmed = SampleTransfer.make!(receiver_institution: my_institution, confirmed_at: Time.new(2022, 2, 24, 15, 31))
-      out_pending = SampleTransfer.make!(sender_institution: my_institution, created_at: Time.new(2022, 3, 4))
-      out_confirmed = SampleTransfer.make!(sender_institution: my_institution, confirmed_at: Time.new(2022, 2, 21, 12, 00))
+      in_pending = SampleTransfer.make!(transfer_package: receiver_package, created_at: Time.new(2022, 3, 4))
+      in_confirmed = SampleTransfer.make!(transfer_package: receiver_package, confirmed_at: Time.new(2022, 2, 24, 15, 31))
+      out_pending = SampleTransfer.make!(transfer_package: sender_package, created_at: Time.new(2022, 3, 4))
+      out_confirmed = SampleTransfer.make!(transfer_package: sender_package, confirmed_at: Time.new(2022, 2, 21, 12, 00))
       unrelated = SampleTransfer.make!
 
       goto_page ListSampleTransfersPage do |page|
@@ -29,8 +31,8 @@ describe "sample transfers" do
     end
 
     it "filters" do
-      subject = SampleTransfer.make!(receiver_institution: my_institution)
-      other = SampleTransfer.make!(receiver_institution: my_institution)
+      subject = SampleTransfer.make!(transfer_package: receiver_package)
+      other = SampleTransfer.make!(transfer_package: receiver_package)
 
       goto_page ListSampleTransfersPage do |page|
         page.filters.sample_id.set subject.sample.uuid
@@ -97,7 +99,7 @@ describe "sample transfers" do
 
     it "verifies sample id" do
       sample = Sample.make!(:filled, institution: institution_a)
-      transfer = TransferPackage.sending_to(institution_b).add!(sample)
+      transfer = TransferPackage.sending_to(institution_a, institution_b).add!(sample)
 
       sign_in user_b
 

--- a/spec/features/sample_transfers_spec.rb
+++ b/spec/features/sample_transfers_spec.rb
@@ -99,7 +99,7 @@ describe "sample transfers" do
 
     it "verifies sample id" do
       sample = Sample.make!(:filled, institution: institution_a)
-      transfer = TransferPackage.sending_to(institution_a, institution_b).add!(sample)
+      transfer = TransferPackage.sending(institution_a, institution_b).add!(sample)
 
       sign_in user_b
 

--- a/spec/models/sample_transfer_spec.rb
+++ b/spec/models/sample_transfer_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe SampleTransfer, type: :model do
   let(:sender) { Institution.make }
   let(:receiver) { Institution.make }
 
-  it "sets sender institution from sample" do
-    expect(SampleTransfer.new(sample: sample).sender_institution).to eq sample.institution
-  end
-
   it "validates" do
     transfer = SampleTransfer.new(sample: sample, transfer_package: TransferPackage.make)
     expect(transfer).to be_valid

--- a/spec/models/sample_transfer_spec.rb
+++ b/spec/models/sample_transfer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SampleTransfer, type: :model do
   end
 
   it "validates" do
-    transfer = SampleTransfer.new(sample: sample, receiver_institution: receiver, sender_institution: sender)
+    transfer = SampleTransfer.new(sample: sample, transfer_package: TransferPackage.make)
     expect(transfer).to be_valid
   end
 

--- a/spec/models/transfer_package_spec.rb
+++ b/spec/models/transfer_package_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe TransferPackage, type: :model do
+  let(:sender) { Institution.make }
+  let(:receiver) { Institution.make }
+
+  it ".new" do
+    transfer = TransferPackage.new
+    expect(transfer).not_to be_valid
+
+    transfer = TransferPackage.new(receiver_institution: receiver, sender_institution: sender)
+    expect(transfer).to be_valid
+  end
+end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -171,8 +171,7 @@ end
 
 SampleTransfer.blueprint do
   sample { Sample.make!(:filled) }
-  receiver_institution { Institution.make! }
-  sender_institution { object.sample.institution || Institution.make! }
+  transfer_package { TransferPackage.make(sender_institution: object.sample.institution || Institution.make!) }
 end
 
 SampleTransfer.blueprint(:confirmed) do

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -164,6 +164,8 @@ end
 TransferPackage.blueprint do
   uuid { SecureRandom.uuid }
   receiver_institution { Institution.make! }
+  receiver_institution { Institution.make! }
+  sender_institution { Institution.make! }
   recipient { Faker::Name.name }
 end
 


### PR DESCRIPTION
Resolves #1595

Builds on top of #1588 to avoid merge conflicts