### PR TITLE
Add validation for sample in box context

### DIFF
--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -34,6 +34,8 @@ class Box < ApplicationRecord
           concentration_number: 1,
           concentration_exponent: exponent,
           replicate: replicate,
+          institution: institution,
+          site: site,
         )
       end
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -35,6 +35,12 @@ class Sample < ApplicationRecord
   validates_numericality_of :concentration_exponent, only_integer: true, greater_than: 0, allow_blank: true
   validates_numericality_of :replicate, only_integer: true, greater_than_or_equal_to: 0, allow_blank: true
   validates_inclusion_of :media, in: ->(_) { Sample.medias }, allow_blank: true
+  validate :validate_box_context, if: -> { box.present? }
+
+  def validate_box_context
+    errors.add(:institution, "must be the same as the box it is contained in") unless institution == box.institution
+    errors.add(:site, "must be the same box it is contained in") unless site == box.site
+  end
 
   def self.entity_scope
     "sample"

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -65,4 +65,19 @@ describe Sample do
     expect(Sample.new(concentration_number: 1, concentration_exponent: 8).concentration).to eq(1 * (10 ** -8))
     expect(Sample.new(concentration_number: 2, concentration_exponent: 4).concentration).to eq(2 * (10 ** -4))
   end
+
+  it "validates box context" do
+    institution = Institution.make!
+    site = Site.make!(institution: institution)
+    sample = Sample.make(institution: institution, site: site)
+
+    sample.box = Box.make!
+    expect(sample).not_to be_valid
+
+    sample.box = Box.make!(institution: institution)
+    expect(sample).not_to be_valid
+
+    sample.box = Box.make!(institution: institution, site: site)
+    expect(sample).to be_valid
+  end
 end


### PR DESCRIPTION
This patch adds a simple validation that a sample has the same institution and site as the box it is contained in.