### PR TITLE
Pattern to validate input of concentration field

### DIFF
--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -65,7 +65,7 @@
       = f.form_field :concentration do
         - @sample_form.blinded_attribute(:concentration) do
           .row.input-unit
-            = f.text_field :concentration, min:0, readonly: !@can_update, :class=> "input-medium", :value => humanize_concentration(@sample_form.concentration), :pattern => "[\\d.]+(?:e-?\\d+)?"
+            = f.text_field :concentration, min:0, readonly: !@can_update, :class=> "input-medium", :value => humanize_concentration(@sample_form.concentration), :pattern => "[\\d.]+(?:[eE]\\+?\\d+)?"
             .span.unit (copies/ml)
             
       = f.form_field :replicate do

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -65,7 +65,7 @@
       = f.form_field :concentration do
         - @sample_form.blinded_attribute(:concentration) do
           .row.input-unit
-            = f.text_field :concentration, min:0, readonly: !@can_update, :class=> "input-medium", :value => humanize_concentration(@sample_form.concentration)
+            = f.text_field :concentration, min:0, readonly: !@can_update, :class=> "input-medium", :value => humanize_concentration(@sample_form.concentration), :pattern => "[\\d.]+(?:e-?\\d+)?"
             .span.unit (copies/ml)
             
       = f.form_field :replicate do

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -65,7 +65,7 @@
       = f.form_field :concentration do
         - @sample_form.blinded_attribute(:concentration) do
           .row.input-unit
-            = f.text_field :concentration, min:0, readonly: !@can_update, :class=> "input-medium", :value => humanize_concentration(@sample_form.concentration), :pattern => "[\\d.]+(?:[eE]\\+?\\d+)?"
+            = f.text_field :concentration, min:0, readonly: !@can_update, :class=> "input-medium", :value => humanize_concentration(@sample_form.concentration), :pattern => "[\\d.]+(?:[eE]\\+?\\d+)?", :title => "(examples: 120, 12e1, 1.2e2, 1.2e+2, 1.2E2, 1.2E+2, 1.2E+02)"
             .span.unit (copies/ml)
             
       = f.form_field :replicate do


### PR DESCRIPTION
Closes #1795 

Added a pattern to `concentration` field to allow only for positive numbers allowing scientific notation or raw numbers.

![image](https://user-images.githubusercontent.com/13782680/202454959-6806fe59-1d4f-4fea-8cfa-61a846a0ce85.png)
