### PR TITLE
Custom form builder for attaching error messages to fields

### DIFF
--- a/app/assets/stylesheets/_errors.scss
+++ b/app/assets/stylesheets/_errors.scss
@@ -12,19 +12,10 @@ form {
     margin-top: 5px;
     visibility: hidden;
     display: flex;
-    
+
     li {
       display: inline-flex;
       align-items: center;
     }
-  }
-
-  .field_with_errors {
-    color: #EB2122;
-    border-bottom-color: #EB2122 !important;
-  }
-    
-  .field_with_errors + .error {
-    visibility: visible;
   }
 }

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -98,7 +98,7 @@ label {
     padding-bottom: 6px;
     height: 34px;
   }
-  
+
   .value{
     margin-left: 5px;
   }
@@ -497,4 +497,41 @@ input + .error {
 div.input-required + .error,
 input.input-required + .error {
   visibility: visible;
+}
+
+// .form-errors is written at the end of the form but should show up on the front
+form {
+  display: flex;
+  flex-direction: column;
+
+  > .form-errors {
+    order: -1;
+  }
+}
+
+.form-field {
+  &.form-field--error {
+    input, textarea {
+      border-color: $red;
+    }
+
+    label {
+      color: $red;
+    }
+  }
+}
+
+.errors {
+  color: $red;
+  > li {
+    margin: 5px 0;
+  }
+}
+
+.field-errors {
+
+}
+.form-errors {
+  margin: 10px;
+  border-bottom: 1px solid $red;
 }

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -519,6 +519,10 @@ form {
       color: $red;
     }
   }
+
+  > .form-field__label {
+    flex: 0 0 17em;
+  }
 }
 
 .errors {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -206,23 +206,8 @@ module ApplicationHelper
   def short_uuid_with_title(uuid)
     uuid.nil? ? "" : content_tag(:abbr, format_uuid(uuid), title: uuid)
   end
-  
+
   def format_uuid(uuid)
     "#{uuid[0,4]}…#{uuid[-4,4]}"
   end
-
-  def field_errors(record, attr_name)
-    messages = record.errors.full_messages_for(attr_name)
-    return if messages.empty?
-  
-    content_tag :ul, class: "error" do
-      messages.each do |message|
-        concat (content_tag :li do
-          concat content_tag :i, "", class: "icon-error icon-red"
-          concat message
-        end)
-      end
-    end
-  end
-
 end

--- a/app/helpers/cdx_form_helper.rb
+++ b/app/helpers/cdx_form_helper.rb
@@ -1,0 +1,70 @@
+module CdxFormHelper
+  # Creates a form builder instance using CdxFormBuilder
+  def cdx_form_for(record_or_name_or_array, *args, &block)
+    options = args.extract_options!
+    form_for(record_or_name_or_array, *(args << options.merge(builder: FormFieldBuilder))) do |form|
+      yield form
+
+      # `form_errors` could be called in the block, but that doesn't matter because a
+      # second call is a no-op.
+      concat form.form_errors
+    end
+  end
+end
+
+# This form builder adds some methods for showing error messages.
+# It keeps track which error messages are shown directly with the corresponding
+# fields.
+class FormFieldBuilder < ActionView::Helpers::FormBuilder
+  # Renders a form field including label, value (block) and error messages.
+  def form_field(method, options = {}, &block)
+    if block_given?
+      value = @template.capture(&block)
+    else
+      value = @template.content_tag("div", options[:value], class: "value")
+    end
+
+    @template.render partial: "form_builder/field", locals: {
+      form: self,
+      method: method,
+      value: value,
+      options: objectify_options(options),
+    }
+  end
+
+  # Renders all error messages for *attribute*.
+  def field_errors(attribute)
+    messages = @object.errors.full_messages_for(attribute)
+    return if messages.empty?
+
+    errors_to_show.delete attribute
+
+    @template.render partial: "form_builder/field_errors", locals: {
+      form: self,
+      messages: messages,
+    }
+  end
+
+  # Renders form errors for fields that have not been handled by a dedicated
+  # `#field` errors.
+  def form_errors
+    @template.render partial: "form_builder/form_errors", locals: {
+      form: self,
+      messages: error_messages_to_show,
+    }
+  end
+
+  private
+
+  def errors_to_show
+    @errors_to_show ||= @object.errors.keys
+  end
+
+  def error_messages_to_show
+    errors_to_show.map do |attribute|
+      @object.errors.full_messages_for(attribute)
+    end.flatten.tap do
+      @errors_to_show = []
+    end
+  end
+end

--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -1,73 +1,43 @@
-= form_for(@batch_form) do |f|
-
-  = validation_errors @batch_form
-
+= cdx_form_for(@batch_form) do |f|
   .row
     .col
-      .row.form-field
-        .col.pe-3
-          = f.label :batch_id
-        .col
-          = f.text_field :batch_number, readonly: !@can_update
+      = f.form_field :batch_number do
+        = f.text_field :batch_number, readonly: !@can_update
 
-      .row.form-field
-        .col.pe-3
-          = f.label :date_produced
-        .col
-          = f.text_field :date_produced, placeholder: Batch.date_produced_placeholder, readonly: !@can_update
+      = f.form_field :date_produced do
+        = f.text_field :date_produced, placeholder: Batch.date_produced_placeholder, readonly: !@can_update
 
-      .row.form-field
-        .col.pe-3
-          = f.label :lab_technician
-        .col
-          = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
+      = f.form_field :lab_technician do
+        = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
 
-      .row.form-field
-        .col.pe-3
-          = f.label :specimen_role
-        .col
-          - if @can_update
-            = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
-              - select.items Batch.specimen_roles, :id, :description
-          - else
-            = text_field_tag :specimen_role, Batch.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
+      = f.form_field :specimen_role do
+        - if @can_update
+          = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
+            - select.items Batch.specimen_roles, :id, :description
+        - else
+          = text_field_tag :specimen_role, Batch.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
 
-      .row.form-field
-        .col.pe-3
-          = f.label :isolate_name
-        .col
-          = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
+      = f.form_field :isolate_name do
+        = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
 
-      .row.form-field
-        .col.pe-3
-          = f.label :inactivation_method
-        .col
-          - if @can_update
-            = cdx_select form: f, name: :inactivation_method, searchable: false do |select|
-              - select.items Batch.inactivation_methods
-          - else
-            = f.text_field :inactivation_method, readonly: true
+      = f.form_field :inactivation_method do
+        - if @can_update
+          = cdx_select form: f, name: :inactivation_method, searchable: false do |select|
+            - select.items Batch.inactivation_methods
+        - else
+          = f.text_field :inactivation_method, readonly: true
 
-      .row.form-field
-        .col.pe-3
-          = f.label :volume
-        .col
-          .row.input-unit
-            = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
-            .span.unit (μl)
+      = f.form_field :volume do
+        .row.input-unit
+          = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
+          .span.unit (μl)
 
       - if @can_edit_sample_quantity
-        .row.form-field
-          .col.pe-3
-            = f.label :samples_quantity
-          .col
-            = f.number_field :samples_quantity, min: 0, :class => "input-small"
+        = f.form_field :samples_quantity do
+          = f.number_field :samples_quantity, min: 0, :class => "input-small"
       - else
-        .row.form-field
-          .col.pe-3
-            = f.label :samples
-          .col.pe-7
-            = render (@can_update ? 'samples' : 'show_samples')
+        = f.form_field :samples do
+          = render (@can_update ? 'samples' : 'show_samples')
 
   - if @can_update
     .row.button-actions

--- a/app/views/form_builder/_field.haml
+++ b/app/views/form_builder/_field.haml
@@ -1,0 +1,7 @@
+.row.form-field{class: form.object.errors.has_key?(method) && "form-field--error" }
+  .col.pe-4
+    = form.label method, options[:label_opts] || {}
+  .col
+    = value
+
+    = form.field_errors method

--- a/app/views/form_builder/_field.haml
+++ b/app/views/form_builder/_field.haml
@@ -1,5 +1,5 @@
 .row.form-field{class: form.object.errors.has_key?(method) && "form-field--error" }
-  .col.pe-4
+  .col.form-field__label
     = form.label method, options[:label_opts] || {}
   .col
     = value

--- a/app/views/form_builder/_field_errors.haml
+++ b/app/views/form_builder/_field_errors.haml
@@ -1,0 +1,5 @@
+.field-errors
+  %ul.errors
+    - messages.each do |message|
+      %li
+        = message

--- a/app/views/form_builder/_form_errors.haml
+++ b/app/views/form_builder/_form_errors.haml
@@ -1,0 +1,7 @@
+- unless messages.empty?
+  .row.form-errors
+    .col
+      %ul.errors
+        - messages.each do |message|
+          %li
+            = message

--- a/app/views/institutions/_form.haml
+++ b/app/views/institutions/_form.haml
@@ -1,4 +1,4 @@
-= form_for(@institution) do |f|
+= cdx_form_for(@institution) do |f|
   - if @institution.new_record?
     .row.centered.institution-container{:class => ("active" unless @institution.kind.blank?)}
       .col
@@ -37,7 +37,7 @@
         = f.label :name, :class => 'block'
       .col
         = f.text_field :name, readonly: @readonly, :class => ['input-block', @institution.errors.has_key?(:name) ? 'input-required':'']
-        = field_errors @institution, :name
+        = f.field_errors :name
         = f.hidden_field :pending_institution_invite_id
     - if not f.object.new_record?
       .row

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -1,74 +1,44 @@
-= form_for(@sample_form) do |f|
-
-  = validation_errors @sample_form
-
+= cdx_form_for(@sample_form) do |f|
   .row
     .col
       - unless f.object.qc_info.nil?
-        .row.form-field
-          .col.pe-4
-            = f.label :quality_control
-          .col
-            = link_to edit_qc_info_path(f.object.qc_info.id, sample_id: f.object.id), class: 'centered' do
-              .icon-test.icon-blue
-              = "VIEW QC INFO"
+        = f.form_field :quality_control do
+          = link_to edit_qc_info_path(f.object.qc_info.id, sample_id: f.object.id), class: 'centered' do
+            .icon-test.icon-blue
+            = "VIEW QC INFO"
 
-      .row.form-field
-        .col.pe-4
-          = f.label :uuid
-        .col
-          .value= f.object.uuid
+      = f.form_field :uuid, value: f.object.uuid
+
       - if batch_number = f.object.batch_number
-        .row.form-field
-          .col.pe-4
-            = f.label :batch_id
-          .col
-            .value= batch_number
+        = f.form_field :batch_id, value: batch_number
 
-      .row.form-field
-        .col.pe-4
-          = f.label :date_produced
-        .col
-          = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
+      = f.form_field :date_produced do
+        = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
 
-      .row.form-field
-        .col.pe-4
-          = f.label :lab_technician
-        .col
-          = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
+      = f.form_field :lab_technician do
+        = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
 
-      .row.form-field
-        .col.pe-4
-          = f.label :specimen_role
-        .col
-          - if @can_update
-            = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
-              - select.items Sample.specimen_roles, :id, :description
-          - else
-            = text_field_tag :specimen_role, Sample.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
-      .row.form-field
-        .col.pe-4
-          = f.label :isolate_name
-        .col
-          = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
+      = f.form_field :specimen_role do
+        - if @can_update
+          = cdx_select form: f, name: :specimen_role, searchable: true, :class => 'input-x-large' do |select|
+            - select.items Sample.specimen_roles, :id, :description
+        - else
+          = text_field_tag :specimen_role, Sample.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
 
-      .row.form-field
-        .col.pe-4
-          = f.label :inactivation_method
-        .col
-          - if @can_update
-            = cdx_select form: f, name: :inactivation_method, searchable: false do |select|
-              - select.items Sample.inactivation_methods
-          - else
-            = f.text_field :inactivation_method, readonly: true
+      = f.form_field :isolate_name do
+        = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
 
-      .row.form-field
-        .col.pe-4
-          = f.label :volume
-        .col
-          .row.input-unit
-            = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
-            .span.unit (μl)
+      = f.form_field :inactivation_method do
+        - if @can_update
+          = cdx_select form: f, name: :inactivation_method, searchable: false do |select|
+            - select.items Sample.inactivation_methods
+        - else
+          = f.text_field :inactivation_method, readonly: true
+
+      = f.form_field :volume do
+        .row.input-unit
+          = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
+          .span.unit (μl)
 
     .col.pe-5
       - if @show_barcode_preview

--- a/app/views/transfer_packages/_form.haml
+++ b/app/views/transfer_packages/_form.haml
@@ -1,38 +1,24 @@
-= form_for(@transfer_package) do |f|
-  = validation_errors @transfer_package
-
+= cdx_form_for(@transfer_package) do |f|
   .row
     .col
-      .row.form-field
-        .col.pe-4
-          = f.label :uuid
-        .col
-          .value
-            = f.object.uuid
+      = f.form_field :uuid do
+        .value
+          = f.object.uuid
 
-      .row.form-field
-        .col.pe-4
-          = f.label :receiver_institution, title: "Receiver institution"
-        .col
-          - if @can_update
-            = cdx_select form: f, name: :receiver_institution_id, searchable: true, class: "input-x-large" do |select|
-              - select.items available_institutions, :id, :name
-          - else
-            = text_field_tag :receiver_institution, { :class => 'input-x-large', readonly: true }
+      = f.form_field :receiver_institution do
+        - if @can_update
+          = cdx_select form: f, name: :receiver_institution_id, searchable: true, class: "input-x-large" do |select|
+            - select.items available_institutions, :id, :name
+        - else
+          = text_field_tag :receiver_institution, { :class => 'input-x-large', readonly: true }
 
-      .row.form-field
-        .col.pe-4
-          = f.label :recipient
-        .col
-          = f.text_field :recipient, :class => 'input-x-large', readonly: !@can_update
+      = f.form_field :recipient do
+        = f.text_field :recipient, :class => 'input-x-large', readonly: !@can_update
 
-      .row.form-field
-        .col.pe-4
-          = f.label :sample_transfers
-        .col
-          = react_component("SampleTransferSelector",
-              context: @navigation_context.uuid,
-              includeQcInfo: @transfer_package.includes_qc_info, samples: samples_data(@transfer_package.sample_transfers.map(&:sample)))
+      = f.form_field :sample_transfers do
+        = react_component("SampleTransferSelector",
+          context: @navigation_context.uuid,
+          includeQcInfo: @transfer_package.includes_qc_info, samples: samples_data(@transfer_package.sample_transfers.map(&:sample)))
 
   - if @can_update
     .row.button-actions

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,9 @@ module Cdp
     config.action_mailer.asset_host = "http://#{Settings.host}"
 
     config.assets.paths << Rails.root.join("app", "assets", "fonts")
+
+    # disable <div class="field_with_errors"> wrapper
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 
   def self.version

--- a/spec/helpers/cdx_form_helper_spec.rb
+++ b/spec/helpers/cdx_form_helper_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+RSpec.describe CdxFormHelper, type: :helper do
+  class FooModel
+    include ActiveModel::Model
+
+    attr_accessor :foo, :bar
+  end
+
+  describe "#form_field" do
+    it "basics" do
+      model = FooModel.new(foo: "bar")
+      cdx_form_for(model, url: "") do |form|
+        rendered = form.form_field(:foo) { form.text_field :foo }
+        expect(rendered).to include(%(<input type="text" value="bar" name="foo_model[foo]" id="foo_model_foo" />))
+        expect(rendered).to include "Foo"
+      end
+    end
+
+    it "shows error" do
+      model = FooModel.new(foo: "bar")
+      model.errors.add(:foo, "has an error")
+      model.errors.add(:bar, "has an error")
+      model.errors.add(:other, "has an error")
+      model.errors.add(:base, "base error")
+      cdx_form_for(model, url: "") do |form|
+        rendered = form.form_field(:foo) { form.text_field :foo }
+        expect(rendered).to include("Foo has an error")
+        expect(rendered).not_to include("Bar has an errror")
+      end
+    end
+  end
+
+  describe "#form_errors" do
+    it "shows all error messages" do
+      model = FooModel.new(foo: "bar")
+      model.errors.add(:base, "base error")
+      model.errors.add(:other, "has an error")
+      cdx_form_for(model, url: "") do |form|
+        rendered = form.form_errors
+        expect(rendered).to include("base error")
+        expect(rendered).to include("Other has an error")
+      end
+    end
+
+    it "remembers error messages that have been displayed" do
+      model = FooModel.new(foo: "bar")
+      model.errors.add(:foo, "has an error")
+      model.errors.add(:base, "base error")
+      model.errors.add(:other, "has an error")
+      cdx_form_for(model, url: "") do |form|
+        form.form_field(:foo) {}
+        rendered = form.form_errors
+        expect(rendered).to include("base error")
+        expect(rendered).to include("Other has an error")
+        expect(rendered).not_to include("Foo has an errror")
+      end
+    end
+
+    it "renders errors only once" do
+      model = FooModel.new(foo: "bar")
+      model.errors.add(:foo, "has an error")
+      cdx_form_for(model, url: "") do |form|
+        rendered = form.form_errors
+        expect(rendered).to include("Foo has an error")
+
+        rendered = form.form_errors
+        expect(rendered).to be_blank
+      end
+    end
+
+    it "renders errors implicitly" do
+      model = FooModel.new(foo: "bar")
+      model.errors.add(:foo, "has an error")
+      rendered = cdx_form_for(model, url: "") { }
+      expect(rendered).to include("Foo has an error")
+    end
+  end
+end


### PR DESCRIPTION
I've implemented a custom form builder which takes care of showing error messages adjacent to the respective fields.
It keeps track which error messages are shown directly. The remaining ones are displayed as form-wide errors.
This makes it safe to apply this helper to forms without fearing about error messages getting lost.

The builder also comes with a neat helper for grouping all pieces of a form field (label, value, errors) and thus reducing a lot of boilerplate in the form templates.

![Screenshot 2022-05-16 at 20-25-04 Connected Diagnostics Platform](https://user-images.githubusercontent.com/466378/168661068-1d700a6b-c9c6-4608-9106-039c3efcec80.png)

So far I have only adapted a couple of forms to gather some feedback. The others should follow.

This does not touch errors in React components (using `input-required`). This should be done in a follow-up and can re-use the introduced DOM structure.

Ref  #1065, #1623
Builds on #1659