### PR TITLE
Fix: open box/sample labels PDF in new tab

### DIFF
--- a/app/views/boxes/_barcode_card.haml
+++ b/app/views/boxes/_barcode_card.haml
@@ -16,6 +16,6 @@
 
   .row.actions
     - unless @box.blinded?
-      = link_to print_box_path(@box), download: "cdx_box_#{@box.uuid}.pdf", target: "_blank", class: 'btn-link' do
+      = link_to print_box_path(@box), target: "_blank", class: 'btn-link' do
         .icon-print.btn-icon
         %span Print box and sample labels


### PR DESCRIPTION
There was a `target=_blank` attribute on the link, but the presence of a `download` attribute prevented the link to open in a new tab.

closes #1688 