### PR TITLE
Configure human attribute names in locale instead of form UI

### DIFF
--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -12,7 +12,7 @@
 
       .row.form-field
         .col.pe-3
-          = f.label :date_produced, "production date"
+          = f.label :date_produced
         .col
           = f.text_field :date_produced, placeholder: Batch.date_produced_placeholder, readonly: !@can_update
 

--- a/app/views/devices/_form.haml
+++ b/app/views/devices/_form.haml
@@ -53,7 +53,7 @@
         .col.pe-2= f.text_field :ftp_hostname, placeholder: 'Hostname'
         .col.pe-2= f.number_field :ftp_port, min: 0, max: 65535, placeholder: 'Port'
         .col.pe-1
-          = f.label :ftp_passive, "Passive"
+          = f.label :ftp_passive
         .col.pe-1
           = f.check_box :ftp_passive
           = f.label :ftp_passive, "&nbsp;".html_safe

--- a/app/views/qc_infos/_form.haml
+++ b/app/views/qc_infos/_form.haml
@@ -17,7 +17,7 @@
 
       .row
         .col.pe-4
-          = f.label :date_produced, "production date"
+          = f.label :date_produced
         .col
           = f.text_field :formatted_date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
 

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -27,7 +27,7 @@
 
       .row.form-field
         .col.pe-4
-          = f.label :date_produced, "production date"
+          = f.label :date_produced
         .col
           = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
 

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -35,7 +35,7 @@
 
   .row.form-field
     .col.pe-2
-      = f.label :sample_id_reset_policy, "Sample ID reset policy"
+      = f.label :sample_id_reset_policy
     .col
       = cdx_select form: f, name: :sample_id_reset_policy, class: 'input-large' do |select|
         - select.item "yearly", "Yearly"
@@ -43,7 +43,7 @@
         - select.item "weekly", "Weekly"
   .row.form-field
     .col.pe-2
-      = f.label :allows_manual_entry, "Allow manual entry"
+      = f.label :allows_manual_entry
     .col
       = f.check_box :allows_manual_entry
       %label{for: 'site_allows_manual_entry'} &nbsp;

--- a/app/views/subscribers/_form.html.haml
+++ b/app/views/subscribers/_form.html.haml
@@ -19,12 +19,12 @@
       = f.text_field :name
   .row
     .col.pe-2
-      = f.label :url, "URL"
+      = f.label :url
     .col
       = f.text_field :url
   .row
     .col.pe-2
-      = f.label :verb, "HTTP Verb"
+      = f.label :verb
     .col
       .value.annotation GET will send fields in query string. POST will send a JSON object in the request body.
       = cdx_select form: f, name: :verb do |select|

--- a/app/views/transfer_packages/_form.haml
+++ b/app/views/transfer_packages/_form.haml
@@ -10,7 +10,7 @@
 
       .row.form-field
         .col.pe-4
-          = f.label :receiver_institution_id, "Destination", title: "Receiver institution"
+          = f.label :receiver_institution, title: "Receiver institution"
         .col
           - if @can_update
             = cdx_select form: f, name: :receiver_institution_id, searchable: true, class: "input-x-large" do |select|
@@ -26,7 +26,7 @@
 
       .row.form-field
         .col.pe-4
-          = f.label :sample_transfers, "Samples"
+          = f.label :sample_transfers
         .col
           = react_component("SampleTransferSelector",
               context: @navigation_context.uuid,

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -13,7 +13,7 @@
           .value= f.object.email
       .row
         .col.pe-2
-          = f.label :telephone, "Phone"
+          = f.label :telephone
         .col
           .value= f.object.telephone
       .row
@@ -27,14 +27,14 @@
         - if @can_update
           .row
             .col.pe-2
-              .value= f.label :is_active, "Status"
+              .value= f.label :is_active
             .col
               .value
                 = f.check_box :is_active, class: 'power'
                 %label{:for => 'user_is_active'} Can access Cdx?
         .row
           .col.pe-2
-            = f.label :last_sign_in_at, "Activity"
+            = f.label :last_sign_in_at
           .col
             .value= last_activity(f.object)
   - if @can_update

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,15 +20,38 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  attributes:
+    date_produced: Production date
+    url: URL
+
   activerecord:
     attributes:
+      device:
+        ftp_passive: Passive
+
       manifest:
         definition: Manifest
-      site:
-        parent: Parent site
+
       patient:
         dob: Birthday
         entity_id: Patient id
+
+      site:
+        parent: Parent site
+        sample_id_reset_policy: Sample ID reset policy
+        allows_manual_entry: Allow manual entry
+
+      subscribe:
+        verb: HTTP Verb
+
+      transfer_package:
+        receiver_institution: Destination
+        sample_transfers: Samples
+
+      user:
+        telephone: Phone
+        is_active: Status
+        last_sign_in_at: Activity
 
   user:
     settings:


### PR DESCRIPTION
This makes the human attribute names known to Rails so they are used uniformly everywhere.
Without this there were discrepancies between the form labels and other display locations such as error messages.

Before:
![grafik](https://user-images.githubusercontent.com/466378/168632622-9330582b-10d1-4cab-86d3-530c13afeee3.png)
After:
![grafik](https://user-images.githubusercontent.com/466378/168632505-9b123390-ddd1-41e3-aac6-16ef41127ed0.png)
