### PR TITLE
Export box inventory as ~XLS~ CSV

### DIFF
--- a/app/assets/stylesheets/_barcode_card.scss
+++ b/app/assets/stylesheets/_barcode_card.scss
@@ -10,7 +10,7 @@
 
     background: $white;
     padding: 5px 7px;
-    margin: 15px;
+    margin: 15px 15px 7px;
 
     .title {
       font-size: 14px;
@@ -21,11 +21,6 @@
     .barcode {
       @include flexbox();
       justify-content: center;
-    }
-
-    .title {
-      font-weight: bold;
-      font-size: 16px;
     }
 
     .code {
@@ -60,13 +55,25 @@
   }
 
   .actions {
-    margin: 0 15px 15px;
+    margin: 0 15px 7px;
 
     .btn-icon {
+      margin: -3px 0 0;
+      font-size: 24px;
       background: none !important;
       color: inherit;
-      margin: -3px 0 0;
     }
+  }
+}
+
+.barcode-after {
+  margin: 7px 15px 0;
+
+  .btn-icon {
+    margin: -3px 0 0;
+    font-size: 24px;
+    background: none !important;
+    color: inherit;
   }
 }
 

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -17,7 +17,19 @@ class BoxesController < ApplicationController
     return unless authorize_resource(@box, READ_BOX)
     @can_delete = has_access?(@box, DELETE_BOX)
 
-    @samples = @box.scrambled_samples.preload(:batch).to_a
+    @samples = @box.scrambled_samples.preload(:batch, :sample_identifiers)
+  end
+
+  def inventory
+    return unless authorize_resource(@box, READ_BOX)
+
+    @samples = @box.samples.preload(:batch, :sample_identifiers)
+
+    respond_to do |format|
+      format.csv do
+        @filename = "cdx_box_inventory_#{@box.uuid}.csv"
+      end
+    end
   end
 
   def print
@@ -28,7 +40,7 @@ class BoxesController < ApplicationController
       layout: "layouts/pdf.html",
       locals: {
         box: @box,
-        samples: @box.samples.preload(:sample_identifiers),
+        samples: @box.samples.preload(:batch, :sample_identifiers),
       },
       margin: { top: 0, bottom: 0, left: 0, right: 0 },
       page_width: "1in",

--- a/app/models/box_form.rb
+++ b/app/models/box_form.rb
@@ -88,8 +88,12 @@ class BoxForm
     when "Variants"
       @box.errors.add(:base, "You must select at least two batches") unless count >= 2
     when "Challenge"
-      @box.errors.add(:virus, "A virus batch is required") unless @batches["virus"] || @box.errors.include?(:virus)
-      @box.errors.add(:base, "You must select at least one distractor batch") unless count >= 2
+      if @batches["virus"]
+        @box.errors.add(:base, "You must select at least one distractor batch") unless count >= 2
+      else
+        @box.errors.add(:virus, "A virus batch is required") unless @box.errors.include?(:virus)
+        @box.errors.add(:base, "You must select at least one distractor batch") unless count >= 1
+      end
     end
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -155,7 +155,17 @@ class Sample < ApplicationRecord
 
   def concentration
     if (n = concentration_number) && (e = concentration_exponent)
-      n.to_i * (10 ** -e.to_i)
+      n * (10 ** -e)
+    end
+  end
+
+  def concentration_formula
+    if (n = concentration_number) && (e = concentration_exponent)
+      if n == 1
+        "10E-#{e}"
+      else
+        "#{n} × 10E-#{e}"
+      end
     end
   end
 end

--- a/app/views/boxes/inventory.csv.csvbuilder
+++ b/app/views/boxes/inventory.csv.csvbuilder
@@ -1,0 +1,27 @@
+csv << [
+  "Purpose",
+  "Sample #",
+  "Label ID (QR code)",
+  "Batch ID",
+  "Virus Lineage",
+  "Replicate",
+  "Production Date",
+  "Concentration",
+  "Inactivation Method",
+  "Media",
+]
+
+@samples.each_with_index do |sample, index|
+  csv << [
+    @box.purpose,
+    index + 1,
+    sample.uuid,
+    sample.batch_number,
+    sample.virus_lineage,
+    sample.replicate,
+    sample.date_produced.to_date,
+    sample.concentration_formula,
+    sample.inactivation_method,
+    sample.media,
+  ]
+end

--- a/app/views/boxes/show.haml
+++ b/app/views/boxes/show.haml
@@ -27,6 +27,11 @@
       .col
         = render "barcode_card"
 
+        .barcode-after
+          = link_to inventory_box_path(@box, format: "csv"), target: "_blank", class: 'btn-link' do
+            .icon-download.btn-icon
+            %span Download inventory
+
 .row
   .col
     .row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,7 @@ Rails.application.routes.draw do
   resources :boxes, except: [:edit, :update] do
     member do
       get 'print'
+      get 'inventory', constraints: { format: 'csv' }
     end
     collection do
       post 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'destroy' }, action: :bulk_destroy

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -125,6 +125,32 @@ RSpec.describe BoxesController, type: :controller do
     end
   end
 
+  describe "inventory" do
+    it "should be accessible to institution owner" do
+      get :inventory, params: { id: box.id, format: "csv" }
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to eq("text/csv")
+      expect(response.body.strip.split("\n").size).to eq(box.samples.count + 1)
+      expect(response.headers["Content-Disposition"]).to match(/cdx_box_inventory_#{box.uuid}\.csv/)
+    end
+
+    it "should be allowed if can read" do
+      grant user, other_user, box, READ_BOX
+      sign_in other_user
+
+      get :inventory, params: { id: box.id, format: "csv" }
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to eq("text/csv")
+    end
+
+    it "shouldn't be allowed if can't read" do
+      sign_in other_user
+
+      get :inventory, params: { id: box.id, format: "csv" }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe "new" do
     it "should be accessible to institution owner" do
       get :new


### PR DESCRIPTION
Generates a flat XLS file, which is usually nicer to deal with than a CSV file.

![Capture d'écran du 2022-05-19 18 57 00@2x](https://user-images.githubusercontent.com/47380/169358779-245c71a8-1375-4a6a-840b-666e170c16f1.jpeg)

[cdx_inventory_1953cedc-5174-cdcc-1221-a6531618f1c6.xls](https://github.com/instedd/cdx/files/8732419/cdx_inventory_1953cedc-5174-cdcc-1221-a6531618f1c6.xls). My batches didn't have a virus lineage field, and the samples don't have a media field (until we go and change it manually for each), so they're empty. BTW: we probably don't need the media field for this inventory sheet, do we @diegoliberman?

closes #1609 