### PR TITLE
Simplify boxes transfer blinding flow - Stage 1

### DIFF
--- a/app/assets/stylesheets/_barcode_card.scss
+++ b/app/assets/stylesheets/_barcode_card.scss
@@ -10,7 +10,7 @@
 
     background: $white;
     padding: 5px 7px;
-    margin: 15px 15px;
+    margin: 15px 15px 7px;
 
     .title {
       font-size: 14px;
@@ -63,6 +63,17 @@
       background: none !important;
       color: inherit;
     }
+  }
+}
+
+.barcode-after {
+  margin: 7px 15px 0;
+
+  .btn-icon {
+    margin: -3px 0 0;
+    font-size: 24px;
+    background: none !important;
+    color: inherit;
   }
 }
 

--- a/app/assets/stylesheets/_box_preview.scss
+++ b/app/assets/stylesheets/_box_preview.scss
@@ -1,38 +1,19 @@
 .box-preview {
   display: grid;
   grid-template-areas:
-      "uuid uuid uuid btns"
-      "purpose samples time btns";
-  grid-template-columns: auto auto auto 1fr;
+      "uuid uuid uuid uuid uuid"
+      "data data data data data";
+  grid-template-columns: auto 1fr auto;
   grid-gap: 5px;
 
   .box__uuid {
     font-weight: bold;
     margin-right: 15px;
     grid-area: uuid;
-    padding-top: 8px;
 
     > a {
       color: inherit;
     }
-  }
-  .box__btns {
-    grid-area: btns;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-  }
-  .box__created_at {
-    grid-area: time;
-  }
-  .box__purpose {
-    grid-area: purpose;
-  }
-  .box__samples {
-    grid-area: samples;
-  }
-  .btn-link {
-    display: block;
   }
 }
 

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -1,6 +1,5 @@
 class BoxesController < ApplicationController
-  before_action :load_box, only: %i[show destroy]
-  before_action :load_box_print, only: %i[print inventory]
+  before_action :load_box, except: %i[index new create bulk_destroy]
   helper_method :samples_data
 
   def index
@@ -101,17 +100,6 @@ class BoxesController < ApplicationController
     end
   end
 
-  def load_box_print
-    @box = Box.where(institution: @navigation_context.institution, id: params.fetch(:id)).take
-    if @box.nil?
-      @box = Box
-        .joins(box_transfers: :transfer_package)
-        .merge( TransferPackage.within( @navigation_context.institution ) )
-        .where(id: params.fetch(:id))
-        .take
-    end
-  end
-  
   def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
     samples = samples.scrambled if @box.blinded?
@@ -151,5 +139,4 @@ class BoxesController < ApplicationController
       }
     end
   end
-  
 end

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -1,6 +1,5 @@
 class BoxesController < ApplicationController
-  before_action :load_box, only: %i[show destroy]
-  before_action :load_box_print, only: %i[print inventory]
+  before_action :load_box, except: %i[index new create bulk_destroy]
   helper_method :samples_data
 
   def index
@@ -23,9 +22,9 @@ class BoxesController < ApplicationController
   end
 
   def inventory
-    return unless authorize_resource( box_resource(@box), READ_BOX )
+    return unless authorize_resource(@box, READ_BOX)
 
-    @samples = load_box_samples( sender? )
+    @samples = load_box_samples
 
     respond_to do |format|
       format.csv do
@@ -35,16 +34,14 @@ class BoxesController < ApplicationController
   end
 
   def print
-    return unless authorize_resource( box_resource(@box), READ_BOX )
-
-    @samples = load_box_samples
+    return unless authorize_resource(@box, READ_BOX)
 
     render pdf: "cdx_box_#{@box.uuid}",
       template: "boxes/print.pdf",
       layout: "layouts/pdf.html",
       locals: {
         box: @box,
-        samples: @samples,
+        samples: @box.samples.preload(:batch, :sample_identifiers),
       },
       margin: { top: 0, bottom: 0, left: 0, right: 0 },
       page_width: "1in",
@@ -103,36 +100,10 @@ class BoxesController < ApplicationController
     end
   end
 
-  def load_box_print
-    @box = Box.where(institution: @navigation_context.institution, id: params.fetch(:id)).take
-    if @box.nil?
-      @box = Box
-        .joins(box_transfers: :transfer_package)
-        .merge( TransferPackage.within( @navigation_context.institution ) )
-        .where(id: params.fetch(:id))
-        .take
-    end
-  end
-
-  def load_box_samples( force_unblind = false )
+  def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
-    if !@box.blinded or sender?
-      samples = samples.sort_by{ |sample| [sample.batch_number, sample.concentration, sample.replicate ] }
-    else
-      samples = samples.scrambled
-    end
-    unless force_unblind
-      samples = SamplePresenter.map(samples, request.format)
-    end
-    samples
-  end
-
-  def sender?
-    return @sender unless @sender.nil?
-    @sender = BoxTransfer
-      .joins(:transfer_package)
-      .where( box_id: params.fetch(:id), transfer_packages: { sender_institution_id: @navigation_context.institution } )
-      .exists?
+    samples = samples.scrambled if @box.blinded?
+    SamplePresenter.map(samples, request.format)
   end
 
   def load_batches
@@ -167,17 +138,5 @@ class BoxesController < ApplicationController
         batch_number: sample.batch_number,
       }
     end
-  end
-
-  def box_resource(box)
-    return box if box.institution_id == @navigation_context.institution.id || !sender?
-
-    # the box is being transferred or the user is the sender:
-    {
-      resource_type: "box",
-      resource_id: box.id,
-      institution_id: @navigation_context.institution.id,
-      site_id: @navigation_context.site.try(&:uuid),
-    }
   end
 end

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -1,5 +1,6 @@
 class BoxesController < ApplicationController
-  before_action :load_box, except: %i[index new create bulk_destroy]
+  before_action :load_box, only: %i[show destroy]
+  before_action :load_box_print, only: %i[print inventory]
   helper_method :samples_data
 
   def index
@@ -100,6 +101,17 @@ class BoxesController < ApplicationController
     end
   end
 
+  def load_box_print
+    @box = Box.where(institution: @navigation_context.institution, id: params.fetch(:id)).take
+    if @box.nil?
+      @box = Box
+        .joins(box_transfers: :transfer_package)
+        .merge( TransferPackage.within( @navigation_context.institution ) )
+        .where(id: params.fetch(:id))
+        .take
+    end
+  end
+  
   def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
     samples = samples.scrambled if @box.blinded?
@@ -139,4 +151,5 @@ class BoxesController < ApplicationController
       }
     end
   end
+  
 end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -30,7 +30,7 @@ class SamplesController < ApplicationController
     @samples = perform_pagination(@samples)
       .preload(:batch, :sample_identifiers)
 
-    @samples = SamplePresenter.map(@samples, request.format )
+    @samples = @samples.map { |sample|  SamplePresenter.new(sample, request.format ) }
   end
 
   def autocomplete
@@ -119,7 +119,6 @@ class SamplesController < ApplicationController
     @sample = Sample.find(params[:id])
     return unless authorize_resource(@sample, READ_SAMPLE)
 
-    @sample = SamplePresenter.new(@sample, request.format)
     render pdf: "cdx_sample_#{@sample.uuid}",
       template: "samples/barcode.pdf",
       layout: "layouts/pdf.html",

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -36,7 +36,7 @@ class TransferPackagesController < ApplicationController
       .within(@navigation_context.institution)
       .includes(:box_transfers, :boxes)
       .find(params[:id])
-    @show_print_buttons = true
+
     @transfer_package = TransferPackagePresenter.new(transfer_package, @navigation_context)
 
     @view_helper = view_helper({ save_back_path: true })
@@ -76,10 +76,8 @@ class TransferPackagesController < ApplicationController
     full_uuid = uuid.size == 36
     @boxes = Box
       .within(@navigation_context.entity, @navigation_context.exclude_subsites)
-      .left_joins(:box_transfers)
-      .where(box_transfers: {id: nil})
       .autocomplete(uuid)
-      .order("boxes.created_at DESC")
+      .order("created_at DESC")
       .count_samples
       .limit(5)
 

--- a/app/views/boxes/_barcode_card.haml
+++ b/app/views/boxes/_barcode_card.haml
@@ -12,3 +12,10 @@
     .logo
       = image_tag 'cdx-logo-bw.png'
       .label https://cdx.io
+
+
+  .row.actions
+    - unless @box.blinded?
+      = link_to print_box_path(@box), target: "_blank", class: 'btn-link' do
+        .icon-print.btn-icon
+        %span Print box and sample labels

--- a/app/views/boxes/_preview.haml
+++ b/app/views/boxes/_preview.haml
@@ -1,22 +1,10 @@
 .box-preview
   .box__uuid{title: "UUID"}
     = box.uuid
-
-  .box__created_at{title: "Creation date"}
-    = time_tag box.created_at, I18n.l(box.created_at, format: I18n.t("date.formats.long"))
-
   .box__purpose{title: "Purpose"}
     = box.purpose
   .box__samples{title: "Samples"}
     = box.samples_count
     samples
-
-  .box__btns{title: "Actions"}
-    - if @show_print_buttons and !@can_confirm
-      = link_to print_box_path(box), target: "_blank", class: 'btn-link' do
-        .icon-print.btn-icon
-        %span Print box and sample labels
-
-      = link_to inventory_box_path(box, format: "csv"), target: "_blank", class: 'btn-link' do
-        .icon-download.btn-icon
-        %span Download inventory
+  .box__created_at{title: "Creation date"}
+    = time_tag box.created_at, I18n.l(box.created_at, format: I18n.t("date.formats.long"))

--- a/app/views/boxes/inventory.csv.csvbuilder
+++ b/app/views/boxes/inventory.csv.csvbuilder
@@ -4,9 +4,9 @@ csv << [
   "Label ID (QR code)",
   "Batch ID",
   "Virus Lineage",
+  "Replicate",
   "Production Date",
   "Concentration",
-  "Replicate",
   "Inactivation Method",
   "Media",
 ]
@@ -18,9 +18,9 @@ csv << [
     sample.uuid,
     sample.batch_number,
     sample.virus_lineage,
+    sample.replicate,
     sample.date_produced.to_date,
     sample.concentration_formula,
-    sample.replicate,
     sample.inactivation_method,
     sample.media,
   ]

--- a/app/views/boxes/show.haml
+++ b/app/views/boxes/show.haml
@@ -30,6 +30,11 @@
       .col
         = render "barcode_card"
 
+        .barcode-after
+          = link_to inventory_box_path(@box, format: "csv"), target: "_blank", class: 'btn-link' do
+            .icon-download.btn-icon
+            %span Download inventory
+
 .row
   .col
     .row

--- a/app/views/samples/barcode.pdf.haml
+++ b/app/views/samples/barcode.pdf.haml
@@ -9,12 +9,8 @@
         #{sample.uuid}
     .code
       I.N. #{sample.isolate_name}
-    - if sample.box
-      .code
-        Purpose: #{sample.box.purpose}
-    - else
-      .code
-        I.M. #{sample.inactivation_method}
+    .code
+      I.M. #{sample.inactivation_method}
     .code
       P.D. #{sample.date_produced_description}
     .logo

--- a/app/views/samples/index.haml
+++ b/app/views/samples/index.haml
@@ -47,9 +47,7 @@
                   =check_box_tag 'sample_ids[]', sample.id, false, { id: "sample_ids.#{sample.id}" }
                   %label.row{for: "sample_ids.#{sample.id}"}
                 %td{id: 'sample_uuid', data: {uuid: sample.uuid}}= short_uuid_with_title sample.uuid
-                %td{id: 'sample_isolate_name'}
-                  = sample.blinded_attribute(:isolate_name) do
-                    - sample.isolate_name
+                %td{id: 'sample_isolate_name'}= sample.isolate_name
                 %td= sample.inactivation_method
                 %td= sample.specimen_role_description
                 %td= sample.date_produced_description

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -259,14 +259,18 @@ RSpec.describe BoxesController, type: :controller do
       end.to change(institution.boxes, :count).by(0)
     end
 
-    def expect_samples(batch, concentration_exponents:, replicates:)
-      samples = batch.samples.order(:id).to_a
-      expect(samples.size).to eq(concentration_exponents.size * replicates)
+    def expect_samples(batch, concentration_number: 1, concentration_exponents: [0], replicates:)
+      # NOTE: can't where/order in SQL because entity fields...
+      samples = batch.samples.to_a.reject { |s| s.concentration_number != concentration_number }.sort! do |a, b|
+        cmp = a.concentration_exponent <=> b.concentration_exponent
+        cmp = a.replicate <=> b.replicate if cmp == 0
+        cmp
+      end
 
       concentration_exponents.each do |e|
         1.upto(replicates) do |r|
           expect(sample = samples.shift).to_not be_nil
-          expect(sample.concentration).to eq(1 * (10 ** -e))
+          expect(sample.concentration).to eq(concentration_number * (10 ** -e))
           expect(sample.replicate).to eq(r)
         end
       end
@@ -280,10 +284,11 @@ RSpec.describe BoxesController, type: :controller do
             batch_uuids: { "lod" => batch.uuid },
           } }
           expect(response).to redirect_to(boxes_path)
-        end.to change(institution.samples, :count).by(24)
+        end.to change(institution.samples, :count).by(28)
 
-        expect(Box.last.samples.count).to eq(24)
+        expect(Box.last.samples.count).to eq(28)
         expect_samples(batch, concentration_exponents: 1..8, replicates: 3)
+        expect_samples(batch, concentration_number: 0, replicates: 4)
       end
 
       it "requires one batch" do

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -11,15 +11,7 @@ RSpec.describe BoxesController, type: :controller do
     @site = Site.make! institution: @institution
     @site_box = Box.make! institution: @institution, site: @site
 
-    @other_institution = Institution.make!
-    @other_user = @other_institution.user
-
-    @floating_transfer = TransferPackage.make! sender_institution: @institution, receiver_institution: @other_institution, blinded: true
-    @floating_box = @floating_transfer.box_transfers[0].box
-
-    @confirmed_transfer = TransferPackage.make! :receiver_confirmed, sender_institution: @institution, receiver_institution: @other_institution, blinded: true
-    @confirmed_box = @confirmed_transfer.box_transfers[0].box
-
+    @other_user = Institution.make!.user
     grant @user, @other_user, @institution, READ_INSTITUTION
   end
 
@@ -125,19 +117,14 @@ RSpec.describe BoxesController, type: :controller do
       grant user, other_user, box, READ_BOX
       sign_in other_user
 
-      get :print, params: { id: @confirmed_box.id, context: other_institution.uuid }
+      get :print, params: { id: box.id }
       expect(response).to have_http_status(:ok)
     end
 
     it "shouldn't be allowed if can't read" do
       sign_in other_user
-      get :print, params: { id: box.id }
-      expect(response).to have_http_status(:forbidden)
-    end
 
-    it "floating box shouldn't be accessible receiver" do
-      sign_in other_user
-      get :print, params: { id: @floating_box.id, context: other_institution.uuid }
+      get :print, params: { id: box.id }
       expect(response).to have_http_status(:forbidden)
     end
   end
@@ -162,10 +149,10 @@ RSpec.describe BoxesController, type: :controller do
     end
 
     it "should be allowed if can read" do
-      grant user, other_user, confirmed_box, READ_BOX
+      grant user, other_user, box, READ_BOX
       sign_in other_user
 
-      get :inventory, params: { id: @confirmed_box.id, context: other_institution.uuid, format: "csv" }
+      get :inventory, params: { id: box.id, format: "csv" }
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to eq("text/csv")
     end

--- a/spec/controllers/transfer_packages_controller_spec.rb
+++ b/spec/controllers/transfer_packages_controller_spec.rb
@@ -189,17 +189,6 @@ RSpec.describe TransferPackagesController, type: :controller do
         expect(data["samples"].map { |s| s["uuid"] }).to eq [qc_sample.uuid]
         expect(data["samples"].map { |s| s["error"] }).to eq ["Sample 01234567-4444-a0c8-ac1b-58bed3633e88 is a QC sample and can't be transferred."]
       end
-      
-      it "blocks transfered boxes" do
-        confirmed_transfer = TransferPackage.make! :receiver_confirmed, sender_institution: @institution, receiver_institution: @other_institution, blinded: true
-        confirmed_box = confirmed_transfer.box_transfers[0].box
-
-        get :find_box, params: { uuid: confirmed_box.uuid }
-        expect(response).to be_success
-
-        data = JSON.parse(response.body)
-        expect(data["boxes"]).to be_empty
-      end
     end
 
     context "partial" do

--- a/spec/controllers/transfer_packages_controller_spec.rb
+++ b/spec/controllers/transfer_packages_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe TransferPackagesController, type: :controller do
 
     @other_institution = Institution.make!
     @other_user = @other_institution.user
-
     grant @other_user, @user, @other_institution, READ_INSTITUTION
   end
 
@@ -189,16 +188,6 @@ RSpec.describe TransferPackagesController, type: :controller do
         data = JSON.parse(response.body)
         expect(data["samples"].map { |s| s["uuid"] }).to eq [qc_sample.uuid]
         expect(data["samples"].map { |s| s["error"] }).to eq ["Sample 01234567-4444-a0c8-ac1b-58bed3633e88 is a QC sample and can't be transferred."]
-      end
-      it "blocks transfered boxes" do
-        confirmed_transfer = TransferPackage.make! :receiver_confirmed, sender_institution: @institution, receiver_institution: @other_institution, blinded: true
-        confirmed_box = confirmed_transfer.box_transfers[0].box
-
-        get :find_box, params: { uuid: confirmed_box.uuid }
-        expect(response).to be_success
-
-        data = JSON.parse(response.body)
-        expect(data["boxes"]).to be_empty
       end
     end
 

--- a/spec/controllers/transfer_packages_controller_spec.rb
+++ b/spec/controllers/transfer_packages_controller_spec.rb
@@ -189,6 +189,17 @@ RSpec.describe TransferPackagesController, type: :controller do
         expect(data["samples"].map { |s| s["uuid"] }).to eq [qc_sample.uuid]
         expect(data["samples"].map { |s| s["error"] }).to eq ["Sample 01234567-4444-a0c8-ac1b-58bed3633e88 is a QC sample and can't be transferred."]
       end
+      
+      it "blocks transfered boxes" do
+        confirmed_transfer = TransferPackage.make! :receiver_confirmed, sender_institution: @institution, receiver_institution: @other_institution, blinded: true
+        confirmed_box = confirmed_transfer.box_transfers[0].box
+
+        get :find_box, params: { uuid: confirmed_box.uuid }
+        expect(response).to be_success
+
+        data = JSON.parse(response.body)
+        expect(data["boxes"]).to be_empty
+      end
     end
 
     context "partial" do

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -165,7 +165,6 @@ end
 TransferPackage.blueprint do
   uuid { SecureRandom.uuid }
   receiver_institution { Institution.make! }
-  receiver_institution { Institution.make! }
   sender_institution { Institution.make! }
   recipient { Faker::Name.name }
   box_transfers { [BoxTransfer.make(transfer_package: object)] }
@@ -173,6 +172,16 @@ end
 
 TransferPackage.blueprint(:confirmed) do
   confirmed_at { Faker::Time.backward }
+end
+
+TransferPackage.blueprint(:receiver_confirmed) do
+  confirmed_at { Faker::Time.backward }
+  box_transfers { [
+    BoxTransfer.make(
+      transfer_package: object,
+      box: Box.make(:overfilled, institution: object.receiver_institution )
+    )
+  ] }
 end
 
 Batch.blueprint do
@@ -199,6 +208,23 @@ Box.blueprint(:filled) do
   samples { [
     Sample.make(:filled, box: object, institution: object.institution, site: object.site),
     Sample.make(:filled, box: object, institution: object.institution, site: object.site),
+  ] }
+end
+
+Box.blueprint(:overfilled) do
+  @batch_one = Batch.make!
+  @batch_two = Batch.make!
+
+  samples { [
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 1, concentration_number: 3, replicate: 1),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 2),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 3),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 1, concentration_number: 3, replicate: 4),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 2, concentration_number: 2, replicate: 5),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 3, concentration_number: 1, replicate: 6),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 1, concentration_number: 3, replicate: 7),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 8),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 9),
   ] }
 end
 

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -165,6 +165,7 @@ end
 TransferPackage.blueprint do
   uuid { SecureRandom.uuid }
   receiver_institution { Institution.make! }
+  receiver_institution { Institution.make! }
   sender_institution { Institution.make! }
   recipient { Faker::Name.name }
   box_transfers { [BoxTransfer.make(transfer_package: object)] }
@@ -172,16 +173,6 @@ end
 
 TransferPackage.blueprint(:confirmed) do
   confirmed_at { Faker::Time.backward }
-end
-
-TransferPackage.blueprint(:receiver_confirmed) do
-  confirmed_at { Faker::Time.backward }
-  box_transfers { [
-    BoxTransfer.make(
-      transfer_package: object,
-      box: Box.make(:overfilled, institution: object.receiver_institution )
-    )
-  ] }
 end
 
 Batch.blueprint do
@@ -208,23 +199,6 @@ Box.blueprint(:filled) do
   samples { [
     Sample.make(:filled, box: object, institution: object.institution, site: object.site),
     Sample.make(:filled, box: object, institution: object.institution, site: object.site),
-  ] }
-end
-
-Box.blueprint(:overfilled) do
-  @batch_one = Batch.make!
-  @batch_two = Batch.make!
-
-  samples { [
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 1, concentration_number: 3, replicate: 1),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 2),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 3),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 1, concentration_number: 3, replicate: 4),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 2, concentration_number: 2, replicate: 5),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 3, concentration_number: 1, replicate: 6),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 1, concentration_number: 3, replicate: 7),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 8),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 9),
   ] }
 end
 

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -174,16 +174,6 @@ TransferPackage.blueprint(:confirmed) do
   confirmed_at { Faker::Time.backward }
 end
 
-TransferPackage.blueprint(:receiver_confirmed) do
-  confirmed_at { Faker::Time.backward }
-  box_transfers { [
-    BoxTransfer.make(
-      transfer_package: object,
-      box: Box.make(:overfilled, institution: object.receiver_institution )
-    )
-  ] }
-end
-
 Batch.blueprint do
   institution { Institution.make }
   batch_number { "#{sn}" }
@@ -208,23 +198,6 @@ Box.blueprint(:filled) do
   samples { [
     Sample.make(:filled, box: object, institution: object.institution, site: object.site),
     Sample.make(:filled, box: object, institution: object.institution, site: object.site),
-  ] }
-end
-
-Box.blueprint(:overfilled) do
-  @batch_one = Batch.make!
-  @batch_two = Batch.make!
-
-  samples { [
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 1, concentration_number: 3, replicate: 1),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 2),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 3),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 1, concentration_number: 3, replicate: 4),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 2, concentration_number: 2, replicate: 5),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 3, concentration_number: 1, replicate: 6),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 1, concentration_number: 3, replicate: 7),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 8),
-    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 9),
   ] }
 end
 


### PR DESCRIPTION
Reverted the changes of #1746.

Diego and I performed a smoke test about functionality recovery and it's there. The full list of the use cases will be tested after the completion of all the functionalities of the stabilization stage of boxes V2 (#1771). 

Some tests written/modified in the reverted PR are useful and were kept, here is a list of them: 

- **Print floating box shouldn't be accessible to the receiver:** To accomplish this we recover in the specs setup the declaration of the floating box (and the confirmed box as well which is useful for some tests described below). Also, the method `load_box_print` within the boxes controller was kept in order to be able to access the floating and confirmed boxes. 
- **Inventory & print actions should be allowed if can read:** these are done over the confirmed transferred box and not over the box as were implemented in the PR (#1746). 
- **Inventory should be ordered by batch_number, concentration, replicate ASC:** The ordering of the inventory is verified in this test and corresponds with the use case described in (#1755), and is passing, this closes issue (#1768). 





