### PR TITLE
Fix migration referencing delegated `SampleTransfer#sender_institution`

### DIFF
--- a/db/migrate/20220412181435_change_sample_transfers_requires_transfer_package.rb
+++ b/db/migrate/20220412181435_change_sample_transfers_requires_transfer_package.rb
@@ -3,8 +3,8 @@ class ChangeSampleTransfersRequiresTransferPackage < ActiveRecord::Migration
     # Create packages for existing transfers
     SampleTransfer.where(transfer_package_id: nil).find_each do |transfer|
       package = TransferPackage.create(
-        sender_institution: transfer.sender_institution,
-        receiver_institution: transfer.receiver_institution,
+        sender_institution_id: transfer.sender_institution_id,
+        receiver_institution_id: transfer.receiver_institution_id,
       )
       transfer.update_columns(
         transfer_package_id: package.id,


### PR DESCRIPTION
`sender_institution` and `receiver_institution` delegate to `transfer_package`, so this couldn't work. We should be able to use the `*_id` attributes directly.

Resolves #1636