### PR TITLE
Fix timing edge case in `password_reset` spec

### DIFF
--- a/features/step_definitions/password_reset_steps.rb
+++ b/features/step_definitions/password_reset_steps.rb
@@ -1,7 +1,7 @@
 Given(/^User foo@example\.com has not changed password for (\d+) months$/) do |changed|
   @user = User.make!(
     password: 'abc123abc',
-    password_changed_at: changed.to_i.months.ago
+    password_changed_at: (changed.to_i.months + 1.days).ago,
   )
   Institution.make! user: @user
 end
@@ -12,13 +12,14 @@ end
 
 Given(/^the previous passwords$/) do |table|
   @prev_passwords = table.raw.flatten[1..-1].unshift(@user.password)
+  password_changed_at = @user.password_changed_at
   table.hashes.each do |hash|
     @user.password = hash['password']
     @user.password_confirmation = hash['password']
     @user.save!
   end
-  @user.password_changed_at = 3.months.ago
-  @user.save!
+  # reset
+  @user.update!(password_changed_at: password_changed_at)
 end
 
 When(/^they try to use one of previous (\d+) passwords$/) do |arg1|


### PR DESCRIPTION
A weird failure has started to show up in CI builds: https://github.com/instedd/cdx/runs/6276901123?check_suite_focus=true

It seems to be caused by a too tight time interval. `user_password_expire_in_months: 3` and we're testing for exactly 3 months ago, thus creating an edge case and the password is still considered fresh. When the last password change in the test is set to more than 3 months ago, it succeeds.

Also removes hard coded time interval in the feature steps defintion.