### PR TITLE
Use `date_field` for `date_produced` form field

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -2,33 +2,11 @@
 // FORMS
 // =============================================================================
 
-input[type="text"][disabled] {
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: .4;
-}
-input[type="number"][disabled] {
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: .4;
-}
-
-input[type="text"][disabled] {
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: .4;
-}
-input[type="number"][disabled] {
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: .4;
-}
-
-
 input[type="text"],
 input[type="email"],
 input[type="password"],
-input[type="number"] {
+input[type="number"],
+input[type="date"] {
   @include placeholder-style(italic);
   background-color: transparent;
   font-family: $sans;
@@ -38,6 +16,12 @@ input[type="number"] {
   padding: 0 5px;
   height: 30px;
   outline: 0 !important;
+
+  &[disabled] {
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: .4;
+  }
 }
 
 textarea {

--- a/app/controllers/concerns/view_helper.rb
+++ b/app/controllers/concerns/view_helper.rb
@@ -7,7 +7,7 @@ module Concerns::ViewHelper
     end
     back_path = session[:back_path] || samples_path
 
-    { date_produced_placeholder: date_format[:placeholder], back_path: back_path }
+    { back_path: back_path }
   end
 
   private

--- a/app/models/concerns/date_produced.rb
+++ b/app/models/concerns/date_produced.rb
@@ -7,7 +7,7 @@ module DateProduced
 
   def date_produced_is_a_date
     return if date_produced.blank?
-    errors.add(:date_produced, "should be a date in #{self.class.date_produced_placeholder}") unless date_produced.is_a?(Time)
+    errors.add(:date_produced, :invalid) unless date_produced.is_a?(Time)
   end
 
   def date_produced_description
@@ -19,10 +19,6 @@ module DateProduced
   end
 
   class_methods do
-    def date_produced_placeholder
-      date_format[:placeholder]
-    end
-
     def date_format
       { pattern: I18n.t('date.input_format.pattern'), placeholder: I18n.t('date.input_format.placeholder') }
     end

--- a/app/models/qc_info.rb
+++ b/app/models/qc_info.rb
@@ -80,16 +80,4 @@ class QcInfo < ApplicationRecord
       qc_info.assay_attachments << new_assay_attachment
     end
   end
-
-  def formatted_date_produced
-    value = date_produced
-
-    if value.is_a?(Time)
-      return value.strftime(self.class.date_format[:pattern])
-    end
-
-    value
-  end
-
 end
-

--- a/app/views/batches/_form.haml
+++ b/app/views/batches/_form.haml
@@ -5,7 +5,7 @@
         = f.text_field :batch_number, readonly: !@can_update
 
       = f.form_field :date_produced do
-        = f.text_field :date_produced, placeholder: Batch.date_produced_placeholder, readonly: !@can_update
+        = f.date_field :date_produced, readonly: !@can_update
 
       = f.form_field :lab_technician do
         = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update

--- a/app/views/qc_infos/_form.haml
+++ b/app/views/qc_infos/_form.haml
@@ -19,7 +19,7 @@
         .col.pe-4
           = f.label :date_produced
         .col
-          = f.text_field :formatted_date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
+          = f.date_field :date_produced, readonly: !@can_update
 
       .row
         .col.pe-4

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -18,7 +18,7 @@
           = g.form_field :purpose, value: box.purpose, label: { text: "Box Purpose" }
 
       = f.form_field :date_produced do
-        = f.text_field :date_produced, placeholder: @view_helper[:date_produced_placeholder], readonly: !@can_update
+        = f.date_field :date_produced, readonly: !@can_update
 
       = f.form_field :lab_technician do
         = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update


### PR DESCRIPTION
Use a dedicated date input field for date value. This adds a useful widget for selecting the date.

![grafik](https://user-images.githubusercontent.com/466378/170483625-24652a7f-e7eb-4565-a001-dea612a4213c.png)

Note: The date format in the field is no longer defined by cdx. It's delegated to the browser's locale.

Ref: #840