### PR TITLE
Fix: use direct SQL in migration instead of removed AR association

### DIFF
--- a/db/migrate/20220408103851_add_sender_institution_to_transfer_packages.rb
+++ b/db/migrate/20220408103851_add_sender_institution_to_transfer_packages.rb
@@ -1,15 +1,12 @@
-class AddSenderInstitutionToTransferPackages < ActiveRecord::Migration
+class AddSenderInstitutionToTransferPackages < ActiveRecord::Migration[5.0]
   def up
     add_reference :transfer_packages, :sender_institution, null: true
 
-    TransferPackage.reset_column_information
-
-    # Fill sender_institution on existing packages
-    TransferPackage.find_each do |package|
-      package.update_columns(
-        sender_institution_id: package.sample_transfers.take.sender_institution_id,
-      )
-    end
+    connection.execute <<-SQL
+    UPDATE transfer_packages
+    INNER JOIN sample_transfers ON sample_transfers.transfer_package_id = transfer_packages.id
+    SET transfer_packages.sender_institution_id = sample_transfers.sender_institution_id;
+    SQL
 
     change_column_null :transfer_packages, :sender_institution_id, false
   end


### PR DESCRIPTION
That should fix the deployment issue in v0.21.0 by avoiding to rely on an AR association (that was removed) and using a direct SQL request.