### PR TITLE
Fix `SELENIUM_URL`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ env:
   COMPOSE_DEFAULT_SERVICE: web
   BUNDLE_GEMFILE: ${{ inputs.gemfile }}
   BUNDLE_LOCKFILE: ${{ inputs.gemfile }}.lock
+  SELENIUM_URL: http://cdx_selenium_%{test_env_number}:4444/ # dealing with docker-compose v1 name (https://github.com/instedd/cdx/pull/1644)
 
 jobs:
   setup:
@@ -64,10 +65,10 @@ jobs:
         run: docker-compose up -d selenium
 
       - name: Run specs (capybara)
-        run: docker-compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e FEATURES=true web bundle exec rspec
+        run: docker-compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e FEATURES=true -e SELENIUM_URL web bundle exec rspec
 
       - name: Run specs (cucumber)
-        run: docker-compose run --rm -e RAILS_ENV=test -e COVERAGE=true web bundle exec cucumber
+        run: docker-compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e SELENIUM_URL web bundle exec cucumber
 
       - run: cp coverage/.resultset.json resultset.integration_tests.json
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,7 +15,7 @@ test_env_number = (ENV["TEST_ENV_NUMBER"].presence || 1).to_i
 ENV['SERVER_HOST'] ||= Socket.ip_address_list.find(&:ipv4_private?).ip_address
 ENV['SERVER_PORT'] ||= (4000 + test_env_number).to_s
 ENV['HEADLESS'] ||= 'true'
-ENV['SELENIUM_URL'] ||= "http://cdx_selenium_#{test_env_number}:4444/"
+ENV['SELENIUM_URL'] ||= "http://cdx-selenium-#{test_env_number}:4444/"
 
 Capybara.configure do |config|
   config.server = :puma, { Silent: true }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,7 +15,7 @@ test_env_number = (ENV["TEST_ENV_NUMBER"].presence || 1).to_i
 ENV['SERVER_HOST'] ||= Socket.ip_address_list.find(&:ipv4_private?).ip_address
 ENV['SERVER_PORT'] ||= (4000 + test_env_number).to_s
 ENV['HEADLESS'] ||= 'true'
-ENV['SELENIUM_URL'] ||= "http://cdx-selenium-#{test_env_number}:4444/"
+ENV["SELENIUM_URL"] = (ENV["SELENIUM_URL"] || "http://cdx-selenium-%{test_env_number}:4444/").gsub("%{test_env_number}", test_env_number.to_s)
 
 Capybara.configure do |config|
   config.server = :puma, { Silent: true }


### PR DESCRIPTION
Fix the spelling of selenium container's host names to match that in `docker-config.yml`. The underscored name failed to resolve. I have no idea how this happened to work and why it's broken now.

```
     1.1) Failure/Error: page.load args

          SocketError:
            getaddrinfo: Name or service not known
          # /usr/local/bundle/gems/webmock-1.23.0/lib/webmock/http_lib_adapters/net_http.rb:109:in `request'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/default.rb:121:in `response_for'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/default.rb:76:in `request'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/common.rb:62:in `call'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/bridge.rb:166:in `execute'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/bridge.rb:99:in `create_session'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/firefox/marionette/driver.rb:50:in `initialize'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/firefox/driver.rb:31:in `new'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/firefox/driver.rb:31:in `new'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/common/driver.rb:52:in `for'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver.rb:86:in `for'
          # /usr/local/bundle/gems/site_prism-2.17.1/lib/site_prism/page.rb:37:in `load'
          # ./spec/support/feature_spec_helpers.rb:39:in `goto_page'
          # ./spec/support/feature_spec_helpers.rb:27:in `sign_in'
          # ./spec/features/samples_spec.rb:9:in `block (3 levels) in <top (required)>'

     1.2) Failure/Error: TCPSocket.open(conn_address, conn_port, @local_host, @local_port)

          SocketError:
            getaddrinfo: Name or service not known
          # /usr/local/bundle/gems/webmock-1.23.0/lib/webmock/http_lib_adapters/net_http.rb:109:in `request'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/default.rb:121:in `response_for'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/default.rb:76:in `request'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/common.rb:62:in `call'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/bridge.rb:166:in `execute'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/bridge.rb:99:in `create_session'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/firefox/marionette/driver.rb:50:in `initialize'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/firefox/driver.rb:31:in `new'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/firefox/driver.rb:31:in `new'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/common/driver.rb:52:in `for'
          # /usr/local/bundle/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver.rb:86:in `for'
```