### PR TITLE
isolate name blinded in every purposes

### DIFF
--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -84,22 +84,12 @@ class Box < ApplicationRecord
 
   # Returns the full list of sample attributes that can be blinded.
   def self.blind_attribute_names
-    %i[batch_number concentration concentration_formula replicate virus_lineage]
+    %i[batch_number concentration concentration_formula replicate virus_lineage isolate_name]
   end
 
   # Returns the list of sample attributes that should be blinded for the box'
-  # purpose.
   def blind_attributes
-    case purpose
-    when "LOD"
-      %i[concentration concentration_formula replicate]
-    when "Variants"
-      %i[batch_number virus_lineage]
-    when "Challenge", "Other"
-      %i[batch_number concentration concentration_formula replicate virus_lineage]
-    else
-      []
-    end
+    %i[batch_number concentration concentration_formula replicate virus_lineage isolate_name]
   end
 
   # Returns true if a sample attribute should be blinded for the current box.

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -41,7 +41,8 @@
           = f.text_field :virus_lineage, class: 'input-x-large', readonly: !@can_update
 
       = f.form_field :isolate_name do
-        = f.text_field :isolate_name, class: 'input-x-large', readonly: !@can_update
+        - @sample_form.blinded_attribute(:isolate_name) do
+          = f.text_field :isolate_name, class: 'input-x-large', readonly: !@can_update
 
       = f.form_field :inactivation_method do
         - if @can_update


### PR DESCRIPTION
Maybe there is something to remove from boxes_controller in inventory describe, but I didn't understand how it works. But...changing the blinded_attributes on boxes.rb it's working on Box Inventory CSV too. So...it's done.