### PR TITLE
Adapt more forms to use `CdxFormHelper`

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -289,14 +289,10 @@ body.devise {
   }
 }
 
-.small-quote {
-  font-size: 70%;
+.form_field-hint {
+  font-size: 80%;
   color: $gray3;
-  font-style: italic;
-  position: absolute;
 }
-
-
 
 
 // Input text & Area sizes ---------------------------------------------------------//

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -146,7 +146,7 @@ class Manifest < ApplicationRecord
     end
 
   rescue Oj::ParseError => ex
-    self.errors.add(:parse_error, ex.message)
+    self.errors.add(:definition, ex.message)
   end
 
   def filename

--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -42,7 +42,6 @@
                   name: "box[batch_uuids][#{key}]", value: @box_form.batch_uuids[key],
                   placeholder: "Enter batch id", className: "input-block" }
 
-  .row.button-actions
-    .col
-      = f.submit 'Save', class: 'btn-primary', id: 'btn-save'
-      = link_to 'Cancel', boxes_path, class: 'btn-link'
+  = f.form_actions do
+    = f.submit 'Save', class: 'btn-primary', id: 'btn-save'
+    = link_to 'Cancel', boxes_path, class: 'btn-link'

--- a/app/views/device_models/_form.haml
+++ b/app/views/device_models/_form.haml
@@ -7,6 +7,9 @@
         = f.text_field :name
 
       = f.fields_for :manifest do |manifest_form|
+        - # FIXME: This is just to surpress the error message showing up in the
+        - # form (via `form_errors`).
+        - f.field_errors :"manifest.definition"
         = manifest_form.form_field :definition do
           - if !@device_model.new_record? && @device_model.manifest.definition
             .file-uploaded

--- a/app/views/device_models/_form.haml
+++ b/app/views/device_models/_form.haml
@@ -1,90 +1,59 @@
-= validation_errors @device_model
-
-= form_for(@device_model, html: { multipart: true }) do |f|
+= cdx_form_for(@device_model, html: { multipart: true }) do |f|
   .row
     .col
-      .row
-        .col.pe-4
-          = f.label :institution
-        .col
-          .value= f.object.institution
+      = f.form_field :institution, value: f.object.institution
 
-      .row
-        .col.pe-4
-          = f.label :name
-        .col
-          = f.text_field :name
-
-
+      = f.form_field :name do
+        = f.text_field :name
 
       = f.fields_for :manifest do |manifest_form|
-        .row
-          .col.pe-4
-            = manifest_form.label :definition
-          .col
-            - if !@device_model.new_record? && @device_model.manifest.definition
-              .file-uploaded
-                %label.input.on
-                  = link_to @device_model.manifest.filename, manifest_device_model_path(@device_model)
-                  %a.clear-label{:href => "#"}
-                    = image_tag "ic-cross.png"
-            .upload-new-file
-              = manifest_form.file_field :definition, :class => "inputfile"
-              %label{:for => 'device_model_manifest_attributes_definition'}
-                %span
-                  .icon-upload.icon-blue
-                  Choose a file to upload
-                %a.clear-input{:href => "#"}
-                  = image_tag "ic-cross.png"
-
-      .row
-        .col.pe-4
-          = f.label :setup_instructions
-        .col
-          - if !@device_model.new_record? && @device_model.setup_instructions.present?
+        = manifest_form.form_field :definition do
+          - if !@device_model.new_record? && @device_model.manifest.definition
             .file-uploaded
               %label.input.on
-                = link_to "download", @device_model.setup_instructions.url
-                .clear-label
-                  = f.check_box :delete_setup_instructions
-                  %label.cross{:for => 'device_model_delete_setup_instructions'}
-                    = image_tag "ic-cross.png"
+                = link_to @device_model.manifest.filename, manifest_device_model_path(@device_model)
+                %a.clear-label{:href => "#"}
+                  = image_tag "ic-cross.png"
           .upload-new-file
-            = f.file_field :setup_instructions, :class => "inputfile", 'data-remove-checkbox' => '#device_model_delete_setup_instructions'
-            %label{:for => 'device_model_setup_instructions'}
+            = manifest_form.file_field :definition, :class => "inputfile"
+            %label{:for => 'device_model_manifest_attributes_definition'}
               %span
                 .icon-upload.icon-blue
                 Choose a file to upload
               %a.clear-input{:href => "#"}
                 = image_tag "ic-cross.png"
-          .text-small.muted Only PDF files below 5MB are allowed
+
+      = f.form_field :setup_instructions do
+        - if !@device_model.new_record? && @device_model.setup_instructions.present?
+          .file-uploaded
+            %label.input.on
+              = link_to "download", @device_model.setup_instructions.url
+              .clear-label
+                = f.check_box :delete_setup_instructions
+                %label.cross{:for => 'device_model_delete_setup_instructions'}
+                  = image_tag "ic-cross.png"
+        .upload-new-file
+          = f.file_field :setup_instructions, :class => "inputfile", 'data-remove-checkbox' => '#device_model_delete_setup_instructions'
+          %label{:for => 'device_model_setup_instructions'}
+            %span
+              .icon-upload.icon-blue
+              Choose a file to upload
+            %a.clear-input{:href => "#"}
+              = image_tag "ic-cross.png"
+        .text-small.muted Only PDF files below 5MB are allowed
 
 
-      .row
-        .col.pe-4
-          = f.label :supports_activation
-        .col
-          = f.check_box :supports_activation
-          = f.label :supports_activation, "&nbsp;".html_safe
+      = f.form_field :supports_activation do
+        = f.check_box :supports_activation
 
-      .row
-        .col.pe-4
-          = f.label :support_url
-        .col
-          = f.text_field :support_url
+      = f.form_field :support_url do
+        = f.text_field :support_url
 
-      .row
-        .col.pe-4
-          = f.label :supports_ftp
-        .col
-          = f.check_box :supports_ftp
-          = f.label :supports_ftp, "&nbsp;".html_safe
+      = f.form_field :supports_ftp do
+        = f.check_box :supports_ftp
 
-      .row.device-model-filename-pattern
-        .col.pe-4
-          = f.label :filename_pattern
-        .col
-          = f.text_field :filename_pattern
+      = f.form_field :filename_pattern do
+        = f.text_field :filename_pattern
 
     .col
       .choose-picture
@@ -104,13 +73,12 @@
           %img{:src => ""}
           = f.file_field :picture, :class => "upload-picture", 'data-remove-checkbox' => '#device_model_delete_picture'
 
-  .row.button-actions
-    .col
-      %hr
-      = f.submit class: 'btn-primary', value: "Save"
-      = link_to 'Cancel', device_models_path, class: 'btn-link'
-      - if can_delete_device_model?(@device_model)
-        = link_to "Delete", @device_model, method: :delete, data: { confirm: 'Are you sure you want to delete this device model? All devices using this device model will be deleted as well, along with any tests they may have uploaded.' }, class: 'btn-danger pull-right'
+  = f.form_actions do
+    %hr
+    = f.submit class: 'btn-primary', value: "Save"
+    = link_to 'Cancel', device_models_path, class: 'btn-link'
+    - if can_delete_device_model?(@device_model)
+      = link_to "Delete", @device_model, method: :delete, data: { confirm: 'Are you sure you want to delete this device model? All devices using this device model will be deleted as well, along with any tests they may have uploaded.' }, class: 'btn-danger pull-right'
   %br
   .box.light
     = render 'publish'

--- a/app/views/devices/_form.haml
+++ b/app/views/devices/_form.haml
@@ -1,51 +1,30 @@
-= form_for(@device) do |f|
-  = validation_errors @device
+= cdx_form_for(@device) do |f|
+  = f.form_field :institution, value: @navigation_context.institution.name
 
-  .row.form-field
-    .col.pe-2
-      = f.label :institution
-    .col
-      .value= @navigation_context.institution.name
-
-  .row.form-field
-    .col.pe-2
-      = f.label :device_model_id
-    .col
-      = cdx_select form: f, name: :device_model_id, class: 'input-x-large' do |select|
-        - select.items(@device_models, :id, :full_name)
+  = f.form_field :device_model do
+    = cdx_select form: f, name: :device_model_id, class: 'input-x-large' do |select|
+      - select.items(@device_models, :id, :full_name)
 
   - if @allow_to_pick_site
-    .row.form-field
-      .col.pe-2
-        = f.label :site
-      .col
-        = cdx_select form: f, name: :site_id, class: 'input-x-large' do |select|
-          - select.item "", "None"
-          - select.items(@sites, :id, :name)
+    = f.form_field :site do
+      = cdx_select form: f, name: :site_id, class: 'input-x-large' do |select|
+        - select.item "", "None"
+        - select.items(@sites, :id, :name)
   - elsif f.object.new_record?
     = f.hidden_field :site_id
   - else # once created is better to show site name, otherwise user might have read access to many site's device, and we should avoid not showing site name in that scenario
-    .row.form-field
-      .col.pe-2
-        = f.label :site
-      .col
-        .value= f.object.site.name
-  .row.form-field
-    .col.pe-2
-      = f.label :name
-    .col
-      = f.text_field :name
-  .row.form-field
-    .col.pe-2
-      = f.label :serial_number
-    .col
-      = f.text_field :serial_number
-  .row.form-field
-    .col.pe-2
-      = f.label :time_zone
-    .col
-      = cdx_select form: f, name: :time_zone, class: 'input-x-large' do |select|
-        - select.items(ActiveSupport::TimeZone.all, :name, :to_s)
+    = f.form_field :site, value: f.object.site.name
+
+  = f.form_field :name do
+    = f.text_field :name
+
+  = f.form_field :serial_number do
+    = f.text_field :serial_number
+
+  = f.form_field :time_zone do
+    = cdx_select form: f, name: :time_zone, class: 'input-x-large' do |select|
+      - select.items(ActiveSupport::TimeZone.all, :name, :to_s)
+
   - if @device.new_record? || @device.device_model.try(:supports_ftp)
     .device-ftp-config{class: ('nodisplay' unless @device.device_model.try(:supports_ftp))}
       .row.form-field
@@ -58,18 +37,19 @@
           = f.check_box :ftp_passive
           = f.label :ftp_passive, "&nbsp;".html_safe
         .col.pe-2= f.text_field :ftp_directory, placeholder: 'Folder'
+
       .row.form-field
         .col.pe-2= f.label :ftp_username, 'Login'
         .col.pe-2= f.text_field :ftp_username, placeholder: 'Username', autocomplete: 'off'
         .col.pe-2= f.password_field :ftp_password, value: @device.ftp_password, placeholder: 'Password', autocomplete: 'off'
+
   #custom_mappings
     = render "custom_mappings" if @device.device_model
 
-  .row.button-actions
-    .col
-      = f.submit 'Save', class: 'btn-primary'
-      - if @can_delete
-        = link_to "Delete", @device, method: :delete, data: { confirm: "You are about to permanently delete this site. This action CANNOT be undone. Are you sure you want to proceed?" }, class: 'btn-secondary pull-right'
+  = f.form_actions do
+    = f.submit 'Save', class: 'btn-primary'
+    - if @can_delete
+      = link_to "Delete", @device, method: :delete, data: { confirm: "You are about to permanently delete this site. This action CANNOT be undone. Are you sure you want to proceed?" }, class: 'btn-secondary pull-right'
 
 :coffeescript
   $ ->

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,10 +1,11 @@
 .row
   .col
     %h1 Resend confirmation instructions
-= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+= cdx_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
   .row
     .col
       = f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "input-block"
+      = f.field_errors :email
   %br
   .row
     .col
@@ -13,4 +14,3 @@
     .col
       %br
       = link_to "Have an account? Log in", new_session_path(resource_name), class: "pull-right"
-= devise_error_messages!

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -2,17 +2,16 @@
   .col
     %h1 Password reset
     %p Choose a strong password and don't reuse it for other accounts.
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+= cdx_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
   = f.hidden_field :reset_password_token
   .row
     .col
       = f.password_field :password, autofocus: true, autocomplete: "off", placeholder: 'Password', class: "input-block"
       - if @minimum_password_length
-        .small-quote
+        .form_field-hint
           (#{@minimum_password_length} characters minimum)
+      = f.field_errors :password
   %br
   .row
     .col
       = f.submit "Reset my password", class: "btn-secondary input-block"
-
-= devise_error_messages!

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -2,10 +2,11 @@
   .col
     %h1 Login problems?
     %p Enter your email and we'll send you a link to reset your password
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+= cdx_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
   .row
     .col
       = f.email_field :email, autofocus: true, placeholder: 'Email', class: "input-block"
+      = f.field_errors :email
   %br
   .row
     .col
@@ -17,4 +18,3 @@
       = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "pull-right"
       %br
       = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "pull-right"
-= devise_error_messages!

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,59 +2,37 @@
   .col
     %h1 My Account
 
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = validation_errors resource
+= cdx_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = f.form_field :first_name do
+    = f.text_field :first_name, autofocus: true
 
-  .row
-    .col.pe-2
-      = f.label :first_name
-    .col
-      = f.text_field :first_name, autofocus: true
-  .row
-    .col.pe-2
-      = f.label :last_name
-    .col
-      = f.text_field :last_name
-  .row
-    .col.pe-2
-      = f.label :email
-    .col
-      = f.text_field :email, readonly: true
-  .row
-    .col.pe-2
-      = f.label :telephone
-    .col
-      = f.text_field :telephone
-  .row
-    .col.pe-2
-      = f.label :password, "New password"
-    .col
-      = f.password_field :password, autocomplete: "off"
-  .row
-    .col.pe-2
-      = f.label :password_confirmation, "Retype new password"
-    .col
-      = f.password_field :password_confirmation
-  .row
-    .col.pe-2
-      = f.label :locale
-    .col
-      = cdx_select form: f, name: :locale, class: 'input-xx-large' do |select|
-        - select.items(@locales, :second, :first)
-  .row
-    .col.pe-2
-      = f.label :time_zone
-    .col
-      = cdx_select form: f, name: :time_zone, class: 'input-xx-large' do |select|
-        - select.items(ActiveSupport::TimeZone.all, :name, :to_s)
-  .row
-    .col.pe-2
-      = f.label :timestamps_in_device_time_zone, "Test timestamps"
-    .col
-      = cdx_select form: f, name: :timestamps_in_device_time_zone, class: 'input-xx-large' do |select|
-        - select.item false, "Relative to my time zone"
-        - select.item true, "Relative to the device time zone"
+  = f.form_field :last_name do
+    = f.text_field :last_name
 
-  .row.button-actions
-    .col
-      = f.submit 'Save', class: 'btn-primary'
+  = f.form_field :email do
+    = f.text_field :email, readonly: true
+
+  = f.form_field :telephone do
+    = f.text_field :telephone
+
+  = f.form_field :password, label: { text: "New password" } do
+    = f.password_field :password, autocomplete: "off"
+
+  = f.form_field :password_confirmation, label: { text: "Retype new password" } do
+    = f.password_field :password_confirmation
+
+  = f.form_field :locale do
+    = cdx_select form: f, name: :locale, class: 'input-xx-large' do |select|
+      - select.items(@locales, :second, :first)
+
+  = f.form_field :time_zone do
+    = cdx_select form: f, name: :time_zone, class: 'input-xx-large' do |select|
+      - select.items(ActiveSupport::TimeZone.all, :name, :to_s)
+
+  = f.form_field :timestamps_in_device_time_zone, label: { text: "Test timestamps" } do
+    = cdx_select form: f, name: :timestamps_in_device_time_zone, class: 'input-xx-large' do |select|
+      - select.item false, "Relative to my time zone"
+      - select.item true, "Relative to the device time zone"
+
+  = f.form_actions do
+    = f.submit 'Save', class: 'btn-primary'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,22 +1,30 @@
 .row
   .col
     %h1 Sign up
-= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+= cdx_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   .row
     .col
       = f.text_field :first_name, autofocus: true, placeholder: 'First name', class: 'input-block'
+      = f.field_errors :first_name
   .row
     .col
       = f.text_field :last_name, placeholder: 'Last name', class: 'input-block'
+      = f.field_errors :last_name
   .row
     .col
       = f.email_field :email, placeholder: 'Email', class: "input-block"
+      = f.field_errors :email
   .row
     .col
       = f.password_field :password, autocomplete: "off", placeholder: 'Password', class: "input-block"
       - if @minimum_password_length
-        .small-quote.pull-right
+        .form_field-hint
           (#{@minimum_password_length} characters minimum)
+      = f.field_errors :password
+  .row
+    .col
+      = f.password_field :password_confirmation, autocomplete: "off", placeholder: 'Password Confirmation', class: "input-block"
+      = f.field_errors :password_confirmation
   %br
   .row
     .col
@@ -25,4 +33,3 @@
       = link_to "Have an account? Log in", new_session_path(resource_name)
       %br
       = link_to "Login problems?", new_password_path(resource_name)
-= devise_error_messages!

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,13 +1,15 @@
 .row
   .col
     %h1 Login
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+= cdx_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   .row
     .col
       = f.email_field :email, autofocus: true, placeholder: 'Email', class: "input-block"
+      = f.field_errors :email
   .row
     .col
       = f.password_field :password, autocomplete: "off", placeholder: 'Password', class: "input-block"
+      = f.field_errors :password
   %br
   .row
     .col

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,12 +1,12 @@
 .row
   .col
     %h1 Resend unlock instructions
-= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+= cdx_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
   .row
     .col
       = f.email_field :email, autofocus: true, placeholder: 'Email', class: "input-block"
+      = f.field_errors :unconfirmed_email
   %br
   .row
     .col
       = f.submit "Resend unlock instructions", class: "btn-secondary input-block"
-= devise_error_messages!

--- a/app/views/filters/_form.haml
+++ b/app/views/filters/_form.haml
@@ -1,33 +1,19 @@
-= form_for(filter) do |f|
-  - if filter.errors.any?
-    #error_explanation
-      %p= "#{pluralize(filter.errors.count, "error")} prohibited this filter from being saved:"
-      %ul
-        - filter.errors.full_messages.each do |msg|
-          %li= msg
-
+= cdx_form_for(filter) do |f|
   = f.fields_for(:query) do |p|
     - filter.query.each do |key, value|
       = p.hidden_field key, value: value
 
-  .row
-    .col.pe-2
-      %label Site
-    .col
-      #{site.try(:name)}
-  .row
-    .col.pe-2
-      %label Condition
-    .col
-      #{condition}
-  .row
-    .col.pe-2
-      = f.label :name, :class => 'block'
-    .col
-      = f.text_field :name
-  .row.button-actions
-    .col
-      = f.submit class: "btn-primary"
-      = link_to 'Cancel', filters_path, class: 'btn-link'
-      - if @editing
-        = confirm_deletion_button filter, 'filter'
+  = f.form_field :site do
+    = site.try(:name)
+
+  = f.form_field :condition do
+    = condition
+
+  = f.form_field :name
+    = f.text_field :name
+
+  = f.form_actions do
+    = f.submit class: "btn-primary"
+    = link_to 'Cancel', filters_path, class: 'btn-link'
+    - if @editing
+      = confirm_deletion_button filter, 'filter'

--- a/app/views/patients/_form.html.haml
+++ b/app/views/patients/_form.html.haml
@@ -1,58 +1,33 @@
-= form_for(@patient) do |f|
+= cdx_form_for(@patient) do |f|
   - unless params[:next_url].blank?
     = hidden_field_tag :next_url, params[:next_url]
 
-  = validation_errors @patient
+  = f.form_field :institution, value: f.object.institution
 
-  .row.form-field
-    .col.pe-2
-      = f.label :institution
-    .col
-      .value= f.object.institution
+  = f.form_field :name do
+    = f.text_field :name, :class => 'input-large'
 
-  .row.form-field
-    .col.pe-2
-      = f.label :name
-    .col
-      = f.text_field :name, :class => 'input-large'
+  = f.form_field :entity_id do
+    = f.text_field :entity_id, :class => 'input-large'
 
-  .row.form-field
-    .col.pe-2
-      = f.label :entity_id
-    .col
-      = f.text_field :entity_id, :class => 'input-large'
+  = f.form_field :gender do
+    = cdx_select form: f, name: :gender do |select|
+      - select.items PatientForm::GENDER_VALUES
 
-  .row.form-field
-    .col.pe-2
-      = f.label :gender
-    .col
-      = cdx_select form: f, name: :gender do |select|
-        - select.items PatientForm::GENDER_VALUES
-
-  .row.form-field
-    .col.pe-2
-      = f.label :dob
-    .col
-      = f.text_field :dob, placeholder: @patient.dob_placeholder
+  = f.form_field :dob do
+    = f.text_field :dob, placeholder: @patient.dob_placeholder
 
   = patient_address_component(@patient)
 
-  .row.form-field
-    .col.pe-2
-      = f.label :email
-    .col
-      = f.text_field :email, :class => 'input-large'
+  = f.form_field :email do
+    = f.text_field :email, :class => 'input-large'
 
-  .row.form-field
-    .col.pe-2
-      = f.label :phone
-    .col
-      = f.text_field :phone, :class => 'input-large'
+  = f.form_field :phone do
+    = f.text_field :phone, :class => 'input-large'
 
-  .row.button-actions
-    .col
-      = f.submit 'Save', class: 'btn-primary'
-      = link_to 'Cancel', patients_path, class: 'btn-link'
+  = f.form_actions do
+    = f.submit 'Save', class: 'btn-primary'
+    = link_to 'Cancel', patients_path, class: 'btn-link'
 
-      - if @can_delete
-        = confirm_deletion_button @patient, 'patient'
+    - if @can_delete
+      = confirm_deletion_button @patient, 'patient'

--- a/app/views/policies/_form.html.haml
+++ b/app/views/policies/_form.html.haml
@@ -1,31 +1,15 @@
-= form_for @policy do |f|
-  - if @policy.errors.any?
-    #error_explanation
-      %p= "#{pluralize(@policy.errors.count, "error")} prohibited this policy from being saved:"
-      %ul
-        - @policy.errors.full_messages.each do |msg|
-          %li= msg
+= cdx_form_for @policy do |f|
+  = f.form_field :name do
+    = f.text_field :name
 
-  .row.form-field
-    .col.pe-2
-      = f.label :name
-    .col
-      = f.text_field :name
-  .row.form-field
-    .col.pe-2
-      = f.label :user_id
-    .col
-      = f.text_field :user_id
+  = f.form_field :user_id do
+    = f.text_field :user_id
 
-  .row
-    .col.pe-2
-      = f.label :definition
-    .col.pe-3
-      .value
-        = f.text_area :definition, :rows => 5, :class => 'input-block'
-  .row.button-actions
-    .col
-      = f.submit 'Save', :class => 'btn-primary'
-      = link_to 'Cancel', policies_path, class: 'btn-link'
-      - if @editing
-        = confirm_deletion_button @policy, 'policy'
+  = f.form_field :definition do
+    = f.text_area :definition, :rows => 5, :class => 'input-block'
+
+  = f.form_actions do
+    = f.submit 'Save', :class => 'btn-primary'
+    = link_to 'Cancel', policies_path, class: 'btn-link'
+    - if @editing
+      = confirm_deletion_button @policy, 'policy'

--- a/app/views/qc_infos/_form.haml
+++ b/app/views/qc_infos/_form.haml
@@ -1,61 +1,33 @@
-= form_for(@qc_info) do |f|
+= cdx_form_for(@qc_info) do |f|
+  = f.form_field :uuid, value: f.object.uuid
 
-  = validation_errors @qc_info
+  = f.form_field :batch_id, value: f.object.batch_number
+
+  = f.form_field :date_produced do
+    = f.text_field :formatted_date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
+
+  = f.form_field :lab_technician do
+    = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
+
+  = f.form_field :specimen_role do
+    = text_field_tag :specimen_role, Sample.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
+
+  = f.form_field :isolate_name do
+    = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
+
+  = f.form_field :inactivation_method do
+    = f.text_field :inactivation_method, readonly: true
+
+  = f.form_field :volume do
+    .row.input-unit
+      = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
+      .span.unit (μl)
 
   .row
     .col
-      .row
-        .col.pe-4
-          = f.label :uuid
-        .col
-          .value= f.object.uuid
-      .row
-        .col.pe-4
-          = f.label :batch_id
-        .col
-          .value= f.object.batch_number
+      = render 'show_assays', f: f
 
-      .row
-        .col.pe-4
-          = f.label :date_produced
-        .col
-          = f.date_field :date_produced, readonly: !@can_update
-
-      .row
-        .col.pe-4
-          = f.label :lab_technician
-        .col
-          = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update
-
-      .row
-        .col.pe-4
-          = f.label :specimen_role
-        .col
-          = text_field_tag :specimen_role, Sample.specimen_role_description(f.object.specimen_role), { :class => 'input-x-large', readonly: true }
-      .row
-        .col.pe-4
-          = f.label :isolate_name
-        .col
-          = f.text_field :isolate_name, :class => 'input-x-large', readonly: !@can_update
-
-      .row
-        .col.pe-4
-          = f.label :inactivation_method
-        .col
-          = f.text_field :inactivation_method, readonly: true
-
-      .row
-        .col.pe-4
-          = f.label :volume
-        .col
-          .row.input-unit
-            = f.number_field :volume, min: 0, step: :any, :class => "input-small", readonly: !@can_update
-            .span.unit (μl)
-
-
-  .col
-    = render 'show_assays', f: f
-
-  .col
-    = render 'show_notes', f: f
+  .row
+    .col
+      = render 'show_notes', f: f
 

--- a/app/views/qc_infos/_show_assays.haml
+++ b/app/views/qc_infos/_show_assays.haml
@@ -1,37 +1,34 @@
-.row
-  .col.pe-2
-    = f.label :assays
-  .col
-    .choose-picture.assay
-      .upload-new-file.picture
-        = f.fields_for :assay_attachments do |ay|
-          .file-uploaded
-            .card-container
-              .info
-                .row
-                  .col.pe-1
-                    = ay.label :loinc_code, 'LOINC'
-                  .col.pe-8
-                    .loinc_inputs
-                      = text_field_tag :loinc_code_component, loinc_code_description(ay.object.loinc_code), { class: 'loinc_input', readonly: true }
-                .row
-                  .col.pe-1
-                    = ay.label :result
-                  .col.pe-8
-                    = ay.text_field :result, readonly: true
+= f.form_field :assays do
+  .choose-picture.assay
+    .upload-new-file.picture
+      = f.fields_for :assay_attachments do |ay|
+        .file-uploaded
+          .card-container
+            .info
+              .row
+                .col.pe-1
+                  = ay.label :loinc_code, 'LOINC'
+                .col.pe-8
+                  .loinc_inputs
+                    = text_field_tag :loinc_code_component, loinc_code_description(ay.object.loinc_code), { class: 'loinc_input', readonly: true }
+              .row
+                .col.pe-1
+                  = ay.label :result
+                .col.pe-8
+                  = ay.text_field :result, readonly: true
 
-              - if ay.object.assay_file.nil?
-                .file.is-hidden
-                  .picture-container.assay-file
+            - if ay.object.assay_file.nil?
+              .file.is-hidden
+                .picture-container.assay-file
+                  .any-filetype
+                    .icon-document
+            - else
+              .file
+                .picture-container.assay-file
+                  - if ay.object.assay_file.is_image?
+                    = image_tag ay.object.assay_file.picture.url(:card)
+                  - else
                     .any-filetype
                       .icon-document
-              - else
-                .file
-                  .picture-container.assay-file
-                    - if ay.object.assay_file.is_image?
-                      = image_tag ay.object.assay_file.picture.url(:card)
-                    - else
-                      .any-filetype
-                        .icon-document
-                    .picture-title{ title: ay.object.assay_file.picture_file_name }
-                      = link_to ay.object.assay_file.picture_file_name, ay.object.assay_file.picture.url, target: "_blank", download: ay.object.assay_file.picture_file_name
+                  .picture-title{ title: ay.object.assay_file.picture_file_name }
+                    = link_to ay.object.assay_file.picture_file_name, ay.object.assay_file.picture.url, target: "_blank", download: ay.object.assay_file.picture_file_name

--- a/app/views/qc_infos/_show_notes.haml
+++ b/app/views/qc_infos/_show_notes.haml
@@ -1,7 +1,5 @@
-.row
-  .col.pe-2
-    = f.label :notes
-  #notes.col
+= f.form_field :notes do
+  #notes
     = f.fields_for :notes do |note|
       .note
         .info

--- a/app/views/roles/_form.html.haml
+++ b/app/views/roles/_form.html.haml
@@ -1,38 +1,18 @@
-= form_for @role do |f|
-  - if @role.errors.any?
-    #error_explanation
-      %p= "#{pluralize(@role.errors.count, "error")} prohibited this role from being saved:"
-      %ul
-        - @role.errors.full_messages.each do |msg|
-          %li= msg
-
-  .row.form-field
-    .col.pe-2
-      = f.label :name
-    .col
-      = f.text_field :name
+= cdx_form_for @role do |f|
+  = f.form_field :name do
+    = f.text_field :name
 
   - if @accessible_institutions != 1
-    .row.form-field
-      .col.pe-2
-        = f.label :institution_id
-      .col
-        .value= @institution
+    = f.form_field :institution_id, value: @institution
 
   - if @role.new_record?
-    .row.form-field
-      .col.pe-2
-        = f.label :site_id
-      .col
-        = cdx_select form: f, name: :site_id, class: 'input-x-large' do |select|
-          - select.item "", "Choose one"
-          - select.items @sites, :id, :name
+    = f.form_field :site_id do
+      = cdx_select form: f, name: :site_id, class: 'input-x-large' do |select|
+        - select.item "", "Choose one"
+        - select.items @sites, :id, :name
+
   - elsif @role.site_id
-    .row.form-field
-      .col.pe-2
-        = f.label :site_id
-      .col
-        .value= @role.site.try(:name)
+    = f.form_field :site_id, value: @role.site.try(:name)
   %br
   %br
   %hr
@@ -42,11 +22,12 @@
       %h1 Policies
       %p.text-small.muted
         %i Policies grant users permisions over specific resources
+      = f.field_errors :policy
   = react_component 'PolicyDefinition', definition: @role.definition, actions: actions_per_resource_type, context: params['context'], resources: @policy_definition_resources, resourceTypes: resource_types
-  .row.button-actions
-    .col
-      = f.submit 'Save', :class => 'btn-primary'
-      = link_to 'Cancel', roles_path, class: 'btn-link'
-      - if @can_delete
-        - unless @role.new_record?
-          = confirm_deletion_button @role, 'role'
+
+  = f.form_actions do
+    = f.submit 'Save', :class => 'btn-primary'
+    = link_to 'Cancel', roles_path, class: 'btn-link'
+    - if @can_delete
+      - unless @role.new_record?
+        = confirm_deletion_button @role, 'role'

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -1,31 +1,17 @@
-= form_for(@site) do |f|
-  = validation_errors @site
+= cdx_form_for(@site) do |f|
+  = f.form_field :institution, value: f.object.institution
 
-  .row.form-field
-    .col.pe-2
-      = f.label :institution
-    .col
-      .value= f.object.institution
+  = f.form_field :name do
+    = f.text_field :name, :class => 'input-large'
 
-  .row.form-field
-    .col.pe-2
-      = f.label :name
-    .col
-      = f.text_field :name, :class => 'input-large'
   - if @site.new_record? || @can_move
-    .row.form-field
-      .col.pe-2
-        = f.label :parent
-      .col
-        = cdx_select form: f, name: :parent_id, class: 'input-x-large' do |select|
-          - select.item "", "None"
-          - select.items @sites, :id, :name
+    = f.form_field :parent do
+      = cdx_select form: f, name: :parent_id, class: 'input-x-large' do |select|
+        - select.item "", "None"
+        - select.items @sites, :id, :name
   - elsif @site.parent
-    .row
-      .col.pe-4
-        = f.label :parent
-      .col
-        = @site.parent.name
+    = f.form_field :parent do
+      = @site.parent.name
 
     .col.pe-4
       - unless @site.new_record?
@@ -33,38 +19,28 @@
 
   = site_address_component(@site)
 
-  .row.form-field
-    .col.pe-2
-      = f.label :sample_id_reset_policy
-    .col
-      = cdx_select form: f, name: :sample_id_reset_policy, class: 'input-large' do |select|
-        - select.item "yearly", "Yearly"
-        - select.item "monthly", "Monthly"
-        - select.item "weekly", "Weekly"
-  .row.form-field
-    .col.pe-2
-      = f.label :allows_manual_entry
-    .col
-      = f.check_box :allows_manual_entry
-      %label{for: 'site_allows_manual_entry'} &nbsp;
-  .row.form-field
-    .col.pe-2
-      = f.label :main_phone_number
-    .col
-      = f.text_field :main_phone_number, :class => 'input-large'
-  .row.form-field
-    .col.pe-2
-      = f.label :email_address
-    .col
-      = f.email_field :email_address, :class => 'input-large'
+  = f.form_field :sample_id_reset_policy do
+    = cdx_select form: f, name: :sample_id_reset_policy, class: 'input-large' do |select|
+      - select.item "yearly", "Yearly"
+      - select.item "monthly", "Monthly"
+      - select.item "weekly", "Weekly"
 
-  .row.button-actions
-    .col
-      = f.submit 'Save', class: 'btn-primary'
-      = link_to 'Cancel', sites_path, class: 'btn-link'
-      - if @can_delete
-        - if @can_be_deleted
-          = confirm_deletion_button @site, 'site'
-        - else
-          - # TODO: link to page with Devices tab always active - it's the current default, but may change
-          = link_to "Delete", '#', data: { confirm: "In order to delete this site you must first reassign the <a href=\"#{edit_site_path(@site)}\">#{@site.devices.count} #{"device".pluralize(@site.devices.count)}</a> assigned to it.", confirm_title: 'Action required', confirm_hide_cancel: 'true', confirm_button_message: 'Understood' }, class: 'btn-secondary pull-right', title: 'Delete Site'
+  = f.form_field :allows_manual_entry do
+    = f.check_box :allows_manual_entry
+    %label{for: 'site_allows_manual_entry'} &nbsp;
+
+  = f.form_field :main_phone_number do
+    = f.text_field :main_phone_number, :class => 'input-large'
+
+  = f.form_field :email_address do
+    = f.email_field :email_address, :class => 'input-large'
+
+  = f.form_actions do
+    = f.submit 'Save', class: 'btn-primary'
+    = link_to 'Cancel', sites_path, class: 'btn-link'
+    - if @can_delete
+      - if @can_be_deleted
+        = confirm_deletion_button @site, 'site'
+      - else
+        - # TODO: link to page with Devices tab always active - it's the current default, but may change
+        = link_to "Delete", '#', data: { confirm: "In order to delete this site you must first reassign the <a href=\"#{edit_site_path(@site)}\">#{@site.devices.count} #{"device".pluralize(@site.devices.count)}</a> assigned to it.", confirm_title: 'Action required', confirm_hide_cancel: 'true', confirm_button_message: 'Understood' }, class: 'btn-secondary pull-right', title: 'Delete Site'

--- a/app/views/sites/_show.html.haml
+++ b/app/views/sites/_show.html.haml
@@ -19,15 +19,11 @@
         .col
           .value= @site.parent.name
     - elsif @can_edit_parent
-      = form_for(@site) do |f|
-        = validation_errors @site
-        .row
-          .col.pe-4
-            = label_tag :parent
-          .col
-            = cdx_select form: f, name: :parent_id, class: 'input-x-large' do |select|
-              - select.item "", "None"
-              - select.items @sites, :id, :name
+      = cdx_form_for(@site) do |f|
+        = f.form_field :parent do
+          = cdx_select form: f, name: :parent_id, class: 'input-x-large' do |select|
+            - select.item "", "None"
+            - select.items @sites, :id, :name
   .col
     = render 'side'
 

--- a/app/views/subscribers/_form.html.haml
+++ b/app/views/subscribers/_form.html.haml
@@ -1,56 +1,34 @@
-= form_for(subscriber) do |f|
-  - if subscriber.errors.any?
-    #error_explanation
-      %p= "#{pluralize(subscriber.errors.count, "error")} prohibited this subscriber from being saved:"
-      %ul
-        - subscriber.errors.full_messages.each do |msg|
-          %li= msg
+= cdx_form_for(subscriber) do |f|
+  = f.form_field :filter do
+    = cdx_select form: f, name: :filter_id do |select|
+      - select.items filters, :id, :name
 
-  .row
-    .col.pe-2
-      = f.label :filter
-    .col
-      = cdx_select form: f, name: :filter_id do |select|
-        - select.items filters, :id, :name
-  .row
-    .col.pe-2
-      = f.label :name
-    .col
-      = f.text_field :name
-  .row
-    .col.pe-2
-      = f.label :url
-    .col
-      = f.text_field :url
-  .row
-    .col.pe-2
-      = f.label :verb
-    .col
-      .value.annotation GET will send fields in query string. POST will send a JSON object in the request body.
-      = cdx_select form: f, name: :verb do |select|
-        - select.items Subscriber::VALID_VERBS
-  .row
-    .col.pe-2
-      = f.label :url_user, "User (optional)"
-    .col
-      = f.text_field :url_user
-  .row
-    .col.pe-2
-      = f.label :url_password, "Password (optional)"
-    .col
-      = f.password_field :url_password
-  .row
-    .col.pe-2
-      = f.label :fields
-    .col
-      .value.annotation Empty selection will send all fields
-      - Subscriber.available_field_names.sort.each do |field|
-        = check_box_tag "fields[#{field}]", true, subscriber.fields.try {|f| f.include?(field)}, id: "fields.#{field}"
-        %label{for: "fields.#{field}"}
-          = field
-  .row.button-actions
-    .col
-      = f.submit nil, class: "btn-primary"
-      = link_to 'Cancel', subscribers_path, class: 'btn-link'
-      - if @editing
-        = confirm_deletion_button subscriber, 'subscriber'
+  = f.form_field :name do
+    = f.text_field :name
+
+  = f.form_field :url do
+    = f.text_field :url
+
+  = f.form_field :verb do
+    .value.annotation GET will send fields in query string. POST will send a JSON object in the request body.
+    = cdx_select form: f, name: :verb do |select|
+      - select.items Subscriber::VALID_VERBS
+
+  = f.form_field :url_user, label_opts: "User (optional)" do
+    = f.text_field :url_user
+
+  = f.form_field :url_password, label_opts: "Password (optional)" do
+    = f.password_field :url_password
+
+  = f.form_field :fields do
+    .value.annotation Empty selection will send all fields
+    - Subscriber.available_field_names.sort.each do |field|
+      = check_box_tag "fields[#{field}]", true, subscriber.fields.try {|f| f.include?(field)}, id: "fields.#{field}"
+      %label{for: "fields.#{field}"}
+        = field
+
+  = f.form_actions do
+    = f.submit nil, class: "btn-primary"
+    = link_to 'Cancel', subscribers_path, class: 'btn-link'
+    - if @editing
+      = confirm_deletion_button subscriber, 'subscriber'

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,44 +1,21 @@
-= form_for(@user) do |f|
+= cdx_form_for(@user) do |f|
   .row
     .col
-      .row
-        .col.pe-2
-          = f.label :name
-        .col
-          .value= f.object.full_name
-      .row
-        .col.pe-2
-          = f.label :email
-        .col
-          .value= f.object.email
-      .row
-        .col.pe-2
-          = f.label :telephone
-        .col
-          .value= f.object.telephone
-      .row
-        .col.pe-2
-          = f.label :roles
-        .col
-          .value
-            = react_component 'OptionList', chosenOnes: @user_roles, callback: "/users/#{@user.id}/assign_role", autocompleteCallback: "/roles/autocomplete"
+      = f.form_field :name, value: f.object.full_name
+      = f.form_field :email, value: f.object.email
+      = f.form_field :telephone, value: f.object.telephone
+
+      = f.form_field :roles do
+        = react_component 'OptionList', chosenOnes: @user_roles, callback: "/users/#{@user.id}/assign_role", autocompleteCallback: "/roles/autocomplete"
     .col
       .box.small.gray
         - if @can_update
-          .row
-            .col.pe-2
-              .value= f.label :is_active
-            .col
-              .value
-                = f.check_box :is_active, class: 'power'
-                %label{:for => 'user_is_active'} Can access Cdx?
-        .row
-          .col.pe-2
-            = f.label :last_sign_in_at
-          .col
-            .value= last_activity(f.object)
+          = f.form_field :is_active do
+            = f.check_box :is_active, class: 'power'
+            %label{:for => 'user_is_active'} Can access Cdx?
+        = f.form_field :last_sign_in_at, value: last_activity(f.object)
+
   - if @can_update
-    .row.button-actions
-      .col
-        = f.submit 'Save', class: 'btn-primary'
-        = link_to 'Cancel', users_path,  class: 'btn-link'
+    = f.form_actions do
+      = f.submit 'Save', class: 'btn-primary'
+      = link_to 'Cancel', users_path,  class: 'btn-link'

--- a/app/views/users/invitations/edit.html.haml
+++ b/app/views/users/invitations/edit.html.haml
@@ -1,21 +1,24 @@
 .row
   .col
     %h1= t 'devise.invitations.edit.header'
-= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put, id: 'accept-invitation' } do |f|
+= cdx_form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put, id: 'accept-invitation' } do |f|
   = f.hidden_field :invitation_token
   .row
     .col
       = f.text_field :first_name, autofocus: true, placeholder: 'First name', class: "input-large"
       = f.text_field :last_name, autofocus: true, placeholder: 'Last name', class: "input-large"
+      = f.field_errors :first_name
+      = f.field_errors :last_name
   .row
     .col
       = f.password_field :password, autofocus: true, placeholder: 'Password', class: "input-block"
+      = f.field_errors :password
   .row
     .col
       = f.password_field :password_confirmation, autofocus: true, placeholder: 'Password confirmation', class: "input-block"
+      = f.field_errors :password_confirmation
   %br
   .row
     .col
       = f.submit t("devise.invitations.edit.submit_button"), class: "btn-secondary input-block"
-= devise_error_messages!
 

--- a/spec/models/manifest_validations_spec.rb
+++ b/spec/models/manifest_validations_spec.rb
@@ -45,7 +45,7 @@ describe Manifest do
       m = Manifest.new(device_model: DeviceModel.make!, definition: definition)
       m.save
       expect(Manifest.count).to eq(0)
-      expect(m.errors[:parse_error]).not_to eq(nil)
+      expect(m.errors[:definition]).not_to eq(nil)
     end
 
     it "shouldn't pass validations if metadata is empty" do


### PR DESCRIPTION
Applies the form field helper introduced in https://github.com/instedd/cdx/pull/1662 to more forms. This should finally resolve #1065.
<del>There are a couple of forms left which didn't seem to be trivial to adapt. We'll have to look into those more carefully.</del>
<ins>I changed it for all forms.</ins>