### PR TITLE
Add `FormFieldBuilder#fields_for`

### DIFF
--- a/app/helpers/cdx_form_helper.rb
+++ b/app/helpers/cdx_form_helper.rb
@@ -80,7 +80,7 @@ class FormFieldBuilder < ActionView::Helpers::FormBuilder
   def fields_for(record_name, record_object = nil, fields_options = {}, &block)
     fields_options[:nested_errors_namespace] = prefixed_error_key(record_name)
 
-    super(record_name, record_object = nil, objectify_options(fields_options)) do |form|
+    super(record_name, record_object, objectify_options(fields_options)) do |form|
       form.errors_to_show = errors_to_show
       block.call(form)
 

--- a/app/views/form_builder/_field.haml
+++ b/app/views/form_builder/_field.haml
@@ -1,4 +1,4 @@
-.row.form-field{class: form.object.errors.has_key?(method) && "form-field--error" }
+.row.form-field{class: form.has_error?(method) && "form-field--error" }
   .col.form-field__label
     - label_options = options[:label] || {}
     = form.label method, label_options[:text], label_options


### PR DESCRIPTION
This adds handling for nested forms to the `FormFieldBuilder`. It needs to track the nested path of the current builder instance and access the error keys by full path.