### PR TITLE
Set Paperclip Attachment's options in a Rails5-friendly way

### DIFF
--- a/config/initializers/paperclip_defaults.rb
+++ b/config/initializers/paperclip_defaults.rb
@@ -10,7 +10,7 @@ if s3_bucket = ENV['PAPERCLIP_S3_BUCKET'].presence
     s3_protocol: 'https',
   }
   paperclip_defaults[:s3_host_name] = ENV['PAPERCLIP_S3_HOST_NAME'].presence
-  Rails.application.config.paperclip_defaults = paperclip_defaults
+  Paperclip::Attachment.default_options.update(paperclip_defaults)
 end
 
 Paperclip.options[:content_type_mappings] = {


### PR DESCRIPTION
Rails 5 doesn't seem to play well with initializers setting the Rails.application.config settings for Paperclip, so we now do
it the suggested way.

See https://github.com/thoughtbot/paperclip/issues/2240