### PR TITLE
Refactor `date_produced` to always cast to `Time` type

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -57,7 +57,7 @@ class Batch < ApplicationRecord
       institution: institution,
       site: site,
       sample_identifiers: [SampleIdentifier.new],
-      date_produced: self[:date_produced], # Time instead of String
+      date_produced: date_produced,
       lab_technician: lab_technician,
       specimen_role: specimen_role,
       isolate_name: isolate_name,

--- a/app/models/concerns/date_produced.rb
+++ b/app/models/concerns/date_produced.rb
@@ -1,21 +1,10 @@
 module DateProduced
   extend ActiveSupport::Concern
 
-  included do
-    validate :date_produced_is_a_date
-  end
-
-  def date_produced_is_a_date
-    return if date_produced.blank?
-    errors.add(:date_produced, :invalid) unless date_produced.is_a?(Time)
-  end
-
   def date_produced_description
-    if date_produced.is_a?(Time)
-      return date_produced.strftime(I18n.t('date.input_format.pattern'))
-    end
+    return unless date_produced
 
-    date_produced
+    date_produced.strftime(I18n.t('date.input_format.pattern'))
   end
 
   class_methods do


### PR DESCRIPTION
Casting `date_produced` to `Time` simplifies the code because we don't have to deal with discerning types (`String` vs `Time` vs `Nil` all the time).
This would be the behaviour for a column-backed field in ActiveRecord. The form models are not tied to the database and have no type information, thus it doesn't work out of the box and we need a custom `date_produced=` setter.  In Rails 6 we can use the Attributes API.