### PR TITLE
Ensure correct inventory ordering

### DIFF
--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -103,7 +103,7 @@ class BoxesController < ApplicationController
 
   def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
-    samples = if @box.blinded?
+    samples = if @box.blinded? && !params[:unblind] 
       samples.sort_by{ |sample|  [ sample.uuid ] }
     else
       samples.sort_by{ |sample|  [ sample.batch_number , sample.concentration , sample.replicate ] }

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -104,7 +104,7 @@ class BoxesController < ApplicationController
   def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
     samples = if @box.blinded? && !params[:unblind] 
-      samples.sort_by{ |sample|  [ sample.uuid ] }
+      samples.scrambled
     else
       samples.sort_by{ |sample|  [ sample.batch_number , sample.concentration , sample.replicate ] }
     end 

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -103,7 +103,11 @@ class BoxesController < ApplicationController
 
   def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
-    samples = samples.scrambled if @box.blinded?
+    samples = if @box.blinded?
+      samples.sort_by{ |sample|  [ sample.uuid ] }
+    else
+      samples.sort_by{ |sample|  [ sample.batch_number , sample.concentration , sample.replicate ] }
+    end 
     SamplePresenter.map(samples, request.format, unblind: params[:unblind])
   end
 

--- a/app/views/boxes/inventory.csv.csvbuilder
+++ b/app/views/boxes/inventory.csv.csvbuilder
@@ -5,8 +5,8 @@ csv << [
   "Batch ID",
   "Virus Lineage",
   "Replicate",
-  "Production Date",
   "Concentration",
+  "Production Date",
   "Inactivation Method",
   "Media",
 ]
@@ -19,8 +19,8 @@ csv << [
     sample.batch_number,
     sample.virus_lineage,
     sample.replicate,
-    sample.date_produced.to_date,
     sample.concentration,
+    sample.date_produced.to_date,
     sample.inactivation_method,
     sample.media,
   ]

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe BoxesController, type: :controller do
       results = CSV.parse(response.body).tap(&:shift).map do |row|
         { :batch_number => row[3], :concentration => row[6], :replicate => row[7] }
       end
-      expect( results ).to eq( results.sort_by{ |sample|  [ sample[:batch_number], sample[:concentration], sample[:replicate] ] } )
+      expect( results ).to eq( results.sort_by{ |sample|  [ sample.batch_number , sample.concentration, sample.replicate ] } )
     end
 
     it "should be allowed if can read" do

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe BoxesController, type: :controller do
         expect(row[3]).to eq("Blinded")
         expect(row[4]).to eq("Blinded")
         expect(row[5]).to eq("Blinded")
-        expect(row[7]).to eq("Blinded")
+        expect(row[6]).to eq("Blinded")
       end
     end
 
@@ -187,7 +187,7 @@ RSpec.describe BoxesController, type: :controller do
         expect(row[3]).not_to eq("Blinded")
         expect(row[4]).not_to eq("Blinded")
         expect(row[5]).not_to eq("Blinded")
-        expect(row[7]).not_to eq("Blinded")
+        expect(row[6]).not_to eq("Blinded")
       end
     end
 


### PR DESCRIPTION
Closes #1800.

Inventory ordering is now ensured. The problem was that the `sort_by` method was called in an incorrect manner, and the sort was made using `nil` values.

Debug info will help to understand, this is within the context of the line 106 of `load_box_samples`: 
```
>> samples[0]
=> #<Sample id: 1479, sensitive_data: "\x04\xC8\x84\xAD\x9BF\x97\xED#\xD27\xCD\xDE\x01\xE2\x9A", institution_id: 12, custom_fields: {}, core_fields: {"date_produced"=>2009-09-09 00:00:00 +0000, "lab_technician"=>"123", "specimen_role"=>"b", "isolate_name"=>"zzzx", "inactivation_method"=>"Formaldehyde", "concentration"=>"102e1", "replicate"=>"1", "media"=>"Culture media"}, created_at: "2022-11-17 09:07:22", updated_at: "2022-11-17 09:07:41", patient_id: nil, encounter_id: nil, is_phantom: true, deleted_at: nil, batch_id: 18, isolate_name: "zzzx", site_id: nil, site_prefix: nil, specimen_role: "b", old_batch_number: nil, qc_info_id: nil, box_id: 39>
>> samples[0][:concentration]
=> nil
>> samples[0].concentration
=> 1020
```

The spec checking correct ordering was modified accordingly.

 **Bonus:** As the issue specify, the `concentration` column of the inventory was moved next to the replicate, this required as well to modify a spec. 