### PR TITLE
Add `transfer_packages#confirm`

### DIFF
--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -92,7 +92,7 @@ class TransferPackagesController < ApplicationController
       .find(params[:id])
     @transfer_package = TransferPackagePresenter.new(transfer_package, @navigation_context)
 
-    return unless authorize_resource(confirmation_resource(transfer_package.boxes.take), UPDATE_BOX)
+    return unless authorize_resource(confirmation_resource(transfer_package), UPDATE_BOX)
 
     if transfer_package.confirmed?
       flash[:info] = "Transfer had already been confirmed."
@@ -144,10 +144,10 @@ class TransferPackagesController < ApplicationController
     }
   end
 
-  def confirmation_resource(box)
+  def confirmation_resource(transfer_package)
     {
       resource_type: "box",
-      resource_id: box.id,
+      resource_id: transfer_package.boxes.take.id,
       institution_id: @navigation_context.institution.id,
       site_id: @navigation_context.site.try(&:uuid),
     }

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -59,20 +59,15 @@ class TransferPackage < ApplicationRecord
     box_transfers.build(box: box)
   end
 
-  def confirm
-    if confirmed?
-      false
-    else
-      self.confirmed_at = Time.now
-      true
-    end
-  end
-
   def confirm!
-    if confirm
+    raise ActiveRecord::RecordNotSaved.new("Transfer package has already been confirmed.") if confirmed?
+
+    transaction do
+      boxes.update_all(institution_id: receiver_institution.id)
+      samples.update_all(institution_id: receiver_institution.id)
+
+      self.confirmed_at = Time.now
       save!
-    else
-      raise ActiveRecord::RecordNotSaved.new("Transfer package has already been confirmed.")
     end
   end
 

--- a/app/views/form_builder/_field.haml
+++ b/app/views/form_builder/_field.haml
@@ -1,4 +1,4 @@
-.row.form-field{class: form.object.errors.has_key?(method) && "form-field--error" }
+.row.form-field{class: "#{form.object.errors.has_key?(method) ? "form-field--error " : ""}form-field--#{method}" }
   .col.form-field__label
     - label_options = options[:label] || {}
     = form.label method, label_options[:text], label_options

--- a/app/views/transfer_packages/_form.haml
+++ b/app/views/transfer_packages/_form.haml
@@ -1,5 +1,6 @@
 = cdx_form_for(@transfer_package) do |f|
-  = f.form_field :uuid, value: f.object.uuid
+  - if f.object.persisted?
+    = f.form_field :uuid, value: f.object.uuid
 
   = f.form_field :receiver_institution do
     - if @can_update

--- a/app/views/transfer_packages/index.haml
+++ b/app/views/transfer_packages/index.haml
@@ -15,7 +15,7 @@
           %col{width: "20%"}
           %col{width: "20%"}
           %col{width: "20%"}
-          %col{width: "2%"}
+          %col{style: "width: 1.7em;"}
         - t.thead do
           %tr
             %th Transfer Id
@@ -27,21 +27,21 @@
             %th
         - t.tbody do
           - @transfer_packages.each do |transfer|
-            %tr{class: ("faded" if transfer.confirmed?), data: { href: transfer_package_path(transfer) }}
-              %td= short_uuid_with_title(transfer.uuid)
-              %td{title: "#{transfer.sender_institution} sent on #{I18n.l(transfer.created_at)}"}
+            %tr.transfer_package-row{class: ("faded" if transfer.confirmed?), data: { href: transfer_package_path(transfer) }}
+              %td.col-uuid= short_uuid_with_title(transfer.uuid)
+              %td.col-transfer_date{title: "#{transfer.sender_institution} sent on #{I18n.l(transfer.created_at)}"}
                 = time_tag transfer.created_at, I18n.l(transfer.created_at, format: I18n.t("date.formats.long"))
-              %td= transfer.sender_institution
-              %td= transfer.receiver_institution
-              %td= transfer.recipient
+              %td.col-origin= transfer.sender_institution
+              %td.col-destination= transfer.receiver_institution
+              %td.col-recipient= transfer.recipient
               - if confirmed_at = transfer.confirmed_at
-                %td.text-right{title: "#{transfer.receiver_institution} confirmed receipt on #{I18n.l(confirmed_at)}"}
+                %td.col-state.text-right{title: "#{transfer.receiver_institution} confirmed receipt on #{I18n.l(confirmed_at)}"}
                   Recieved
                   = time_tag confirmed_at, I18n.l(confirmed_at, format: I18n.t("date.formats.long"))
                 %td{style: "padding-left: 0;"}
                   %span.icon-tick.icon-text-color{style: "vertical-align: bottom;"}
               - else
-                %td.text-right
+                %td.col-state.text-right
                   In transit
                 %td{style: "padding-left: 0;"}
                   %span.icon-local_shipping.icon-text-color{style: "vertical-align: bottom;"}

--- a/app/views/transfer_packages/show.haml
+++ b/app/views/transfer_packages/show.haml
@@ -36,6 +36,10 @@
     %div
       = render partial: 'boxes/preview', layout: 'shared/list', collection: @transfer_package.boxes.count_samples, as: :box
 
+  - if @can_confirm
+    = f.form_actions do
+      = f.submit "Confirm Transfer", formaction: confirm_transfer_package_path(@transfer_package), class: "btn-primary", id: "btn-save"
+
 - if @transfer_package.sender?
   .row
     .col

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
   resources :transfer_packages, only: [:new, :create, :index, :show] do
     member do
       post :unblind
+      patch 'confirm'
     end
     collection do
       get "find_box"

--- a/features/support/page_objects/transfer_package_page.rb
+++ b/features/support/page_objects/transfer_package_page.rb
@@ -22,3 +22,37 @@ class NewTransferPackagePage < CdxPageBase
     submit_button.click
   end
 end
+
+class ListTransferPackagesPage < CdxPageBase
+  set_url "/transfer_packages"
+
+  class TransferEntry < SitePrism::Section
+    element :uuid, "td.col-uuid"
+    element :transfer_date, "td.col-transfer_date"
+    element :origin, "td.col-origin"
+    element :destination, "td.col-destination"
+    element :recipient, "td.col-recipient"
+    element :state, "td.col-state"
+  end
+
+  section :filters, "#filters-form" do
+    element :sample_id, :field, "Sample ID"
+    element :batch_number, :field, "Batch Number"
+    element :isolate_name, :field, "Isolate Name"
+    element :specimen_role, :field, "Specimen Role"
+
+    include CdxPageHelper
+  end
+
+  sections :entries, TransferEntry, "tr.transfer_package-row"
+
+  def entry(uuid)
+    TransferEntry.new(self, find("tr.transfer_package-row", text: uuid))
+  end
+end
+
+class ShowTransferPackagePage < CdxPageBase
+  set_url "/transfer_packages/{id}"
+
+  element :confirm_button, :button, "Confirm"
+end

--- a/spec/features/transfer_packages_spec.rb
+++ b/spec/features/transfer_packages_spec.rb
@@ -30,36 +30,47 @@ describe "transfer packages" do
         page.submit
       end
 
-      # TODO: This needs to be re-enabled when TransferPackageControler#index is implemented
-      # expect_page ListBoxTransfersPage do |page|
-      #   entry = page.entry(box1.uuid)
-      #   expect(entry.state).to have_text("Sent on")
+      expect_page ListTransferPackagesPage do |page|
+        entry = page.entries.first
+        expect(entry.origin).to have_text(institution_a.name)
+        expect(Date.parse(entry.transfer_date.text)).to be_today
+        expect(entry.destination).to have_text(institution_b.name)
+        expect(entry.recipient).to have_text("Santa Claus")
+        expect(entry.state).to have_text("In transit")
+      end
 
-      #   entry = page.entry(box2.uuid)
-      #   expect(entry.state).to have_text("Sent on")
-      # end
+      sign_in user_b
 
-      # sign_in user_b
+      goto_page ListTransferPackagesPage do |page|
+        entry = page.entries.first
+        expect(entry.origin).to have_text(institution_a.name)
+        expect(Date.parse(entry.transfer_date.text)).to be_today
+        expect(entry.destination).to have_text(institution_b.name)
+        expect(entry.recipient).to have_text("Santa Claus")
+        expect(entry.state).to have_text("In transit")
 
-      # goto_page ListBoxTransfersPage do |page|
-      #   expect(page).to have_content(box1.partial_uuid)
-      #   expect(page).to have_content(box2.partial_uuid)
+        entry.uuid.click
+      end
 
-      #   page.entry(box1.partial_uuid).confirm.click
+      expect_page ShowTransferPackagePage do |page|
+        expect(page).to have_content("Transfer Details")
 
-      #   page.confirm_receipt_modal.tap do |modal|
-      #     expect(modal).to have_content("Confirm receipt")
+        expect(page).to have_content("Sent on")
+        page.confirm_button.click
+      end
 
-      #     modal.uuid_check.set box1.uuid[-4..-1]
+      expect_page ShowTransferPackagePage do |page|
+        expect(page).to have_content("Transfer Details")
 
-      #     modal.submit
-      #   end
-      # end
+        expect(page).to have_content("Sent on")
+        expect(page).to have_content("Confirmed on")
+        expect(page).not_to have_confirm_button
+      end
 
-      # expect_page ListBoxTransfersPage do |page|
-      #   entry = page.entry(box1.uuid)
-      #   expect(entry.state).to have_text("Receipt confirmed")
-      # end
+      goto_page ListTransferPackagesPage do |page|
+        entry = page.entries.first
+        expect(entry.state).to have_text("Recieved")
+      end
     end
 
     describe "box selector" do

--- a/spec/models/transfer_package_spec.rb
+++ b/spec/models/transfer_package_spec.rb
@@ -80,32 +80,9 @@ RSpec.describe TransferPackage, type: :model do
     end
   end
 
-  describe "#confirm" do
-    it "sets confirmed_at" do
-      transfer = TransferPackage.make
-      expect(transfer).not_to be_confirmed
-
-      Timecop.freeze(Time.now.change(usec: 0)) do
-        expect(transfer.confirm).to be true
-        expect(transfer.confirmed_at).to eq Time.now
-      end
-
-      expect(transfer).to be_confirmed
-      expect(transfer).to be_changed
-    end
-
-    it "returns false if already confirmed" do
-      transfer = TransferPackage.make(:confirmed)
-
-      expect {
-        expect(transfer.confirm).to be false
-      }.not_to change { transfer.confirmed_at }
-    end
-  end
-
   describe "#confirm!" do
     it "sets confirmed_at" do
-      transfer = TransferPackage.make
+      transfer = TransferPackage.make!
       expect(transfer).not_to be_confirmed
 
       Timecop.freeze(Time.now.change(usec: 0)) do
@@ -113,8 +90,11 @@ RSpec.describe TransferPackage, type: :model do
         expect(transfer.confirmed_at).to eq Time.now
       end
 
+      transfer.reload
       expect(transfer).to be_confirmed
       expect(transfer).not_to be_changed
+      expect(transfer.boxes.map(&:institution)).to eq [transfer.receiver_institution]
+      expect(transfer.samples.map(&:institution)).to eq [transfer.receiver_institution, transfer.receiver_institution]
     end
 
     it "raises if already confirmed" do

--- a/spec/support/feature_spec_helpers.rb
+++ b/spec/support/feature_spec_helpers.rb
@@ -56,7 +56,9 @@ module FeatureSpecHelpers
 
   def expect_page(klass)
     page = klass.new
-    expect(page).to be_displayed
+    unless page.displayed?
+      fail "Expected `#{page.inspect}` to be displayed, got `#{page.page.current_url}`"
+    end
     yield page if block_given?
   end
 


### PR DESCRIPTION
Implements the core feature of #1611.
This is just a basic confirmation without any validation step. This will be provided in a follow-up.