### PR TITLE
Add `TransferPackageController#show`

### DIFF
--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -256,7 +256,12 @@ a[title="Back"] {
   h2 {
     margin: 0.3em 0;
   }
+}
 
+.show {
+  background: $gray1;
+  margin: -10px -10px 0;
+  padding: 0 1em 0.5em;
 }
 
 #nav-context {

--- a/app/assets/stylesheets/_transfer_packages.scss
+++ b/app/assets/stylesheets/_transfer_packages.scss
@@ -1,0 +1,13 @@
+.dispatch-log {
+  margin: 0;
+  padding: 0;
+  width: max-content;
+
+  .log-entry {
+    padding: 0px 10px;
+
+    + .log-entry {
+      border-top: 1px solid $gray-light;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,5 +40,6 @@
 @import "user_institution_invites_modal";
 @import "sample_transfer_modal";
 @import "box_preview";
+@import "transfer_packages";
 @import "selector_list";
 @import "alert";

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -36,6 +36,17 @@ class TransferPackagesController < ApplicationController
       .map { |transfer| TransferPackagePresenter.new(transfer, @navigation_context) }
   end
 
+  def show
+    transfer_package = TransferPackage
+      .within(@navigation_context.institution)
+      .includes(:box_transfers, :boxes)
+      .find(params[:id])
+
+    @transfer_package = TransferPackagePresenter.new(transfer_package, @navigation_context)
+    @view_helper = view_helper({ save_back_path: true })
+    @can_update = false
+  end
+
   def new
     @view_helper = view_helper({ save_back_path: true })
     @can_update = true

--- a/app/presenters/transfer_package_presenter.rb
+++ b/app/presenters/transfer_package_presenter.rb
@@ -7,7 +7,7 @@ class TransferPackagePresenter
   end
 
   # TODO(Rails 5.1): Use delegate_missing
-  delegate :uuid, :recipient, :confirmed_at, :confirmed?, :created_at, :receiver_institution, :sender_institution, :sample_transfers, :samples, to: :transfer_package
+  delegate :uuid, :errors, :recipient, :confirmed_at, :confirmed?, :created_at, :receiver_institution, :sender_institution, :box_transfers, :boxes, :samples, to: :transfer_package
 
   def receiver?
     context.institution == transfer_package.receiver_institution

--- a/app/views/shared/_list.haml
+++ b/app/views/shared/_list.haml
@@ -1,0 +1,2 @@
+.selector-list-item
+  = yield

--- a/app/views/transfer_packages/index.haml
+++ b/app/views/transfer_packages/index.haml
@@ -27,7 +27,7 @@
             %th
         - t.tbody do
           - @transfer_packages.each do |transfer|
-            %tr{class: ("faded" if transfer.confirmed?)}
+            %tr{class: ("faded" if transfer.confirmed?), data: { href: transfer_package_path(transfer) }}
               %td= short_uuid_with_title(transfer.uuid)
               %td{title: "#{transfer.sender_institution} sent on #{I18n.l(transfer.created_at)}"}
                 = time_tag transfer.created_at, I18n.l(transfer.created_at, format: I18n.t("date.formats.long"))

--- a/app/views/transfer_packages/show.haml
+++ b/app/views/transfer_packages/show.haml
@@ -1,0 +1,37 @@
+- content_for(:subheader) do
+  .row.center.edit
+    .col.pe-10
+      .row
+        .col
+          %h2
+            = link_to @view_helper[:back_path], class: 'side-link', title: 'Back' do
+              = image_tag "arrow-left.png"
+            Transfer Details
+
+= cdx_form_for(@transfer_package) do |f|
+  = f.form_field :uuid, value: @transfer_package.uuid
+
+  = f.form_field :origin, value: @transfer_package.sender_institution
+
+  = f.form_field :destination, value: @transfer_package.receiver_institution
+
+  = f.form_field :recipient, value: @transfer_package.recipient
+
+  = f.form_field :log do
+    .value
+      %ol.dispatch-log
+        %li.log-entry.log-entry--created
+          %span.icon-local_shipping.icon-text-color
+          Sent on
+          = time_tag @transfer_package.created_at, I18n.l(@transfer_package.created_at, format: I18n.t("date.formats.long"))
+        - if @transfer_package.confirmed?
+          %li.log-entry.log-entry--confirmed
+            %span.icon-tick.icon-text-color
+            Confirmed on
+            = time_tag @transfer_package.confirmed_at, I18n.l(@transfer_package.confirmed_at, format: I18n.t("date.formats.long"))
+
+  = f.form_field :boxes do
+    .value
+      %strong= pluralize(@transfer_package.boxes.size, "box")
+    %div
+      = render partial: 'boxes/preview', layout: 'shared/list', collection: @transfer_package.boxes.count_samples, as: :box

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,7 +126,7 @@ Rails.application.routes.draw do
       post 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'destroy' }, action: :bulk_destroy
     end
   end
-  resources :transfer_packages, only: [:new, :create, :index] do
+  resources :transfer_packages, only: [:new, :create, :index, :show] do
     collection do
       get "find_box"
     end

--- a/spec/controllers/transfer_packages_controller_spec.rb
+++ b/spec/controllers/transfer_packages_controller_spec.rb
@@ -77,6 +77,36 @@ RSpec.describe TransferPackagesController, type: :controller do
     end
   end
 
+  describe "GET #show" do
+    before(:each) { sign_in user }
+
+    let!(:transfer_out) { TransferPackage.make!(sender_institution: institution, receiver_institution: other_institution) }
+    let!(:transfer_in) { TransferPackage.make!(sender_institution: other_institution, receiver_institution: institution) }
+    let!(:transfer_other) { TransferPackage.make! }
+
+    it "shows outgoing" do
+      get :show, params: { id: transfer_out.id }
+
+      expect(response).to have_http_status :ok
+      expect(response.body).to include("Sent on")
+      expect(response.body).to include(transfer_out.created_at.xmlschema)
+    end
+
+    it "shows incoming" do
+      get :show, params: { id: transfer_in.id }
+
+      expect(response).to have_http_status :ok
+      expect(response.body).to include("Sent on")
+      expect(response.body).to include(transfer_in.created_at.xmlschema)
+    end
+
+    it "doesn't show unrelated transfer" do
+      expect {
+        get :show, params: { id: transfer_other.id }
+      }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe "GET #find_box" do
     let!(:sample) do
       Sample.make! :filled, institution: institution, sample_identifiers: [SampleIdentifier.make!(uuid: "01234567-1111-a0c8-ac1b-58bed3633e88")]


### PR DESCRIPTION
This is a preparatory step for #1611 and builds on #1612
It adds a page for showing the transfer package. It will later be enhanced to allow confirmation.

![grafik](https://user-images.githubusercontent.com/466378/171257079-b1f59923-1b1f-4f9c-9010-dcdeb188faae.png)
