### PR TITLE
Allow to create batches with no samples

### DIFF
--- a/app/models/batch_form.rb
+++ b/app/models/batch_form.rb
@@ -32,6 +32,7 @@ class BatchForm
   delegate :id, :new_record?, :persisted?, to: :batch
 
   validates_presence_of :date_produced
+  validates_numericality_of :samples_quantity, greater_than_or_equal_to: 0, message: "value must be greater or equal to 0", if: :creating_batch?
 
   def self.for(batch)
     new.tap do |form|

--- a/app/models/batch_form.rb
+++ b/app/models/batch_form.rb
@@ -32,7 +32,6 @@ class BatchForm
   delegate :id, :new_record?, :persisted?, to: :batch
 
   validates_presence_of :date_produced
-  validates_numericality_of :samples_quantity, greater_than: 0, message: "value must be greater than 0", if: :creating_batch?
 
   def self.for(batch)
     new.tap do |form|


### PR DESCRIPTION
Closes #1604. 

Based on the discussion on the issue, only the check of values greater than zero was removed from the form. Now is possible to create batches with zero samples:

![Screenshot from 2022-05-05 10-17-45](https://user-images.githubusercontent.com/13782680/166886587-f452dcee-9eb0-4559-b444-ee1e6048fadf.png)

For sake of testing negative values were attempted, the error is shown in this way:

![Screenshot from 2022-05-05 10-15-29](https://user-images.githubusercontent.com/13782680/166886693-d94ecd0e-e76d-4724-99a8-c8e239708c17.png)

Which is different of the standard way (it responds to `min="0"` in the input element). No actions were taken to change this (should we change it?)

