### PR TITLE
Drop migrations using `SampleTransfer`

### DIFF
--- a/db/migrate/20220412181435_change_sample_transfers_requires_transfer_package.rb
+++ b/db/migrate/20220412181435_change_sample_transfers_requires_transfer_package.rb
@@ -1,16 +1,5 @@
 class ChangeSampleTransfersRequiresTransferPackage < ActiveRecord::Migration
   def up
-    # Create packages for existing transfers
-    SampleTransfer.where(transfer_package_id: nil).find_each do |transfer|
-      package = TransferPackage.create(
-        sender_institution_id: transfer.sender_institution_id,
-        receiver_institution_id: transfer.receiver_institution_id,
-      )
-      transfer.update_columns(
-        transfer_package_id: package.id,
-      )
-    end
-
     change_column_null :sample_transfers, :transfer_package_id, false
   end
 

--- a/db/migrate/20220505070823_add_confirmed_at_to_transfer_packages.rb
+++ b/db/migrate/20220505070823_add_confirmed_at_to_transfer_packages.rb
@@ -4,15 +4,6 @@ class AddConfirmedAtToTransferPackages < ActiveRecord::Migration
     add_index :transfer_packages, :confirmed_at
 
     TransferPackage.reset_column_information
-
-    # Fill confirmed_at on existing packages if their sample transfers have been confirmed
-    TransferPackage.find_each do |package|
-      if confirmed_at = package.sample_transfers.map(&:confirmed_at).compact.max
-        package.update_columns(
-          confirmed_at: confirmed_at,
-        )
-      end
-    end
   end
 
   def down


### PR DESCRIPTION
These data migrations are unnecessary and conflict with the removal of the `SampleTransfer` model.