### PR TITLE
[DB] Add `TransferPackage#confirmed_at`

### DIFF
--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -54,6 +54,27 @@ class TransferPackage < ApplicationRecord
     transfer
   end
 
+  def confirm
+    if confirmed?
+      false
+    else
+      self.confirmed_at = Time.now
+      true
+    end
+  end
+
+  def confirm!
+    if confirm
+      save!
+    else
+      raise ActiveRecord::RecordNotSaved.new("Transfer package has already been confirmed.")
+    end
+  end
+
+  def confirmed?
+    !!confirmed_at
+  end
+
   private
 
   def create_qc_info(sample)

--- a/db/migrate/20220505070823_add_confirmed_at_to_transfer_packages.rb
+++ b/db/migrate/20220505070823_add_confirmed_at_to_transfer_packages.rb
@@ -1,0 +1,21 @@
+class AddConfirmedAtToTransferPackages < ActiveRecord::Migration
+  def up
+    add_column :transfer_packages, :confirmed_at, :datetime, null: true
+    add_index :transfer_packages, :confirmed_at
+
+    TransferPackage.reset_column_information
+
+    # Fill confirmed_at on existing packages if their sample transfers have been confirmed
+    TransferPackage.find_each do |package|
+      if confirmed_at = package.sample_transfers.map(&:confirmed_at).compact.max
+        package.update_columns(
+          confirmed_at: confirmed_at,
+        )
+      end
+    end
+  end
+
+  def down
+    remove_column :transfer_packages, :confirmed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220412181435) do
+ActiveRecord::Schema.define(version: 20220505070823) do
 
   create_table "alert_condition_results", force: :cascade do |t|
     t.string  "result",   limit: 255
@@ -671,7 +671,10 @@ ActiveRecord::Schema.define(version: 20220412181435) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "sender_institution_id",   limit: 4,                   null: false
+    t.datetime "confirmed_at"
   end
+
+  add_index "transfer_packages", ["confirmed_at"], name: "index_transfer_packages_on_confirmed_at", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                          limit: 255, default: "",    null: false

--- a/spec/models/transfer_package_spec.rb
+++ b/spec/models/transfer_package_spec.rb
@@ -19,4 +19,50 @@ RSpec.describe TransferPackage, type: :model do
     expect(transfer).not_to be_valid
     expect(transfer.errors["sample_transfers.sample"]).to eq ["Can't transfer QC sample"]
   end
+
+  describe "#confirm" do
+    it "sets confirmed_at" do
+      transfer = TransferPackage.make
+      expect(transfer).not_to be_confirmed
+
+      Timecop.freeze(Time.now.change(usec: 0)) do
+        expect(transfer.confirm).to be true
+        expect(transfer.confirmed_at).to eq Time.now
+      end
+
+      expect(transfer).to be_confirmed
+      expect(transfer).to be_changed
+    end
+
+    it "returns false if already confirmed" do
+      transfer = TransferPackage.make(:confirmed)
+
+      expect {
+        expect(transfer.confirm).to be false
+      }.not_to change { transfer.confirmed_at }
+    end
+  end
+
+  describe "#confirm!" do
+    it "sets confirmed_at" do
+      transfer = TransferPackage.make
+      expect(transfer).not_to be_confirmed
+
+      Timecop.freeze(Time.now.change(usec: 0)) do
+        expect(transfer.confirm!).to be true
+        expect(transfer.confirmed_at).to eq Time.now
+      end
+
+      expect(transfer).to be_confirmed
+      expect(transfer).not_to be_changed
+    end
+
+    it "raises if already confirmed" do
+      transfer = TransferPackage.make(:confirmed)
+
+      expect {
+        expect { transfer.confirm! }.to raise_error(ActiveRecord::RecordNotSaved)
+      }.not_to change { transfer.confirmed_at }
+    end
+  end
 end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -170,6 +170,10 @@ TransferPackage.blueprint do
   recipient { Faker::Name.name }
 end
 
+TransferPackage.blueprint(:confirmed) do
+  confirmed_at { Faker::Time.backward }
+end
+
 SampleTransfer.blueprint do
   sample { Sample.make!(:filled) }
   transfer_package { TransferPackage.make(sender_institution: object.sample.institution || Institution.make!) }


### PR DESCRIPTION
This change prepares `TransferPackage#confirmed_at` which will become necessary for migrating the transfer process to `TransferPackage`. Transfer packages will have a confirmation date.

I'm just copying over the model logic from `SampleTransfer`. The feature just moves over.

We could consider extracting the model logic into a concern. But ultimately, it'll only be used in `TransferPackage`, so there's no DRY benefit.
@ysbaddaden WDYT?