### PR TITLE
Box: add other purpose

### DIFF
--- a/app/assets/javascripts/components/cdx_select_autocomplete.js.jsx
+++ b/app/assets/javascripts/components/cdx_select_autocomplete.js.jsx
@@ -25,6 +25,7 @@ var CdxSelectAutocomplete = React.createClass({
     if (!query) return callback(null, []);
 
     var autoselect = this.props.autoselect;
+    var prepareOptions = this.props.prepareOptions;
     var url = this.props.url;
     url += (url.includes("?") ? "&query=" : "?query=") + encodeURIComponent(query);
 
@@ -33,6 +34,9 @@ var CdxSelectAutocomplete = React.createClass({
       url: url,
 
       success: function (options) {
+        if (prepareOptions) {
+          options = prepareOptions.call(null, options);
+        }
         callback(null, {
           options: options,
           complete: options.size < 10,

--- a/app/assets/javascripts/components/cdx_select_autocomplete.js.jsx
+++ b/app/assets/javascripts/components/cdx_select_autocomplete.js.jsx
@@ -1,4 +1,10 @@
 var CdxSelectAutocomplete = React.createClass({
+  getInitialState: function () {
+    return {
+      options: null,
+    };
+  },
+
   render: function () {
     return (<Select
       className={this.props.className}
@@ -7,7 +13,9 @@ var CdxSelectAutocomplete = React.createClass({
       placeholder={this.props.placeholder}
       searchable={true}
       clearable={true}
-      asyncOptions={this.asyncOptions.bind(this)}
+      asyncOptions={this.asyncOptions}
+      value={this.props.value || ""}
+      onChange={this.onChange}
     />);
   },
 
@@ -17,7 +25,7 @@ var CdxSelectAutocomplete = React.createClass({
     }
 
     var url = this.props.url;
-    url += (url.includes("?") ? "&query=" : "?query=") + encodeURIComponent(query);
+    url += (url.includes("?") ? "&query=" : "?query=") + encodeURIComponent(query.trim());
 
     $.ajax({
       type: this.props.method || "GET",
@@ -34,5 +42,11 @@ var CdxSelectAutocomplete = React.createClass({
         callback(error);
       },
     })
+  },
+
+  onChange: function (value, options) {
+    if (this.props.onSelect) {
+      this.props.onSelect.call(null, value, options);
+    }
   },
 });

--- a/app/assets/javascripts/components/cdx_select_autocomplete.js.jsx
+++ b/app/assets/javascripts/components/cdx_select_autocomplete.js.jsx
@@ -7,6 +7,7 @@ var CdxSelectAutocomplete = React.createClass({
 
   render: function () {
     return (<Select
+      ref={this.setSelectRef}
       className={this.props.className}
       name={this.props.name}
       value={this.props.value}
@@ -20,12 +21,12 @@ var CdxSelectAutocomplete = React.createClass({
   },
 
   asyncOptions: function (query, callback) {
-    if (!query || /^\s*$/.test(query)) {
-      return callback(null, []);
-    }
+    query = query.trim();
+    if (!query) return callback(null, []);
 
+    var autoselect = this.props.autoselect;
     var url = this.props.url;
-    url += (url.includes("?") ? "&query=" : "?query=") + encodeURIComponent(query.trim());
+    url += (url.includes("?") ? "&query=" : "?query=") + encodeURIComponent(query);
 
     $.ajax({
       type: this.props.method || "GET",
@@ -36,7 +37,10 @@ var CdxSelectAutocomplete = React.createClass({
           options: options,
           complete: options.size < 10,
         });
-      },
+        if (autoselect && options.length === 1 && options[0].value === query) {
+          this.selectRef.setValue(query);
+        }
+      }.bind(this),
 
       error: function (_, error) {
         callback(error);
@@ -49,4 +53,8 @@ var CdxSelectAutocomplete = React.createClass({
       this.props.onSelect.call(null, value, options);
     }
   },
+
+  setSelectRef: function (ref) {
+    this.selectRef = ref;
+  }
 });

--- a/app/assets/javascripts/components/samples_selector.js.jsx
+++ b/app/assets/javascripts/components/samples_selector.js.jsx
@@ -1,0 +1,89 @@
+var SamplesSelector = React.createClass({
+  getInitialState: function () {
+    return {
+      samples: this.props.samples,
+    };
+  },
+
+  render: function () {
+    return (<div className="samples-selector">
+      {this.renderTitle()}
+      {this.state.samples.map(this.renderSample.bind(this))}
+
+      <a className="add-samples" href="#" onClick={this.addSample}>
+        <div className="add-samples">
+          <div className="icon-circle-plus icon-blue icon-margin"></div>
+          <div className="add-sample-link">ADD SAMPLE</div>
+        </div>
+      </a>
+    </div>);
+  },
+
+  renderTitle() {
+    var samples = this.state.samples;
+    if (!samples.length) return;
+
+    var count = samples.reduce(function (a, e) {
+      return e.uuid ? a + 1 : a;
+    }, 0);
+
+    return (<div className="samples-count">
+      <div className="title">{count}&nbsp;{count == 1 ? "sample" : "samples"}</div>
+    </div>);
+  },
+
+  renderSample(sample, index) {
+    var self = this;
+
+    if (sample.uuid) {
+      return (<div className="batches-samples">
+        <div className="samples-row">
+          <div className="samples-item">{sample.uuid}</div>
+          <div className="samples-row-actions">
+            <input type="hidden" name={self.props.name + "[" + index + "]"} value={sample.uuid}/>
+            <span>{sample.batch_number}</span>
+            <a href="#" onClick={function (event) { self.removeSample(event, index) }} title="Remove this sample">
+              <i className="icon-close icon-gray bigger"></i>
+            </a>
+          </div>
+        </div>
+      </div>);
+    } else {
+      return (<div className="batches-samples">
+        <div className="samples-row">
+          <CdxSelectAutocomplete
+            key={"samples-selector-" + index}
+            className={self.props.className}
+            url={self.props.url}
+            placeholder={self.props.placeholder}
+            value={sample.uuid}
+            onSelect={function (_, options) { self.selectSample(index, options && options[0]) }}
+          />
+        </div>
+      </div>);
+    }
+  },
+
+  addSample: function (event) {
+    event.preventDefault();
+
+    var samples = this.state.samples;
+    samples.push({ uuid: "" });
+    this.setState({ samples: samples });
+  },
+
+  selectSample(index, sample) {
+    var samples = this.state.samples;
+    samples[index] = sample;
+    this.setState({ samples: samples });
+  },
+
+  removeSample(event, index) {
+    event.preventDefault();
+
+    var samples = this.state.samples;
+    samples.splice(index, 1);
+
+    this.setState({ samples: samples });
+  }
+});

--- a/app/assets/javascripts/components/samples_selector.js.jsx
+++ b/app/assets/javascripts/components/samples_selector.js.jsx
@@ -33,31 +33,36 @@ var SamplesSelector = React.createClass({
   },
 
   renderSample(sample, index) {
-    var self = this;
-
     if (sample.uuid) {
+      function removeSample(event) {
+        this.removeSample(event, index);
+      }
       return (<div className="batches-samples">
         <div className="samples-row">
           <div className="samples-item">{sample.uuid}</div>
           <div className="samples-row-actions">
-            <input type="hidden" name={self.props.name + "[" + index + "]"} value={sample.uuid}/>
+            <input type="hidden" name={this.props.name + "[" + index + "]"} value={sample.uuid}/>
             <span>{sample.batch_number}</span>
-            <a href="#" onClick={function (event) { self.removeSample(event, index) }} title="Remove this sample">
+            <a href="#" onClick={removeSample.bind(this)} title="Remove this sample">
               <i className="icon-close icon-gray bigger"></i>
             </a>
           </div>
         </div>
       </div>);
     } else {
+      function selectSample(_, options) {
+        this.selectSample(index, options && options[0]);
+      }
       return (<div className="batches-samples">
         <div className="samples-row">
           <CdxSelectAutocomplete
             key={"samples-selector-" + index}
-            className={self.props.className}
-            url={self.props.url}
-            placeholder={self.props.placeholder}
+            className={this.props.className}
+            url={this.props.url}
+            placeholder={this.props.placeholder}
             value={sample.uuid}
-            onSelect={function (_, options) { self.selectSample(index, options && options[0]) }}
+            autoselect={true}
+            onSelect={selectSample.bind(this)}
           />
         </div>
       </div>);
@@ -72,18 +77,18 @@ var SamplesSelector = React.createClass({
     this.setState({ samples: samples });
   },
 
-  selectSample(index, sample) {
+  selectSample: function (index, sample) {
     var samples = this.state.samples;
     samples[index] = sample;
     this.setState({ samples: samples });
   },
 
-  removeSample(event, index) {
+  removeSample: function (event, index) {
     event.preventDefault();
 
     var samples = this.state.samples;
     samples.splice(index, 1);
 
     this.setState({ samples: samples });
-  }
+  },
 });

--- a/app/assets/javascripts/components/samples_selector.js.jsx
+++ b/app/assets/javascripts/components/samples_selector.js.jsx
@@ -8,7 +8,7 @@ var SamplesSelector = React.createClass({
   render: function () {
     return (<div className="samples-selector">
       {this.renderTitle()}
-      {this.state.samples.map(this.renderSample.bind(this))}
+      {this.state.samples.map(this.renderSample)}
 
       <a className="add-samples" href="#" onClick={this.addSample}>
         <div className="add-samples">
@@ -37,7 +37,7 @@ var SamplesSelector = React.createClass({
       function removeSample(event) {
         this.removeSample(event, index);
       }
-      return (<div className="batches-samples">
+      return (<div className="batches-samples" key={"samples-selector-" + index}>
         <div className="samples-row">
           <div className="samples-item">{sample.uuid}</div>
           <div className="samples-row-actions">
@@ -53,20 +53,28 @@ var SamplesSelector = React.createClass({
       function selectSample(_, options) {
         this.selectSample(index, options && options[0]);
       }
-      return (<div className="batches-samples">
+      return (<div className="batches-samples" key={"samples-selector-" + index}>
         <div className="samples-row">
           <CdxSelectAutocomplete
-            key={"samples-selector-" + index}
             className={this.props.className}
             url={this.props.url}
             placeholder={this.props.placeholder}
             value={sample.uuid}
+            prepareOptions={this.prepareOptions}
             autoselect={true}
             onSelect={selectSample.bind(this)}
           />
         </div>
       </div>);
     }
+  },
+
+  prepareOptions: function (options) {
+    return options.map(function (option) {
+      option.value = option.uuid;
+      option.label = option.uuid + " (" + option.batch_number + ")";
+      return option;
+    });
   },
 
   addSample: function (event) {

--- a/app/assets/stylesheets/_batches.scss
+++ b/app/assets/stylesheets/_batches.scss
@@ -69,6 +69,11 @@
   align-items: center;
   min-height: 40px;
 }
+.samples-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 
 .transfer-data {
   color: black;

--- a/app/assets/stylesheets/_sprites.scss
+++ b/app/assets/stylesheets/_sprites.scss
@@ -67,6 +67,9 @@
     color: inherit;
   }
 
+  &.bigger {
+    font-size: 24px;
+  }
   &.medium {
     font-size: 35px;
   }

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -1,5 +1,6 @@
 class BoxesController < ApplicationController
   before_action :load_box, except: %i[index new create bulk_destroy]
+  helper_method :samples_data
 
   def index
     @can_create = has_access?(@navigation_context.institution, CREATE_INSTITUTION_BOX)
@@ -59,6 +60,7 @@ class BoxesController < ApplicationController
 
     @box_form = BoxForm.build(@navigation_context, box_params)
     @box_form.batches = check_access(load_batches, READ_BATCH)
+    @box_form.samples = check_access(load_samples, READ_SAMPLE)
 
     if @box_form.valid?
       @box_form.build_samples
@@ -106,13 +108,29 @@ class BoxesController < ApplicationController
       .where(uuid: @box_form.batch_uuids.values.reject(&:blank?))
   end
 
+  def load_samples
+    Sample
+      .within(@navigation_context.entity, @navigation_context.exclude_subsites)
+      .find_all_by_any_uuid(@box_form.sample_uuids.values.reject(&:blank?))
+  end
+
   def box_params
     if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 0
       params.require(:box).permit(:purpose, :media).tap do |allowed|
-        allowed[:batch_uuids] = params[:box][:batch_uuids].permit!
+        allowed[:batch_uuids] = params[:box][:batch_uuids].try(&:permit!)
+        allowed[:sample_uuids] = params[:box][:sample_uuids].try(&:permit!)
       end
     else
-      params.require(:box).permit(:purpose, :media, batch_uuids: {})
+      params.require(:box).permit(:purpose, :media, batch_uuids: {}, sample_uuids: [])
+    end
+  end
+
+  def samples_data(samples)
+    samples.map do |sample|
+      {
+        value: sample.uuid,
+        label: "#{sample.uuid} (#{sample.batch_number})",
+      }
     end
   end
 end

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -126,10 +126,12 @@ class BoxesController < ApplicationController
   end
 
   def samples_data(samples)
+    # NOTE: duplicates the samples/autocomplete template (but returns an
+    # Array<Hash> instead of rendering to a JSON String)
     samples.map do |sample|
       {
-        value: sample.uuid,
-        label: "#{sample.uuid} (#{sample.batch_number})",
+        uuid: sample.uuid,
+        batch_number: sample.batch_number,
       }
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -25,6 +25,20 @@ class SamplesController < ApplicationController
       .preload(:batch, :sample_identifiers)
   end
 
+  def autocomplete
+    samples = Sample
+      .where(institution: @navigation_context.institution)
+      .within(@navigation_context.entity, @navigation_context.exclude_subsites)
+
+    samples = samples.without_qc if params[:qc] == "0"
+
+    @samples = check_access(samples, READ_SAMPLE)
+      .joins(:sample_identifiers)
+      .autocomplete(params[:query])
+      .limit(10)
+      .preload(:batch)
+  end
+
   def edit_or_show
     sample = Sample.find(params[:id])
 

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -95,10 +95,8 @@ class Box < ApplicationRecord
       %i[concentration concentration_formula replicate]
     when "Variants"
       %i[batch_number virus_lineage]
-    when "Challenge"
+    when "Challenge", "Other"
       %i[batch_number concentration concentration_formula replicate virus_lineage]
-    when "Other"
-      []
     else
       []
     end

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -97,6 +97,8 @@ class Box < ApplicationRecord
       %i[batch_number virus_lineage]
     when "Challenge"
       %i[batch_number concentration concentration_formula replicate virus_lineage]
+    when "Other"
+      []
     else
       []
     end

--- a/app/models/box_form.rb
+++ b/app/models/box_form.rb
@@ -1,5 +1,5 @@
 class BoxForm
-  attr_reader :box, :batch_uuids
+  attr_reader :box, :batch_uuids, :sample_uuids
   attr_accessor :media
 
   delegate :purpose, :purpose=, to: :box
@@ -18,12 +18,21 @@ class BoxForm
     @box = box
     @media = params[:media].presence
     @batch_uuids = params[:batch_uuids].presence.to_h
+    @sample_uuids = params[:sample_uuids].presence.to_h
   end
 
   def batches=(relation)
     records = relation.to_a
 
     @batches = @batch_uuids.transform_values do |batch_uuid|
+      records.find { |b| b.uuid == batch_uuid }
+    end.compact
+  end
+
+  def samples=(relation)
+    records = relation.to_a
+
+    @samples = @sample_uuids.transform_values do |batch_uuid|
       records.find { |b| b.uuid == batch_uuid }
     end.compact
   end
@@ -46,13 +55,17 @@ class BoxForm
           @box.build_samples(batch, concentration_exponents: [1, 4, 8], replicates: 3, media: media)
         end
       end
+
+    when "Other"
+      @box.samples = @samples.values
     end
   end
 
   def valid?
     @box.valid?
     validate_existence_of_batches
-    validate_batches_for_purpose
+    validate_existence_of_samples
+    validate_batches_or_samples_for_purpose
     @box.errors.empty?
   end
 
@@ -74,21 +87,37 @@ class BoxForm
     end
   end
 
-  def validate_batches_for_purpose
-    count = @batches.map { |_, b| b.try(&:uuid) }.uniq.size
+  def validate_existence_of_samples
+    @sample_uuids.each do |key, sample_uuid|
+      unless sample_uuid.blank? || @samples[key]
+        @box.errors.add(key, "Sample doesn't exist")
+      end
+    end
+  end
 
+  def validate_batches_or_samples_for_purpose
     case @box.purpose
     when "LOD"
       @box.errors.add(:lod, "A batch is required") unless @batches["lod"] || @box.errors.include?(:lod)
     when "Variants"
-      @box.errors.add(:base, "You must select at least two batches") unless count >= 2
+      @box.errors.add(:base, "You must select at least two batches") unless unique_batch_count >= 2
     when "Challenge"
       if @batches["virus"]
-        @box.errors.add(:base, "You must select at least one distractor batch") unless count >= 2
+        @box.errors.add(:base, "You must select at least one distractor batch") unless unique_batch_count >= 2
       else
         @box.errors.add(:virus, "A virus batch is required") unless @box.errors.include?(:virus)
-        @box.errors.add(:base, "You must select at least one distractor batch") unless count >= 1
+        @box.errors.add(:base, "You must select at least one distractor batch") unless unique_batch_count >= 1
+      end
+    when "Other"
+      if @samples.empty?
+        @box.errors.add(:base, "You must select at least one sample")
+      elsif @samples.any? { |_, sample| sample.is_quality_control? }
+        @box.errors.add(:base, "You can't select a QC sample")
       end
     end
+  end
+
+  def unique_batch_count
+    @batches.map { |_, b| b.try(&:uuid) }.uniq.size
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -84,6 +84,8 @@ class Sample < ApplicationRecord
     joins(:sample_identifiers).order("sample_identifiers.uuid")
   }
 
+  scope :without_qc, -> { where.not(specimen_role: "q") }
+
   def self.media
     entity_fields.find { |f| f.name == 'media' }.options
   end

--- a/app/views/batches/_samples.haml
+++ b/app/views/batches/_samples.haml
@@ -20,7 +20,7 @@
         %label.row{for: "sample_ids_#{sample.id}"}
         = check_box_tag 'destroy_sample_ids[]', sample.id, false, { id: "destroy_sample_ids_#{sample.id}", class: "destroy-checkbox" }
         = sample.uuid
-      .sample-row-actions
+      .samples-row-actions
         - if sample.is_quality_control?
           .icon-test.icon-gray{title: 'Q - Control specimen'}
         = link_to edit_sample_path(sample.id) do

--- a/app/views/batches/_show_samples.haml
+++ b/app/views/batches/_show_samples.haml
@@ -8,7 +8,7 @@
     .samples-row
       .samples-item
         = sample.uuid
-      .sample-row-actions
+      .samples-row-actions
         - if sample.is_quality_control?
           .icon-test.icon-gray{title: 'Q - Control specimen'}
         = link_to sample_path(sample.id) do

--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -7,7 +7,7 @@
           value: @box_form.purpose, submit: "#btn-save" }
 
       = f.form_field :media do
-        = cdx_select form: f, name: :media, searchable: false do |select|
+        = cdx_select form: f, name: :media, searchable: false, class: "input-large" do |select|
           - select.item "", " "
           - select.items Sample.media
 
@@ -41,6 +41,11 @@
                 = react_component "CdxSelectAutocomplete", { url: autocomplete_batches_path(format: "json", context: params[:context]),
                   name: "box[batch_uuids][#{key}]", value: @box_form.batch_uuids[key],
                   placeholder: "Enter batch id", className: "input-block" }
+
+          %fieldset#Other(disabled)
+            = react_component "SamplesSelector", { url: autocomplete_samples_path(format: "json", context: params[:context], qc: 0),
+              name: "box[sample_uuids]", samples: samples_data(@box_form.samples), placeholder: "Enter sample id", className: "input-block" }
+            /= f.field_errors :"box.samples"
 
   = f.form_actions do
     = f.submit 'Save', class: 'btn-primary', id: 'btn-save'

--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -44,8 +44,8 @@
 
           %fieldset#Other(disabled)
             = react_component "SamplesSelector", { url: autocomplete_samples_path(format: "json", context: params[:context], qc: 0),
-              name: "box[sample_uuids]", samples: samples_data(@box_form.samples), placeholder: "Enter sample id", className: "input-block" }
-            /= f.field_errors :"box.samples"
+              name: "box[sample_uuids]", placeholder: "Enter sample id", className: "input-block",
+              samples: samples_data(@box_form.samples) }
 
   = f.form_actions do
     = f.submit 'Save', class: 'btn-primary', id: 'btn-save'

--- a/app/views/samples/autocomplete.json.jbuilder
+++ b/app/views/samples/autocomplete.json.jbuilder
@@ -1,7 +1,4 @@
 json.array!(@samples) do |sample|
-  json.uuid sample.uuid
+  json.uuid         sample.uuid
   json.batch_number sample.batch_number
-
-  json.value sample.uuid
-  json.label "#{sample.uuid} (#{sample.batch_number})"
 end

--- a/app/views/samples/autocomplete.json.jbuilder
+++ b/app/views/samples/autocomplete.json.jbuilder
@@ -1,0 +1,7 @@
+json.array!(@samples) do |sample|
+  json.uuid sample.uuid
+  json.batch_number sample.batch_number
+
+  json.value sample.uuid
+  json.label "#{sample.uuid} (#{sample.batch_number})"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
       get 'edit_or_show'
     end
     collection do
+      get 'autocomplete'
       post 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'print' }, action: :bulk_print
       post 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'destroy' }, action: :bulk_destroy
     end

--- a/deps/cdx_core/lib/config/fields.yml
+++ b/deps/cdx_core/lib/config/fields.yml
@@ -139,6 +139,7 @@ entities:
           - LOD
           - Variants
           - Challenge
+          - Other
   test: &TEST
     allows_custom: true
     fields:

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -197,18 +197,17 @@ RSpec.describe BoxesController, type: :controller do
       end
     end
 
-    xit "blinds columns for Other purpose" do
+    it "blinds columns for Other purpose" do
       box = Box.make! :filled, institution: institution, purpose: "Other", blinded: true
 
       get :inventory, params: { id: box.id, format: "csv" }
       expect(response).to have_http_status(:ok)
 
-      # TODO: which columns should be blinded?
       CSV.parse(response.body).tap(&:shift).each do |row|
-        # expect(row[3]).to eq("Blinded")
-        # expect(row[4]).to eq("Blinded")
-        # expect(row[5]).to eq("Blinded")
-        # expect(row[7]).to eq("Blinded")
+        expect(row[3]).to eq("Blinded")
+        expect(row[4]).to eq("Blinded")
+        expect(row[5]).to eq("Blinded")
+        expect(row[7]).to eq("Blinded")
       end
     end
   end

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe BoxesController, type: :controller do
         Box.make!(3, :filled, institution: @institution, purpose: "LOD")
         Box.make!(2, :filled, institution: @institution, purpose: "Variants")
         Box.make!(4, :filled, institution: @institution, purpose: "Challenge")
+        Box.make!(1, :filled, institution: @institution, purpose: "Other")
       end
 
       it "paginates" do
@@ -73,6 +74,9 @@ RSpec.describe BoxesController, type: :controller do
 
         get :index, params: { purpose: "Challenge" }
         expect(assigns(:boxes).count).to eq(4)
+
+        get :index, params: { purpose: "Other" }
+        expect(assigns(:boxes).count).to eq(1)
       end
     end
   end
@@ -190,6 +194,21 @@ RSpec.describe BoxesController, type: :controller do
         expect(row[4]).to eq("Blinded")
         expect(row[5]).to eq("Blinded")
         expect(row[7]).to eq("Blinded")
+      end
+    end
+
+    xit "blinds columns for Other purpose" do
+      box = Box.make! :filled, institution: institution, purpose: "Other", blinded: true
+
+      get :inventory, params: { id: box.id, format: "csv" }
+      expect(response).to have_http_status(:ok)
+
+      # TODO: which columns should be blinded?
+      CSV.parse(response.body).tap(&:shift).each do |row|
+        # expect(row[3]).to eq("Blinded")
+        # expect(row[4]).to eq("Blinded")
+        # expect(row[5]).to eq("Blinded")
+        # expect(row[7]).to eq("Blinded")
       end
     end
   end
@@ -426,6 +445,56 @@ RSpec.describe BoxesController, type: :controller do
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(63)
+      end
+    end
+
+    describe "Other purpose" do
+      it "creates with samples" do
+        samples = Sample.make! 2, :filled, institution: institution, specimen_role: "b"
+
+        expect do
+          expect do
+            post :create, params: { box: {
+              purpose: "Other",
+              sample_uuids: {
+                "sample_0" => samples[0].uuid,
+                "sample_1" => samples[1].uuid,
+              }
+            } }
+            expect(response).to redirect_to(boxes_path)
+          end.to change(institution.samples, :count).by(0)
+        end.to change(institution.boxes, :count).by(1)
+
+        expect(Box.last.samples.map(&:uuid).sort).to eq(samples.map(&:uuid).sort)
+      end
+
+      it "won't create with QC samples" do
+        samples = [
+          Sample.make!(:filled, institution: institution, specimen_role: "b"),
+          Sample.make!(:filled, institution: institution, specimen_role: "q"),
+        ]
+
+        expect do
+          expect do
+            post :create, params: { box: {
+              purpose: "Other",
+              sample_uuids: {
+                "sample_0" => samples[0].uuid,
+                "sample_1" => samples[1].uuid,
+              }
+            } }
+            expect(response).to have_http_status(:unprocessable_entity)
+          end.to change(institution.samples, :count).by(0)
+        end.to change(institution.boxes, :count).by(0)
+      end
+
+      it "requires at least 1 sample" do
+        expect do
+          expect do
+            post :create, params: { box: { purpose: "Other", sample_uuids: {} } }
+            expect(response).to have_http_status(:unprocessable_entity)
+          end.to change(institution.samples, :count).by(0)
+        end.to change(institution.boxes, :count).by(0)
       end
     end
   end

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -224,13 +224,12 @@ RSpec.describe SamplesController, type: :controller do
         assert_select "input[name='sample[virus_lineage]']", count: 0
       end
 
-      xit "blinds values when box is blinded (Other)" do
+      it "blinds values when box is blinded (Other)" do
         Box.make! institution: institution, samples: [sample], purpose: "Other", blinded: true
 
         get :show, params: { id: sample.to_param }
         expect(response).to have_http_status(:ok)
 
-        # TODO: which columns are expected to be blinded?
         expect(response.body).to include("Blinded value")
         expect(response.body).to_not include(batch.batch_number)
         assert_select "input[name='sample[concentration_number]']", count: 0


### PR DESCRIPTION
We can now select the "Other" purpose when creating a Box. It will present an interface to select samples one by one by their UUID. You can type an UUID and it will be autocompleted, or you can paste/scan a QR code.

Notes/Questions:

1. ~~Which sample attributes should be blinded for this purpose?~~ all of them

2. QC samples aren't autocompleted and can't be selected (we can't transfer a box with QC samples). ~~Alternative would be to warn about the sample being QC, and eventually prevent transferring a box with QC samples.~~

Improvement:

- [x] Auto-select the sample when we entered the UUID completely (and got one result) to improve the UX with QR scanners.

closes #1619 