### PR TITLE
Simplify boxes transfer blinding flow - Stage 2

### DIFF
--- a/app/assets/stylesheets/_barcode_card.scss
+++ b/app/assets/stylesheets/_barcode_card.scss
@@ -66,17 +66,6 @@
   }
 }
 
-.barcode-after {
-  margin: 7px 15px 0;
-
-  .btn-icon {
-    margin: -3px 0 0;
-    font-size: 24px;
-    background: none !important;
-    color: inherit;
-  }
-}
-
 // Print Barcode style
 
 .barcode-card-print {
@@ -128,5 +117,18 @@
       width: 15px;
       height: auto;
     }
+  }
+}
+
+// INVENTORY
+
+.inventory-button {
+  margin: 6px 15px 0;
+
+  .btn-icon {
+    margin: -3px 0 0;
+    font-size: 24px;
+    background: none !important;
+    color: inherit;
   }
 }

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -23,7 +23,7 @@ class BoxesController < ApplicationController
 
   def inventory
     return unless authorize_resource(@box, READ_BOX)
-    return head :forbidden unless !(params[:unblind] && @box.transferred?)
+    return head :forbidden if params[:unblind] && @box.transferred?
 
     @samples = load_box_samples
 
@@ -104,7 +104,7 @@ class BoxesController < ApplicationController
   def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
     samples = samples.scrambled if @box.blinded?
-    SamplePresenter.map(samples, request.format, params[:unblind])
+    SamplePresenter.map(samples, request.format, unblind: params[:unblind])
   end
 
   def load_batches

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -103,7 +103,7 @@ class BoxesController < ApplicationController
   def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
     samples = samples.scrambled if @box.blinded?
-    SamplePresenter.map(samples, request.format)
+    SamplePresenter.map(samples, request.format, params[:unblind])
   end
 
   def load_batches

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -23,6 +23,7 @@ class BoxesController < ApplicationController
 
   def inventory
     return unless authorize_resource(@box, READ_BOX)
+    return head :forbidden unless !(params[:unblind] && @box.transferred?)
 
     @samples = load_box_samples
 

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -76,6 +76,8 @@ class TransferPackagesController < ApplicationController
     full_uuid = uuid.size == 36
     @boxes = Box
       .within(@navigation_context.entity, @navigation_context.exclude_subsites)
+      .left_joins(:box_transfers)
+      .where(box_transfers: {id: nil})
       .autocomplete(uuid)
       .order("created_at DESC")
       .count_samples

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -58,6 +58,7 @@ class TransferPackagesController < ApplicationController
     @transfer_package.box_transfers.each do |box_transfer|
       box = box_transfer.box
       raise "User not authorized for transferring box #{box.uuid}" unless authorize_resource?(box, UPDATE_BOX)
+      raise "Box was already transferred and cannot be transfered a second time" unless !box.transferred?
     end
 
     if @transfer_package.save

--- a/app/controllers/transfer_packages_controller.rb
+++ b/app/controllers/transfer_packages_controller.rb
@@ -58,7 +58,7 @@ class TransferPackagesController < ApplicationController
     @transfer_package.box_transfers.each do |box_transfer|
       box = box_transfer.box
       raise "User not authorized for transferring box #{box.uuid}" unless authorize_resource?(box, UPDATE_BOX)
-      raise "Box was already transferred and cannot be transfered a second time" unless !box.transferred?
+      raise "Box was already transferred and cannot be transfered a second time" if box.transferred?
     end
 
     if @transfer_package.save

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -91,4 +91,8 @@ class Box < ApplicationRecord
   def blind_attribute?(attr_name)
     Box.blind_attribute_names.include?(attr_name)
   end
+
+  def transferred?
+    box_transfers.exists?
+  end
 end

--- a/app/presenters/sample_presenter.rb
+++ b/app/presenters/sample_presenter.rb
@@ -1,11 +1,11 @@
 class SamplePresenter
   delegate_missing_to :@sample
 
-  def self.map(samples, format, unblind= false)
-    samples.map { |sample| new(sample, format, unblind) }
+  def self.map(samples, format, unblind: false)
+    samples.map { |sample| new(sample, format, unblind: unblind) }
   end
 
-  def initialize(sample, format, unblind= false)
+  def initialize(sample, format, unblind: false)
     @sample = sample
     @format = format
     @unblind = unblind

--- a/app/presenters/sample_presenter.rb
+++ b/app/presenters/sample_presenter.rb
@@ -1,13 +1,14 @@
 class SamplePresenter
   delegate_missing_to :@sample
 
-  def self.map(samples, format)
-    samples.map { |sample| new(sample, format) }
+  def self.map(samples, format, unblind= false)
+    samples.map { |sample| new(sample, format, unblind) }
   end
 
-  def initialize(sample, format)
+  def initialize(sample, format, unblind= false)
     @sample = sample
     @format = format
+    @unblind = unblind
   end
 
   def to_param
@@ -18,7 +19,7 @@ class SamplePresenter
 
   Box.blind_attribute_names.each do |attr_name|
     define_method attr_name do
-      if blinded_attribute?(attr_name)
+      if blinded_attribute?(attr_name) && !@unblind
         blinded_value
       else
         @sample.__send__(attr_name)

--- a/app/views/batches/_samples.haml
+++ b/app/views/batches/_samples.haml
@@ -3,7 +3,7 @@
     = check_box_tag 'select_all_samples'
     %label.row{for: "select_all_samples"}
     #count
-      = @batch_form.batch.samples.count.to_s + ' ' + "Samples"
+      = "#{@batch_form.batch.samples.count} Samples"
   .actions
     = button_tag id: 'bulk_print', class: 'btn-link', name: 'bulk_action', value: 'print' do
       .icon-print.btn-icon

--- a/app/views/boxes/_barcode_card.haml
+++ b/app/views/boxes/_barcode_card.haml
@@ -15,7 +15,6 @@
 
 
   .row.actions
-    - unless @box.blinded?
-      = link_to print_box_path(@box), target: "_blank", class: 'btn-link' do
-        .icon-print.btn-icon
-        %span Print box and sample labels
+    = link_to print_box_path(@box), target: "_blank", class: 'btn-link' do
+      .icon-print.btn-icon
+      %span Print box and sample labels

--- a/app/views/boxes/show.haml
+++ b/app/views/boxes/show.haml
@@ -30,17 +30,29 @@
       .col
         = render "barcode_card"
 
-        .barcode-after
-          = link_to inventory_box_path(@box, format: "csv"), target: "_blank", class: 'btn-link' do
-            .icon-download.btn-icon
-            %span Download inventory
-
 .row
+  .col.pe-3
+    %label Contents
   .col
     .row
       .col.pe-3
-        %label Contents
-      .col.pe-9
+        .samples-count
+          .title
+            = @box.samples.count.to_s + ' ' + "samples" + (@box.blinded ? ' (blinded)' : '' )
+      .col.pe-3
+        .inventory-button
+          = link_to inventory_box_path(@box, format: "csv"), target: "_blank", class: 'btn-link' do
+            .icon-download.btn-icon
+            %span Download inventory
+      - if @box.blinded && @box.box_transfers.count == 0
+        .col.pe-3
+          .inventory-button
+            = link_to inventory_box_path(@box, format: "csv", unblind: true), target: "_blank", class: 'btn-link' do
+              .icon-download.btn-icon
+              %span Download unblinded inventory
+
+    .row
+      .col
         - @samples.each do |sample|
           .col.pe-7.batches-samples
             .samples-row

--- a/app/views/boxes/show.haml
+++ b/app/views/boxes/show.haml
@@ -38,13 +38,13 @@
       .col.pe-3
         .samples-count
           .title
-            = @box.samples.count.to_s + ' ' + "samples" + (@box.blinded ? ' (blinded)' : '' )
+            = "#{@box.samples.count} samples" + (@box.blinded ? ' (blinded)' : '')
       .col.pe-3
         .inventory-button
           = link_to inventory_box_path(@box, format: "csv"), target: "_blank", class: 'btn-link' do
             .icon-download.btn-icon
             %span Download inventory
-      - if @box.blinded && @box.box_transfers.count == 0
+      - if @box.blinded && !@box.transferred?
         .col.pe-3
           .inventory-button
             = link_to inventory_box_path(@box, format: "csv", unblind: true), target: "_blank", class: 'btn-link' do

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -176,6 +176,21 @@ RSpec.describe BoxesController, type: :controller do
         expect(row[7]).to eq("Blinded")
       end
     end
+
+    it "don't blind columns for unblinded inventory" do
+      box = Box.make! :filled, institution: institution, blinded: true
+
+      get :inventory, params: { id: box.id, format: "csv", unblind: true }
+      expect(response).to have_http_status(:ok)
+
+      CSV.parse(response.body).tap(&:shift).each do |row|
+        expect(row[3]).not_to eq("Blinded")
+        expect(row[4]).not_to eq("Blinded")
+        expect(row[5]).not_to eq("Blinded")
+        expect(row[7]).not_to eq("Blinded")
+      end
+    end
+
   end
 
   describe "new" do


### PR DESCRIPTION
Closes #1775 and #1771.

Changes made to meet the acceptance criteria for the remaining issues of the boxes stabilization.

**Issue #1775 (Downloading and printing boxes)**:  there are comments to make only in one of the use cases described:

- `When the sender creates a blinded box, they can print the blinded labels and download the unblinded or the blinded inventory.`

_Respect to labels:_ 
Within the `/views/boxes/_barcode_card.haml` file there was the condition: " `unless @box.blinded?` show the print button",  which prevented showing the print button for blinded boxes. This condition was removed in order to allow the printing of blinded labels. 

_Respect to inventory:_ 
(This is also mentioned in #1755: "The Sender of the box can see an action for downloading an unblinded inventory. The Unblinded inventory action")

After discussing with @diegoliberman and @omelao this behavior was specified in the issue [#1786]( #https://github.com/instedd/cdx/issues/1786) which is actually in `open` state. 

This behavior was implemented and now it looks like this.

![image](https://user-images.githubusercontent.com/13782680/201651426-4fd3726a-ed53-4146-99f9-7548fbd62185.png)

I don't consider that the mentioned issue is closed because there are changes in style for this and other views considered in the issue that aren't part of this PR. 

With respect to the code, this button is implemented under the condition `@box.blinded && @box.box_transfers.count == 0`. If the box is unblinded is unnecessary and this button should not be accessible to box receivers. The style for the `Download Inventory` buttons was renamed, but kept in the `_barcode_card.scss`. There is no specific styles file for boxes, should I make a new styles file? 

The rest of the cases of #1775 work correctly.

**Issue #1771  and other test cases of #1755**:

- `Transferring more than once: "let's keep the prohibition to avoid risks, as we don't have a use case to justify a 2nd transfer"` 

Thanks to @omelao input, this was restored by adding 

```
      .left_joins(:box_transfers)
      .where(box_transfers: {id: nil})
```
To the `find_box` method on the `TransferPackagesController`. 

-  `The sender should be able to edit a box, but for now, just allow to edit the blind check box`

This behavior is not present actually and after discussion with @diegoliberman this will be implemented on the new increment, since actually when entering a box detail we are viewing them but not editing the boxes.

- `The user might want to manually change the concentration of some individual samples, after creating the box. a) An unblinded box can always be edited. b) A blinded box can be edited only if it doesn't have an associated transfer record.`

As the latter use case, will be implemented in the new increment.

The rest of the use cases were tested and worked correctly.







