### PR TITLE
Fix: WickedPDF skips CSS in production

### DIFF
--- a/app/views/boxes/barcode.pdf.haml
+++ b/app/views/boxes/barcode.pdf.haml
@@ -12,5 +12,5 @@
     .code
       &nbsp;
     .logo
-      = wicked_pdf_image_tag "cdx-logo-bw.png"
+      = image_tag wicked_pdf_asset_base64('cdx-logo-bw.png')
       .label https://cdx.io

--- a/app/views/layouts/pdf.html.haml
+++ b/app/views/layouts/pdf.html.haml
@@ -2,10 +2,7 @@
 %html
   %head
     %title Connected Diagnostics Platform
-    - if Rails::VERSION::MAJOR < 5
-      = stylesheet_link_tag wicked_pdf_asset_base64("pdf")
-    - else
-      = wicked_pdf_stylesheet_link_tag "pdf"
+    = stylesheet_link_tag wicked_pdf_asset_base64("pdf")
     = wicked_pdf_stylesheet_link_tag "https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap"
   %body
     = yield

--- a/app/views/samples/barcode.pdf.haml
+++ b/app/views/samples/barcode.pdf.haml
@@ -14,6 +14,5 @@
     .code
       P.D. #{sample.date_produced_description}
     .logo
-      -# = image_tag 'cdx-logo-bw.png'
-      = wicked_pdf_image_tag 'cdx-logo-bw.png'
+      = image_tag wicked_pdf_asset_base64('cdx-logo-bw.png')
       .label https://cdx.io


### PR DESCRIPTION
As well as all other assets. The solution was to use base64 encoded data-uris.

closes #1634 