### PR TITLE
Fix `TransferPackageController#create` to update sample status

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -41,6 +41,12 @@ class Batch < ApplicationRecord
     self.qc_sample.present?
   end
 
+  def qc_info
+    if qc_sample = self.qc_sample
+      QcInfo.find_or_duplicate_from(qc_sample)
+    end
+  end
+
   private
 
   def isolate_name_batch_number_combination_create

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -99,4 +99,16 @@ class Sample < ApplicationRecord
   def has_qc_reference?
     !!(qc_info || (batch && batch.has_qc_sample?))
   end
+
+  # Removes sample from its context when getting transferred.
+  # It's added to the destination context when confirmed.
+  def detach_from_context
+    assign_attributes(site: nil, institution: nil)
+  end
+
+  def attach_qc_info
+    if qc_info = batch.try(&:qc_info)
+      self.qc_info = qc_info
+    end
+  end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -103,7 +103,12 @@ class Sample < ApplicationRecord
   # Removes sample from its context when getting transferred.
   # It's added to the destination context when confirmed.
   def detach_from_context
-    assign_attributes(site: nil, institution: nil)
+    assign_attributes(
+      batch: nil,
+      old_batch_number: batch.try(:batch_number),
+      site: nil,
+      institution: nil
+    )
   end
 
   def attach_qc_info

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -32,8 +32,8 @@ class TransferPackage < ApplicationRecord
   before_create do
     sample_transfers.each do |sample_transfer|
       sample = sample_transfer.sample
-      sample.detach_from_context unless confirmed?
       sample.attach_qc_info if includes_qc_info
+      sample.detach_from_context unless confirmed?
       sample.save!
     end
   end

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -32,12 +32,8 @@ class TransferPackage < ApplicationRecord
   before_create do
     sample_transfers.each do |sample_transfer|
       sample = sample_transfer.sample
-      unless confirmed?
-        sample.detach_from_context
-      end
-      if includes_qc_info
-        sample.attach_qc_info
-      end
+      sample.detach_from_context unless confirmed?
+      sample.attach_qc_info if includes_qc_info
       sample.save!
     end
   end

--- a/spec/controllers/transfer_packages_controller_spec.rb
+++ b/spec/controllers/transfer_packages_controller_spec.rb
@@ -154,7 +154,8 @@ RSpec.describe TransferPackagesController, type: :controller do
     let(:default_params) { { context: institution.uuid } }
 
     it "creates transfer package" do
-      sample1 = Sample.make!(:filled, institution: institution)
+      batch = Batch.make!(:qc_sample)
+      sample1 = Sample.make!(:filled, institution: institution, batch: batch)
       sample2 = Sample.make!(:filled, institution: institution)
 
       expect do
@@ -181,6 +182,14 @@ RSpec.describe TransferPackagesController, type: :controller do
       expect(package.receiver_institution).to eq other_institution
       expect(package.includes_qc_info?).to eq true
       expect(package.sample_transfers.map(&:sample)).to eq [sample1, sample2]
+
+      sample1.reload
+      sample2.reload
+      expect(sample1.institution).to be_nil
+      expect(sample2.institution).to be_nil
+
+      expect(sample1.qc_info).not_to be_nil
+      expect(sample2.qc_info).to be_nil
     end
 
     it "ignores blank sample_uuid" do

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -50,4 +50,14 @@ describe Sample do
     ])
     expect(sample.has_qc_reference?).to eq(true)
   end
+
+  it "#detach_from_context" do
+    sample = Sample.make(:batch)
+    batch = sample.batch
+    sample.detach_from_context
+    expect(sample.site).to be_nil
+    expect(sample.institution).to be_nil
+    expect(sample.batch).to be_nil
+    expect(sample.old_batch_number).to eq batch.batch_number
+  end
 end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -194,6 +194,10 @@ Batch.blueprint do
   volume { 100 }
 end
 
+Batch.blueprint(:qc_sample) do
+  samples { [Sample.make(specimen_role: 'q')] }
+end
+
 Patient.blueprint do
   institution
 


### PR DESCRIPTION
`TransferPackageController#create` doesn't use `TransferPackage#add!` which takes care of modifying the sample status (like detaching it from the sender context).
So this didn't happen.

This patch fixes that by introducing a `before_create` hook on `TransferPackage` which works well with nested attributes.