### PR TITLE
Regression: wicked_pdf with asset pipeline (Rails 4.2)

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -37,9 +37,9 @@ $icons-140x140-black:        "icons-140x140-black.png";
 // =============================================================================
 // FONTS
 // =============================================================================
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,700);
-@import url(//fonts.googleapis.com/css?family=Titillium+Web:400,300,700);
-@import url(//fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300,700);
+@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400,300,700);
+@import url(https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap);
 $sans: 'Open Sans', sans-serif;
 $sanstitle: 'Titillium Web', sans-serif;
 $roboto: 'Roboto Mono', monospace;

--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -1,0 +1,5 @@
+@import "variables";
+@import "mixins";
+@import "reset";
+@import "layout";
+@import "barcode_card";

--- a/app/views/layouts/pdf.html.haml
+++ b/app/views/layouts/pdf.html.haml
@@ -2,7 +2,10 @@
 %html
   %head
     %title Connected Diagnostics Platform
-    = wicked_pdf_stylesheet_link_tag "application", :media => "all"
+    - if Rails::VERSION::MAJOR < 5
+      = stylesheet_link_tag wicked_pdf_asset_base64("pdf")
+    - else
+      = wicked_pdf_stylesheet_link_tag "pdf"
     = wicked_pdf_stylesheet_link_tag "https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap"
   %body
     = yield


### PR DESCRIPTION
Extracts a smaller PDF stylesheet for printing the labels, and uses the base64 trick as documented by `wicked_pdf` with the assets pipeline for Rails 4.2). Rails 5.0 doesn't exhibit the issue, so I kept the regular helper.

fixes #1645 