### PR TITLE
Fix: samples form has wrong indentation

### DIFF
--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -17,6 +17,12 @@
           = g.form_field :uuid, value: box.uuid, label: { text: "Box ID" }
           = g.form_field :purpose, value: box.purpose, label: { text: "Box Purpose" }
 
+    .col.pe-5
+      - if @show_barcode_preview
+        = render "barcode_card"
+
+  .row
+    .col
       = f.form_field :date_produced do
         = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
 
@@ -66,10 +72,6 @@
             - select.items Sample.medias
         - else
           = f.text_field :media, readonly: true
-
-    .col.pe-5
-      - if @show_barcode_preview
-        = render "barcode_card"
 
   .col
     = render (@can_update ? 'form_assays' : 'show_assays'), f: f


### PR DESCRIPTION
This was caused by the qrcode/print label using the whole column of the form. I reduced it to only use the top part of the form:

![Capture d'écran du 2022-05-24 11 18 35@2x](https://user-images.githubusercontent.com/47380/169998615-d39ef3dd-34ae-415d-b981-1726e83a6bbb.jpeg)
![Capture d'écran du 2022-05-24 11 19 46@2x](https://user-images.githubusercontent.com/47380/169998620-c75a4cd4-ee59-47b8-b43d-14b960a865e4.jpeg)

closes #1603 