### PR TITLE
Fix bugs in `TransferPackage#create` form

### DIFF
--- a/app/assets/javascripts/components/sample_transfer_selector.js.jsx
+++ b/app/assets/javascripts/components/sample_transfer_selector.js.jsx
@@ -29,7 +29,7 @@ var SampleTransferSelector = React.createClass({
         selector.removeSample(sample);
       }
 
-      let id = Date.now();
+      let id = Math.floor(Math.random() * 1000000000);
       let name = `transfer_package[sample_transfers_attributes][${id}][sample_id]`;
       return <div className="sample-transfer-preview">
         <div dangerouslySetInnerHTML={{ __html: sample.preview }}></div>

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -15,11 +15,11 @@ class TransferPackagesController < ApplicationController
     @transfer_package = TransferPackage.new(transfer_package_params)
     @transfer_package.sender_institution = @navigation_context.institution
 
+    valid = @transfer_package.valid?
     if @transfer_package.sample_transfers.empty?
-      @transfer_package.errors.add :sample_transfers, "Must not be empty"
+      @transfer_package.errors.add :sample_transfers, "must not be empty"
+      valid = false
     end
-    no_errors = @transfer_package.errors.empty?
-    valid = @transfer_package.valid? && no_errors
 
     @transfer_package.sample_transfers.each do |sample_transfer|
       sample = sample_transfer.sample

--- a/app/views/transfer_packages/_form.haml
+++ b/app/views/transfer_packages/_form.haml
@@ -1,4 +1,6 @@
 = form_for(@transfer_package) do |f|
+  = validation_errors @transfer_package
+
   .row
     .col
       .row.form-field

--- a/spec/controllers/transfer_packages_controller_spec.rb
+++ b/spec/controllers/transfer_packages_controller_spec.rb
@@ -260,6 +260,7 @@ RSpec.describe TransferPackagesController, type: :controller do
       end.not_to change { TransferPackage.count }
 
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Receiver institution can't be blank")
     end
 
     it "rejects transferring QC sample" do

--- a/spec/controllers/transfer_packages_controller_spec.rb
+++ b/spec/controllers/transfer_packages_controller_spec.rb
@@ -242,6 +242,7 @@ RSpec.describe TransferPackagesController, type: :controller do
       end.not_to change { TransferPackage.count }
 
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Sample transfers must not be empty")
     end
 
     it "shows form again when missing receiver" do


### PR DESCRIPTION
I discovered a number of bugs in the `TransferPackage#create` form while doing my own QA (i.e. working on the next iterations of the feature).

This is a follow-up on #1625