### PR TITLE
Fix/1769 blind checkbox from transfer to box detail

### DIFF
--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -149,12 +149,12 @@ class BoxesController < ApplicationController
 
   def box_params
     if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 0
-      params.require(:box).permit(:purpose, :media).tap do |allowed|
+      params.require(:box).permit(:purpose, :media, :blinded).tap do |allowed|
         allowed[:batch_uuids] = params[:box][:batch_uuids].try(&:permit!)
         allowed[:sample_uuids] = params[:box][:sample_uuids].try(&:permit!)
       end
     else
-      params.require(:box).permit(:purpose, :media, batch_uuids: {}, sample_uuids: [])
+      params.require(:box).permit(:purpose, :media, :blinded, batch_uuids: {}, sample_uuids: [])
     end
   end
 

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -126,7 +126,6 @@ class TransferPackagesController < ApplicationController
       :receiver_institution_id,
       :recipient,
       :includes_qc_info,
-      :blinded,
       box_transfers_attributes: [:box_id, :_destroy],
     )
   end

--- a/app/models/box_form.rb
+++ b/app/models/box_form.rb
@@ -10,6 +10,7 @@ class BoxForm
       institution: navigation_context.institution,
       site: navigation_context.site,
       purpose: params[:purpose],
+      blinded: params[:blinded],
     )
     new(box, params)
   end

--- a/app/models/transfer_package.rb
+++ b/app/models/transfer_package.rb
@@ -16,8 +16,6 @@ class TransferPackage < ApplicationRecord
   validates_presence_of :sender_institution
   validates_presence_of :receiver_institution
 
-  attr_accessor :blinded
-
   after_initialize do
     self.uuid ||= SecureRandom.uuid
   end
@@ -43,7 +41,6 @@ class TransferPackage < ApplicationRecord
       box = box_transfer.box
       box.attach_qc_info if includes_qc_info
       box.detach_from_context unless confirmed?
-      box.blinded = !!blinded
       box.save!
     end
   end

--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -47,6 +47,11 @@
               name: "box[sample_uuids]", placeholder: "Enter sample id", className: "input-block",
               samples: samples_data(@box_form.samples) }
 
+  .row
+    .col
+      = f.check_box :blinded
+      = f.label :blinded, "Blind samples (you'll be able to unblind them later from transfer details)"
+
   = f.form_actions do
     = f.submit 'Save', class: 'btn-primary', id: 'btn-save'
     = link_to 'Cancel', boxes_path, class: 'btn-link'

--- a/app/views/transfer_packages/_form.haml
+++ b/app/views/transfer_packages/_form.haml
@@ -18,11 +18,6 @@
       includeQcInfo: @transfer_package.includes_qc_info, boxes: boxes_data(@transfer_package.boxes))
     = f.field_errors :"box_transfers.box.sample"
 
-  .row
-    .col
-      = f.check_box :blinded
-      = f.label :blinded, "Blind samples (you'll be able to unblind them later from transfer details)"
-
   - if @can_update
     = f.form_actions do
       = f.submit 'Transfer', class: 'btn-primary', id: 'btn-save'

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe BoxesController, type: :controller do
     @other_institution = Institution.make!
     @other_user = @other_institution.user
 
-    @floating_transfer = TransferPackage.make! sender_institution: @institution, receiver_institution: @other_institution, blinded: true
+    @floating_transfer = TransferPackage.make! :blinded, sender_institution: @institution, receiver_institution: @other_institution
     @floating_box = @floating_transfer.box_transfers[0].box
 
-    @confirmed_transfer = TransferPackage.make! :receiver_confirmed, sender_institution: @institution, receiver_institution: @other_institution, blinded: true
+    @confirmed_transfer = TransferPackage.make! :receiver_confirmed, sender_institution: @institution, receiver_institution: @other_institution
     @confirmed_box = @confirmed_transfer.box_transfers[0].box
 
     grant @user, @other_user, @institution, READ_INSTITUTION
@@ -246,6 +246,7 @@ RSpec.describe BoxesController, type: :controller do
       {
         purpose: "LOD",
         batch_uuids: { "lod" => batch.uuid },
+        blinded: true,
       }
     end
 
@@ -276,7 +277,7 @@ RSpec.describe BoxesController, type: :controller do
 
     it "should create box with optional params" do
       expect do
-        post :create, params: { box: box_plan.merge(media: "Saliva") }
+        post :create, params: { box: box_plan.merge(media: "Saliva", blinded: true) }
         expect(response).to redirect_to boxes_path
       end.to change(institution.boxes, :count).by(1)
 
@@ -327,6 +328,7 @@ RSpec.describe BoxesController, type: :controller do
           post :create, params: { box: {
             purpose: "LOD",
             batch_uuids: { "lod" => batch.uuid },
+            blinded: true
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(28)
@@ -356,6 +358,7 @@ RSpec.describe BoxesController, type: :controller do
           post :create, params: { box: {
             purpose: "Variants",
             batch_uuids: batch_uuids,
+            blinded: true,
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(54)
@@ -386,6 +389,7 @@ RSpec.describe BoxesController, type: :controller do
               "variant_4" => batch.uuid,
               "variant_2" => other_batch.uuid,
             },
+            blinded: true,
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(18)
@@ -402,6 +406,7 @@ RSpec.describe BoxesController, type: :controller do
           post :create, params: { box: {
             purpose: "Challenge",
             batch_uuids: batch_uuids,
+            blinded: true,
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(108)
@@ -449,6 +454,7 @@ RSpec.describe BoxesController, type: :controller do
               "virus" => batch.uuid,
               "distractor_4" => distractor.uuid,
             },
+            blinded: true
           } }
           expect(response).to redirect_to(boxes_path)
         end.to change(institution.samples, :count).by(63)
@@ -466,7 +472,8 @@ RSpec.describe BoxesController, type: :controller do
               sample_uuids: {
                 "sample_0" => samples[0].uuid,
                 "sample_1" => samples[1].uuid,
-              }
+              },
+              blinded: true,
             } }
             expect(response).to redirect_to(boxes_path)
           end.to change(institution.samples, :count).by(0)

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -283,6 +283,7 @@ RSpec.describe BoxesController, type: :controller do
 
       box = assigns(:box_form).box.reload
       expect(box.samples.map(&:media).uniq).to eq(["Saliva"])
+      expect(box.blinded).to eq true
     end
 
     it "should create box if allowed" do

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -179,7 +179,16 @@ TransferPackage.blueprint(:receiver_confirmed) do
   box_transfers { [
     BoxTransfer.make(
       transfer_package: object,
-      box: Box.make(:overfilled, institution: object.receiver_institution )
+      box: Box.make(:overfilled_blinded, institution: object.receiver_institution )
+    )
+  ] }
+end
+
+TransferPackage.blueprint(:blinded) do
+  box_transfers { [
+    BoxTransfer.make(
+      transfer_package: object,
+      box: Box.make(:blinded, institution: object.receiver_institution )
     )
   ] }
 end
@@ -226,6 +235,32 @@ Box.blueprint(:overfilled) do
     Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 8),
     Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 9),
   ] }
+end
+
+Box.blueprint(:blinded) do
+  samples { [
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site),
+  ] }
+  blinded { true }
+end
+
+Box.blueprint(:overfilled_blinded) do
+  @batch_one = Batch.make!
+  @batch_two = Batch.make!
+
+  samples { [
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 1, concentration_number: 3, replicate: 1),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 2),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 3),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 1, concentration_number: 3, replicate: 4),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 2, concentration_number: 2, replicate: 5),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 3, concentration_number: 1, replicate: 6),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 1, concentration_number: 3, replicate: 7),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_two, concentration_exponent: 2, concentration_number: 2, replicate: 8),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, batch: @batch_one, concentration_exponent: 3, concentration_number: 1, replicate: 9),
+  ] }
+  blinded { true }
 end
 
 BoxTransfer.blueprint do


### PR DESCRIPTION
Closes #1769 and #1777.

The blind samples checkbox is now in the 'New Box' form and was removed from the transfers.

![image](https://user-images.githubusercontent.com/13782680/200030841-287c695d-b3f0-41be-bd84-ac0644b035a3.png)

Some comments about the code:
- The `blinded` param was removed from the `TransferPackages` controller and moved into the `Boxes` controller.
- The `BoxForm` build method read the param mentioned above.
- The `TransferPackage` model doesn't have the `attr_accessor :blinded` anymore, this has effects on several tests, where  `make!` was requiring it. New blueprints were created to `make!` transfers of blinded boxes. 
- The `blinded` attribute of the boxes is mandatory, tests creating boxes were modified accordingly to create the boxes with this attribute.
- The test verifying that transferring a box and blinding it was effectively blinding the samples was removed. There is already test for boxes that verify the correct blinding then no new tests were added. 

Functional tests made:
- A box is created unblinded, samples are unblinded for the creator, then is transferred, confirmed and samples remain unblinded for the receiver(#1777 solved!). The automatic blinding was happening.
- A box is created blinded, samples are blinded for the creator, then is transferred and confirmed, samples remain blinded for the receiver, then is unblinded, samples unblind for the receiver. 
