### PR TITLE
fixed style qc-info-checkbox label

### DIFF
--- a/app/assets/stylesheets/_box_preview.scss
+++ b/app/assets/stylesheets/_box_preview.scss
@@ -22,3 +22,11 @@
   align-items: center;
   padding: 0 10px;
 }
+
+.qc-info-checkbox {
+  padding: 10px 10px 0px 10px;
+
+  label{
+    line-height: 35px;
+  }
+}


### PR DESCRIPTION
Closes #1799.

Style for `qc-info-checkbox` was added into `_box_preview.scss`. 

It was taken from `_sample_transfer_modal.scss`, a file that should not exist anymore since now there is no modal for transfers. This apply the correct padding to the whole checkbox and align correctly the label.

IMO the best way to do this was 

```
display: flex;
align-items: center;
```

but couldn't be done since styles were overwritten by form styles. Doing that doesn't fix the alignment as can be seen in the following image:

![image](https://user-images.githubusercontent.com/13782680/202435969-e768afd7-cb60-47bf-8258-e366f0d4503a.png)

While adjusting the line height works properly as can be seen here:

![image](https://user-images.githubusercontent.com/13782680/202436230-cdfc13a2-12fa-4a49-a0b9-03681e833a4f.png)

