### PR TITLE
Box: autocomplete batch number + use batch UUID internally

### DIFF
--- a/app/assets/javascripts/components/cdx_select_autocomplete.js.jsx
+++ b/app/assets/javascripts/components/cdx_select_autocomplete.js.jsx
@@ -1,0 +1,38 @@
+var CdxSelectAutocomplete = React.createClass({
+  render: function () {
+    return (<Select
+      className={this.props.className}
+      name={this.props.name}
+      value={this.props.value}
+      placeholder={this.props.placeholder}
+      searchable={true}
+      clearable={true}
+      asyncOptions={this.asyncOptions.bind(this)}
+    />);
+  },
+
+  asyncOptions: function (query, callback) {
+    if (!query || /^\s*$/.test(query)) {
+      return callback(null, []);
+    }
+
+    var url = this.props.url;
+    url += (url.includes("?") ? "&query=" : "?query=") + encodeURIComponent(query);
+
+    $.ajax({
+      type: this.props.method || "GET",
+      url: url,
+
+      success: function (options) {
+        callback(null, {
+          options: options,
+          complete: options.size < 10,
+        });
+      },
+
+      error: function (_, error) {
+        callback(error);
+      },
+    })
+  },
+});

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -18,6 +18,16 @@ class BatchesController < ApplicationController
     @batches = perform_pagination(@batches)
   end
 
+  def autocomplete
+    batches = Batch
+      .where(institution: @navigation_context.institution)
+      .within(@navigation_context.entity, @navigation_context.exclude_subsites)
+      .autocomplete(params[:query])
+      .limit(10)
+
+    @batches = check_access(batches, READ_BATCH).pluck(:uuid, :batch_number)
+  end
+
   def edit_or_show
     batch = Batch.find(params[:id])
 

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -85,19 +85,19 @@ class BoxesController < ApplicationController
   def load_batches
     Batch
       .within(@navigation_context.entity, @navigation_context.exclude_subsites)
-      .where(batch_number: @box_form.batch_numbers.values.reject(&:blank?))
+      .where(uuid: @box_form.batch_uuids.values.reject(&:blank?))
   end
 
   def box_params
     if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 0
       params.require(:box).permit(:purpose).tap do |allowed|
-        allowed[:batch_numbers] = params[:box][:batch_numbers].permit!
+        allowed[:batch_uuids] = params[:box][:batch_uuids].permit!
       end
     elsif Rails::VERSION::MAJOR >= 5
-      params.require(:box).permit(:purpose, batch_numbers: {})
+      params.require(:box).permit(:purpose, batch_uuids: {})
     else
       params.require(:box).permit(:purpose).tap do |allowed|
-        allowed[:batch_numbers] = params[:box][:batch_numbers]
+        allowed[:batch_uuids] = params[:box][:batch_uuids]
       end
     end
   end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -34,6 +34,10 @@ class Batch < ApplicationRecord
 
   validates_associated :samples, message: "are invalid"
 
+  scope :autocomplete, ->(query) {
+    where("batches.batch_number LIKE ?", "%#{query}%")
+  }
+
   def qc_sample
     self.samples.select {|sample| sample.is_quality_control?}.first
   end

--- a/app/models/box_form.rb
+++ b/app/models/box_form.rb
@@ -1,5 +1,5 @@
 class BoxForm
-  attr_reader :box, :batch_numbers
+  attr_reader :box, :batch_uuids
 
   delegate :purpose, :purpose=, to: :box
   delegate :model_name, :errors, to: :box
@@ -11,25 +11,25 @@ class BoxForm
     )
 
     if params
-      batch_numbers = params.delete(:batch_numbers) || {}
+      batch_uuids = params.delete(:batch_uuids) || {}
       box.attributes = params
     else
-      batch_numbers = {}
+      batch_uuids = {}
     end
 
-    new(box, batch_numbers)
+    new(box, batch_uuids)
   end
 
-  def initialize(box, batch_numbers)
+  def initialize(box, batch_uuids)
     @box = box
-    @batch_numbers = batch_numbers
+    @batch_uuids = batch_uuids
   end
 
   def batches=(relation)
     records = relation.to_a
 
-    @batches = @batch_numbers.transform_values do |batch_number|
-      records.find { |b| b.batch_number == batch_number }
+    @batches = @batch_uuids.transform_values do |batch_uuid|
+      records.find { |b| b.uuid == batch_uuid }
     end.compact
   end
 
@@ -72,15 +72,15 @@ class BoxForm
   private
 
   def validate_existence_of_batches
-    @batch_numbers.each do |key, batch_number|
-      unless batch_number.blank? || @batches[key]
+    @batch_uuids.each do |key, batch_uuid|
+      unless batch_uuid.blank? || @batches[key]
         @box.errors.add(key, "Batch doesn't exist")
       end
     end
   end
 
   def validate_batches_for_purpose
-    count = @batches.map { |_, b| b.try(&:batch_number) }.uniq.size
+    count = @batches.map { |_, b| b.try(&:uuid) }.uniq.size
 
     case @box.purpose
     when "LOD"

--- a/app/views/batches/autocomplete.json.jbuilder
+++ b/app/views/batches/autocomplete.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@batches) do |(uuid, batch_number)|
+  json.value uuid
+  json.label batch_number
+end

--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -12,26 +12,30 @@
         .col
           %fieldset#LOD(disabled)
             = f.form_field "lod", label: { text: "Batch", class: "is-normal-case" }, full_message: false do
-              = text_field_tag "box[batch_numbers][lod]", @box_form.batch_numbers["lod"],
-                id: "box_lod", placeholder: "Enter batch id", class: "input-block"
+              = react_component "CdxSelectAutocomplete", { url: autocomplete_batches_path(format: "json", context: params[:context]),
+                name: "box[batch_uuids][lod]", value: @box_form.batch_uuids["lod"],
+                placeholder: "Enter batch id", className: "input-block" }
 
           %fieldset#Variants(disabled)
             - 1.upto(6) do |index|
               - key = "variant_#{index}"
               = f.form_field key, label: { text: "Variant #{index}", class: "is-normal-case" }, full_message: false do
-                = text_field_tag "box[batch_numbers][#{key}]", @box_form.batch_numbers[key],
-                  id: "box_#{key}", placeholder: "Enter batch id", class: "input-block"
+                = react_component "CdxSelectAutocomplete", { url: autocomplete_batches_path(format: "json", context: params[:context]),
+                  name: "box[batch_uuids][#{key}]", value: @box_form.batch_uuids[key],
+                  placeholder: "Enter batch id", className: "input-block" }
 
           %fieldset#Challenge(disabled)
             = f.form_field "virus", label: { text: "Virus", class: "is-normal-case" }, full_message: false do
-              = text_field_tag "box[batch_numbers][virus]", @box_form.batch_numbers["virus"],
-                id: "box_virus", placeholder: "Enter batch id", class: "input-block"
+              = react_component "CdxSelectAutocomplete", { url: autocomplete_batches_path(format: "json", context: params[:context]),
+                name: "box[batch_uuids][virus]", value: @box_form.batch_uuids["virus"],
+                placeholder: "Enter batch id", className: "input-block" }
 
             - 1.upto(6) do |index|
               - key = "distractor_#{index}"
               = f.form_field key, label: { text: "Distractor #{index}", class: "is-normal-case" }, full_message: false do
-                = text_field_tag "box[batch_numbers][#{key}]", @box_form.batch_numbers[key],
-                  id: "box_#{key}", placeholder: "Enter batch id", class: "input-block"
+                = react_component "CdxSelectAutocomplete", { url: autocomplete_batches_path(format: "json", context: params[:context]),
+                  name: "box[batch_uuids][#{key}]", value: @box_form.batch_uuids[key],
+                  placeholder: "Enter batch id", className: "input-block" }
 
   .row.button-actions
     .col

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
       post 'add_sample'
     end
     collection do
+      get 'autocomplete'
       post 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'destroy' }, action: :bulk_destroy
     end
   end

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe BoxesController, type: :controller do
     let :box_plan do
       {
         purpose: "LOD",
-        batch_numbers: { "lod" => batch.batch_number },
+        batch_uuids: { "lod" => batch.uuid },
       }
     end
 
@@ -222,7 +222,7 @@ RSpec.describe BoxesController, type: :controller do
         expect do
           post :create, params: { box: {
             purpose: "LOD",
-            batch_numbers: { "lod" => batch.batch_number },
+            batch_uuids: { "lod" => batch.uuid },
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(24)
@@ -235,7 +235,7 @@ RSpec.describe BoxesController, type: :controller do
         expect do
           post :create, params: { box: {
             purpose: "LOD",
-            batch_numbers: { "lod" => "" },
+            batch_uuids: { "lod" => "" },
           } }
           expect(response).to have_http_status(:unprocessable_entity)
         end.to change(institution.samples, :count).by(0)
@@ -245,12 +245,12 @@ RSpec.describe BoxesController, type: :controller do
     describe "Variants purpose" do
       it "creates samples" do
         batches = Batch.make!(6, institution: institution)
-        batch_numbers = Hash[batches.map.with_index { |b, i| ["variant_#{i}", b.batch_number] }]
+        batch_uuids = Hash[batches.map.with_index { |b, i| ["variant_#{i}", b.uuid] }]
 
         expect do
           post :create, params: { box: {
             purpose: "Variants",
-            batch_numbers: batch_numbers,
+            batch_uuids: batch_uuids,
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(54)
@@ -265,7 +265,7 @@ RSpec.describe BoxesController, type: :controller do
         expect do
           post :create, params: { box: {
             purpose: "Variants",
-            batch_numbers: { "variant_1" => batch.batch_number },
+            batch_uuids: { "variant_1" => batch.uuid },
           } }
           expect(response).to have_http_status(:unprocessable_entity)
         end.to change(institution.samples, :count).by(0)
@@ -277,9 +277,9 @@ RSpec.describe BoxesController, type: :controller do
         expect do
           post :create, params: { box: {
             purpose: "Variants",
-            batch_numbers: {
-              "variant_4" => batch.batch_number,
-              "variant_2" => other_batch.batch_number,
+            batch_uuids: {
+              "variant_4" => batch.uuid,
+              "variant_2" => other_batch.uuid,
             },
           } }
           expect(response).to redirect_to(boxes_path)
@@ -290,13 +290,13 @@ RSpec.describe BoxesController, type: :controller do
     describe "Challenge purpose" do
       it "creates samples" do
         batches = Batch.make!(6, institution: institution)
-        batch_numbers = { "virus" => batch.batch_number }
-        batches.each_with_index { |b, i| batch_numbers["distractor_#{i + 1}"] = b.batch_number }
+        batch_uuids = { "virus" => batch.uuid }
+        batches.each_with_index { |b, i| batch_uuids["distractor_#{i + 1}"] = b.uuid }
 
         expect do
           post :create, params: { box: {
             purpose: "Challenge",
-            batch_numbers: batch_numbers,
+            batch_uuids: batch_uuids,
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(108)
@@ -318,7 +318,7 @@ RSpec.describe BoxesController, type: :controller do
         expect do
           post :create, params: { box: {
             purpose: "Challenge",
-            batch_numbers: { "1" => distractor.batch_number },
+            batch_uuids: { "1" => distractor.uuid },
           } }
           expect(response).to have_http_status(:unprocessable_entity)
         end.to change(institution.samples, :count).by(0)
@@ -328,7 +328,7 @@ RSpec.describe BoxesController, type: :controller do
         expect do
           post :create, params: { box: {
             purpose: "Challenge",
-            batch_numbers: { "virus" => batch.batch_number },
+            batch_uuids: { "virus" => batch.uuid },
           } }
           expect(response).to have_http_status(:unprocessable_entity)
         end.to change(institution.samples, :count).by(0)
@@ -340,9 +340,9 @@ RSpec.describe BoxesController, type: :controller do
         expect do
           post :create, params: { box: {
             purpose: "Challenge",
-            batch_numbers: {
-              "virus" => batch.batch_number,
-              "distractor_4" => distractor.batch_number,
+            batch_uuids: {
+              "virus" => batch.uuid,
+              "distractor_4" => distractor.uuid,
             },
           } }
           expect(response).to redirect_to(boxes_path)


### PR DESCRIPTION
We can now autocomplete the batch number from the new box form, and it's so much nicer to use. I should have done that sooner!

Also replaces the batch number for the batch UUID internally, which should prove to be a stronger solution.

![Capture d'écran du 2022-05-20 22 20 41@2x](https://user-images.githubusercontent.com/47380/169604879-25f3cc36-e037-4a61-afc9-24a8a13969dd.jpeg)
