### PR TITLE
Improve the ux for missing mandatory fields in all forms

### DIFF
--- a/app/assets/javascripts/components/sample_transfer.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer.js.jsx
@@ -134,7 +134,8 @@ var SampleTransferModal = React.createClass({
 
   validateForm: function(e) {
     if (this.state.institutionId == null){
-      $(".institution-select").addClass("input-required");
+      $(".institution-select").addClass("field_with_errors");
+      $("#institution_id_error").removeClass("hidden-error");
       e.preventDefault();
     }
   },
@@ -147,7 +148,7 @@ var SampleTransferModal = React.createClass({
             <div className="col pe-4"><label>Institution</label></div>
             <div className="col">
               <CdxSelect className="institution-select" name="institution_id" items={this.props.institutions} value={this.state.institutionId} onChange={this.changeInstitution} />
-              <span className="error"><div className="icon-error icon-red" /> Institution can't be blank</span>
+              <ul className="errors-field hidden-error" id="institution_id_error"><li><i className="icon-error icon-red" /> Institution can't be blank</li></ul>
             </div>
           </div>
           <div className="row">

--- a/app/assets/javascripts/sample_transfer_confirm.js.jsx
+++ b/app/assets/javascripts/sample_transfer_confirm.js.jsx
@@ -59,12 +59,13 @@ var SampleTransferConfirmModal = React.createClass({
 
   checkUUID: function(event) {
     let uuidCheck = document.getElementById("uuid_check")
+    let uuidCheckError = document.getElementById("uuid_check_error")
     let submitButton = document.getElementById("samples-transfer-form-submit")
 
     let value = uuidCheck.value
     if(value.length < 4 && value.match(/^[0-9a-f]*$/i)) {
       // don't show error for incomplete input as long as the format is valid
-      uuidCheck.classList.remove("input-required")
+      uuidCheck.classList.remove("field_with_errors")
       submitButton.disabled = true
       return;
     }
@@ -72,10 +73,12 @@ var SampleTransferConfirmModal = React.createClass({
     let valid = value.toLowerCase() == this.props.uuid.substr(-4);
 
     if(valid) {
-      uuidCheck.classList.remove("input-required")
+      uuidCheck.classList.remove("field_with_errors")
+      uuidCheckError.classList.add("hidden-error")
       submitButton.disabled = false
     } else {
-      uuidCheck.classList.add("input-required")
+      uuidCheck.classList.add("field_with_errors")
+      uuidCheckError.classList.remove("hidden-error")
       submitButton.disabled = true
     }
   },
@@ -92,7 +95,7 @@ var SampleTransferConfirmModal = React.createClass({
             <div className="col">
               {this.props.uuid.substr(0, this.props.uuid.length - 4)}
               <input type="text" id="uuid_check" onChange={this.checkUUID} autoFocus autoComplete="false" size="4" minLength="4" maxLength="4" placeholder="XXXX" required />
-              <span className="error"><div className="icon-error icon-red" /> Invalid sample ID</span>
+              <span id="uuid_check_error" className="errors-field hidden-error"><div className="icon-error icon-red" /> Invalid sample ID</span>
             </div>
           </div>
           <div className="modal-footer">

--- a/app/assets/stylesheets/_errors.scss
+++ b/app/assets/stylesheets/_errors.scss
@@ -2,29 +2,3 @@
   color: $orange;
   font-style: italic;
 }
-
-form {
-  // Deprecated: to be generalized
-  .error {
-    font-size: 12px;
-    font-style: italic;
-    color: $red;
-    margin-top: 5px;
-    visibility: hidden;
-    display: flex;
-    
-    li {
-      display: inline-flex;
-      align-items: center;
-    }
-  }
-
-  .field_with_errors {
-    color: #EB2122;
-    border-bottom-color: #EB2122 !important;
-  }
-    
-  .field_with_errors + .error {
-    visibility: visible;
-  }
-}

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -479,22 +479,31 @@ label.on {
   }
 }
 
-.input-required {
-  color: #EB2122;
-  border-bottom-color: #EB2122 !important;
-}
-
 .centered {
   display: flex;
   align-items: center;
 }
 
-div + .error,
-input + .error {
-  visibility: hidden;
+.errors-field {
+  font-size: 12px;
+  font-style: italic;
+  color: $red;
+  margin-top: 5px;
+  display: flex;
+  
+  li {
+    display: inline-flex;
+    align-items: center;
+    line-height: normal;
+  }
 }
 
-div.input-required + .error,
-input.input-required + .error {
-  visibility: visible;
+div.field_with_errors,
+.field_with_errors > input {
+  color: #EB2122;
+  border-bottom-color: #EB2122 !important;
+}
+
+.hidden-error {
+  visibility: hidden;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -215,7 +215,7 @@ module ApplicationHelper
     messages = record.errors.full_messages_for(attr_name)
     return if messages.empty?
   
-    content_tag :ul, class: "error" do
+    content_tag :ul, class: "errors-field" do
       messages.each do |message|
         concat (content_tag :li do
           concat content_tag :i, "", class: "icon-error icon-red"
@@ -224,5 +224,4 @@ module ApplicationHelper
       end
     end
   end
-
 end

--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -1,7 +1,4 @@
 = form_for(@batch_form) do |f|
-
-  = validation_errors @batch_form
-
   .row
     .col
       .row.form-field
@@ -15,6 +12,7 @@
           = f.label :date_produced, "production date"
         .col
           = f.text_field :date_produced, placeholder: Batch.date_produced_placeholder, readonly: !@can_update
+          = field_errors @batch_form, :date_produced
 
       .row.form-field
         .col.pe-3
@@ -62,6 +60,8 @@
             = f.label :samples_quantity
           .col
             = f.number_field :samples_quantity, min: 0, :class => "input-small"
+            = field_errors @batch_form, :samples_quantity
+
       - else
         .row.form-field
           .col.pe-3

--- a/app/views/devices/_form.haml
+++ b/app/views/devices/_form.haml
@@ -1,6 +1,4 @@
 = form_for(@device) do |f|
-  = validation_errors @device
-
   .row.form-field
     .col.pe-2
       = f.label :institution
@@ -13,6 +11,7 @@
     .col
       = cdx_select form: f, name: :device_model_id, class: 'input-x-large' do |select|
         - select.items(@device_models, :id, :full_name)
+      = field_errors @device, :device_model
 
   - if @allow_to_pick_site
     .row.form-field
@@ -35,11 +34,13 @@
       = f.label :name
     .col
       = f.text_field :name
+      = field_errors @device, :name
   .row.form-field
     .col.pe-2
       = f.label :serial_number
     .col
       = f.text_field :serial_number
+      = field_errors @device, :serial_number
   .row.form-field
     .col.pe-2
       = f.label :time_zone

--- a/app/views/institutions/_form.haml
+++ b/app/views/institutions/_form.haml
@@ -36,7 +36,7 @@
       .col.px-1
         = f.label :name, :class => 'block'
       .col
-        = f.text_field :name, readonly: @readonly, :class => ['input-block', @institution.errors.has_key?(:name) ? 'input-required':'']
+        = f.text_field :name, readonly: @readonly, :class => 'input-block'
         = field_errors @institution, :name
         = f.hidden_field :pending_institution_invite_id
     - if not f.object.new_record?

--- a/app/views/policies/_form.html.haml
+++ b/app/views/policies/_form.html.haml
@@ -1,14 +1,8 @@
 = form_for @policy do |f|
-  - if @policy.errors.any?
-    #error_explanation
-      %p= "#{pluralize(@policy.errors.count, "error")} prohibited this policy from being saved:"
-      %ul
-        - @policy.errors.full_messages.each do |msg|
-          %li= msg
-
   .row.form-field
     .col.pe-2
       = f.label :name
+      = field_errors @policy, :name
     .col
       = f.text_field :name
   .row.form-field
@@ -23,6 +17,7 @@
     .col.pe-3
       .value
         = f.text_area :definition, :rows => 5, :class => 'input-block'
+        = field_errors @policy, :definition
   .row.button-actions
     .col
       = f.submit 'Save', :class => 'btn-primary'

--- a/app/views/roles/_form.html.haml
+++ b/app/views/roles/_form.html.haml
@@ -1,16 +1,10 @@
 = form_for @role do |f|
-  - if @role.errors.any?
-    #error_explanation
-      %p= "#{pluralize(@role.errors.count, "error")} prohibited this role from being saved:"
-      %ul
-        - @role.errors.full_messages.each do |msg|
-          %li= msg
-
   .row.form-field
     .col.pe-2
       = f.label :name
     .col
       = f.text_field :name
+      = field_errors @role, :name
 
   - if @accessible_institutions != 1
     .row.form-field
@@ -42,6 +36,7 @@
       %h1 Policies
       %p.text-small.muted
         %i Policies grant users permisions over specific resources
+      = field_errors @role, :policy
   = react_component 'PolicyDefinition', definition: @role.definition, actions: actions_per_resource_type, context: params['context'], resources: @policy_definition_resources, resourceTypes: resource_types
   .row.button-actions
     .col

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -1,7 +1,4 @@
 = form_for(@sample_form) do |f|
-
-  = validation_errors @sample_form
-
   .row
     .col
       - unless f.object.qc_info.nil?
@@ -30,6 +27,7 @@
           = f.label :date_produced, "production date"
         .col
           = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
+          = field_errors @sample_form, :date_produced
 
       .row.form-field
         .col.pe-4

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -1,6 +1,4 @@
 = form_for(@site) do |f|
-  = validation_errors @site
-
   .row.form-field
     .col.pe-2
       = f.label :institution
@@ -12,6 +10,7 @@
       = f.label :name
     .col
       = f.text_field :name, :class => 'input-large'
+      = field_errors @site, :name
   - if @site.new_record? || @can_move
     .row.form-field
       .col.pe-2


### PR DESCRIPTION
Closes #1065.

In order to full cover all the places/conditions this should be implemented for I went through the `*_form.rb` files checking the `validate_*` conditions, plus all the date formats plus I took a look at the logic. After this I went through all the forms but **I didn’t find a systematic way to check that the coverage was full, this needs an in-depth QA**. 

Implemented in:
- Samples,
- Sample transfer (modal),
- Sample transfer confirm (modal),
- Batches, 
- Sites,
- Devices,
- Roles

From the implementation POV, now the `error` class was renamed to `errors-field` (in plural, since there will be an `<ul>` element displaying `<li>`s for each error present in the field. Also, the `input-required` CSS class was deleted, and the rails `field_with_errors` class is used to highlight fields with errors. When it is not automatically applied by rails, it is assigned programmatically as was done with `input-required` (i.e. in the sample transfer modal). 

Also, it wasn’t reachable for the modals if present in` _errors.scss`, all this had to be moved to `_forms.scss` and now is reached both in the forms and in the modals. Is this correct?

As an example, in batches, errors are now shown like this:

![image](https://user-images.githubusercontent.com/13782680/165330729-a32edaec-215d-4c61-84f4-63805d4f1675.png)

Another example, in modals:

![image](https://user-images.githubusercontent.com/13782680/165330908-5b21f95e-5801-48ed-86c3-1ca2ebf7be79.png)

And a special mention to Roles, which maybe needs a new mockup? I didn’t dare to enter within the react component for the policies and I solved it showing errors here:

![image](https://user-images.githubusercontent.com/13782680/165331062-95686669-7ef5-4de8-999a-d29ccfb34fb7.png)

And another special mention to **Alert Groups**, that have a different way of showing errors, then I guess it's not in use? I didn’t modify this form:

![image](https://user-images.githubusercontent.com/13782680/165331381-d67672b7-f6f7-4395-909b-4e74329f4aeb.png)

In my ideal implementation 

```
= field_errors @form, :field
```

shouldn't be call for each field that could present errors, but I didn't found a way to solve it that way (append DOM elements to `field_with_errors` div, cab be done without js?).







