### PR TITLE
Prevent same sample in multiple boxes

### DIFF
--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -116,6 +116,7 @@ class BoxesController < ApplicationController
   def load_samples
     Sample
       .within(@navigation_context.entity, @navigation_context.exclude_subsites)
+      .where(box_id: nil)
       .find_all_by_any_uuid(@box_form.sample_uuids.values.reject(&:blank?))
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -35,7 +35,7 @@ class SamplesController < ApplicationController
 
   def autocomplete
     samples = Sample
-      .where(institution: @navigation_context.institution)
+      .where(institution: @navigation_context.institution, box_id: nil)
       .within(@navigation_context.entity, @navigation_context.exclude_subsites)
 
     samples = samples.without_qc if params[:qc] == "0"


### PR DESCRIPTION
I added a filter on autocomplete
![image](https://user-images.githubusercontent.com/19227697/202265652-6fdc7b7a-e6c5-47c9-b894-b9dfdfc2b9f2.png)

And on box creation. But it can't be tested with the first filter.

If I disable the autocomplete filter, it will not count this sample on saving. Just for the cases that someone could try to force that sample on front end.
![image](https://user-images.githubusercontent.com/19227697/202266091-36739397-7665-49e6-a863-377a8e95800f.png)
