### PR TITLE
Fix/1776 printing blinded labels

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -117,12 +117,13 @@ class SamplesController < ApplicationController
 
   def print
     @sample = Sample.find(params[:id])
+    @sample_form = SamplePresenter.new(@sample, request.format)
     return unless authorize_resource(@sample, READ_SAMPLE)
 
     render pdf: "cdx_sample_#{@sample.uuid}",
       template: "samples/barcode.pdf",
       layout: "layouts/pdf.html",
-      locals: { :sample => @sample },
+      locals: { :sample => @sample_form },
       margin: { top: 0, bottom: 0, left: 0, right: 0 },
       page_width: "1in",
       page_height: "1in",
@@ -131,6 +132,7 @@ class SamplesController < ApplicationController
 
   def bulk_print
     samples = Sample.where(id: params[:sample_ids])
+    sample_forms = samples.each { |s| SamplePresenter.new(@sample, request.format) }
     return unless authorize_resources(samples, READ_SAMPLE)
 
     render pdf: "cdx_samples_#{samples.size}_#{DateTime.now.strftime("%Y%m%d-%H%M")}",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -132,13 +132,13 @@ class SamplesController < ApplicationController
 
   def bulk_print
     samples = Sample.where(id: params[:sample_ids])
-    sample_forms = samples.each { |s| SamplePresenter.new(@sample, request.format) }
+    sample_forms = samples.map { |s|  SamplePresenter.new(s, request.format) }
     return unless authorize_resources(samples, READ_SAMPLE)
 
     render pdf: "cdx_samples_#{samples.size}_#{DateTime.now.strftime("%Y%m%d-%H%M")}",
       template: "samples/bulk_print.pdf",
       layout: "layouts/pdf.html",
-      locals: { samples: samples.preload(:sample_identifiers) },
+      locals: { samples: sample_forms },
       margin: { top: 0, bottom: 0, left: 0, right: 0 },
       page_width: "1in",
       page_height: "1in",


### PR DESCRIPTION
To correctly print the blinded attributes, both in the normal and the bulk print, the `SamplePresenter` object is passed to the PDF generator (instead of `Sample` as it was before, which wasn't blinding. 

Before, incorrectly, blinded attributes were printed, now we can observe they don't: 
 
![image](https://user-images.githubusercontent.com/13782680/200394670-59f6b632-642f-4178-ab7c-7c9882fa904a.png)

