### PR TITLE
Refactor: remove `rescue` in `SampleTransfersController`

### DIFF
--- a/app/controllers/sample_transfers_controller.rb
+++ b/app/controllers/sample_transfers_controller.rb
@@ -25,11 +25,14 @@ class SampleTransfersController < ApplicationController
       flash[:error] = "Destination Institution does not exists."
       redirect_to samples_path
     else
-      if create_transfer(new_owner, params["samples"])
-        flash[:notice] =  "All samples have been transferred successfully."
-        redirect_to samples_path
-      else
+      begin
+        create_transfer(new_owner, params["samples"])
+      rescue => exception
         flash[:error] = "Samples transfer failed."
+
+        raise exception
+      else
+        flash[:notice] = "All samples have been transferred successfully."
         redirect_to samples_path
       end
     end
@@ -80,12 +83,6 @@ class SampleTransfersController < ApplicationController
         package.add!(sample)
       end
     end
-
-    true
-  rescue => exception
-    Raven.capture_exception(exception)
-
-    false
   end
 
   def transfer_package_params


### PR DESCRIPTION
`create_transfer` rescues all exceptions which makes it hard to diagnose errors when specs fail.
This patch removes that rescue and instead lets any exception bubble up through the controller.

Before some refactors, it was originally introduced in #1447

I'm not sure if there was a specific intention behind this rescue, or if it was just a quick solution. There are no tests for this case.
And I don't think there is a particular error we would be expecting here.

So it should be fine to refactor it like this, keeping the behaviour with adding a flash message when an error happens. Maybe that's not even necessary, though.