### PR TITLE
Add `CdxFormBuilder#form_actions`

### DIFF
--- a/app/helpers/cdx_form_helper.rb
+++ b/app/helpers/cdx_form_helper.rb
@@ -54,6 +54,15 @@ class FormFieldBuilder < ActionView::Helpers::FormBuilder
     }
   end
 
+  # Renders the final section of the form which usually includes the submit
+  # button and other actions.
+  def form_actions
+    @template.render partial: "form_builder/form_actions", locals: {
+      form: self,
+      body: yield
+    }
+  end
+
   private
 
   def errors_to_show

--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -40,10 +40,9 @@
           = render (@can_update ? 'samples' : 'show_samples')
 
   - if @can_update
-    .row.button-actions
-      .col
-        = f.submit 'Save', class: 'btn-primary'
-        = link_to 'Cancel', batches_path, class: 'btn-link'
+    = f.form_actions do
+      = f.submit 'Save', class: 'btn-primary'
+      = link_to 'Cancel', batches_path, class: 'btn-link'
 
-        - if @can_delete
-          = confirm_deletion_button @batch_form, 'batch'
+      - if @can_delete
+        = confirm_deletion_button @batch_form, 'batch'

--- a/app/views/form_builder/_form_actions.haml
+++ b/app/views/form_builder/_form_actions.haml
@@ -1,0 +1,3 @@
+.row.button-actions
+  .col
+    = body

--- a/app/views/institutions/_form.haml
+++ b/app/views/institutions/_form.haml
@@ -45,12 +45,12 @@
           = label_tag "kind", "Type", :class => 'block'
         .col
           .value= f.object.kind.humanize.titleize
-    .row.button-actions
-      .col
-        - unless @readonly
-          = f.submit 'Save', class: 'btn-primary'
 
-        = link_to (@readonly ? 'back' : 'Cancel'), (@institutions.one? ? dashboard_path : institutions_path), class: 'btn-link'
+    = f.form_actions do
+      - unless @readonly
+        = f.submit 'Save', class: 'btn-primary'
 
-        - if @can_delete
-          = confirm_deletion_button @institution
+      = link_to (@readonly ? 'back' : 'Cancel'), (@institutions.one? ? dashboard_path : institutions_path), class: 'btn-link'
+
+      - if @can_delete
+        = confirm_deletion_button @institution

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -51,11 +51,9 @@
     = render (@can_update ? 'form_notes' : 'show_notes'), f: f
 
   - if @can_update
-    .row.button-actions
-      .col
-        = f.submit 'Save', class: 'btn-primary', id: 'btn-save'
-        = link_to 'Cancel', @view_helper[:back_path], class: 'btn-link'
+    = f.form_actions do
+      = f.submit 'Save', class: 'btn-primary', id: 'btn-save'
+      = link_to 'Cancel', @view_helper[:back_path], class: 'btn-link'
 
-        - if @can_delete
-          = confirm_deletion_button @sample_form, 'sample'
-
+      - if @can_delete
+        = confirm_deletion_button @sample_form, 'sample'

--- a/app/views/transfer_packages/_form.haml
+++ b/app/views/transfer_packages/_form.haml
@@ -21,7 +21,6 @@
           includeQcInfo: @transfer_package.includes_qc_info, samples: samples_data(@transfer_package.sample_transfers.map(&:sample)))
 
   - if @can_update
-    .row.button-actions
-      .col
-        = f.submit 'Transfer', class: 'btn-primary', id: 'btn-save'
-        = link_to 'Cancel', @view_helper[:back_path], class: 'btn-link'
+    = f.form_actions do
+      = f.submit 'Transfer', class: 'btn-primary', id: 'btn-save'
+      = link_to 'Cancel', @view_helper[:back_path], class: 'btn-link'


### PR DESCRIPTION
This adds a neat little tool to the form helper for abstracting the section containing form actions.

With this change, form bodies should usually consist of a number of `#form_field` and a final `#form_actions`. The HTML boilerplate structure is extracted into abstract templates.