### PR TITLE
Fix for concentration migration

### DIFF
--- a/db/migrate/20221109105200_change_sample_concentrations_to_single_value.rb
+++ b/db/migrate/20221109105200_change_sample_concentrations_to_single_value.rb
@@ -5,7 +5,7 @@ class ChangeSampleConcentrationsToSingleValue < ActiveRecord::Migration
       exponent = sample.core_fields["concentration_exponent"].try(&:to_i)
 
       if number && exponent
-        sample.core_fields["concentration"] = number * (10**exponent)
+        sample.core_fields["concentration"] = number * (10**-exponent)
         sample.core_fields.delete("concentration_number")
         sample.core_fields.delete("concentration_exponent")
         sample.save!


### PR DESCRIPTION
Closes #1817 

Bug fix in concentrations migrations from two fields(`concentration_number` & `concentration_exponent`) into one field (`concentration`). Sign of the exponent was badly expressed as positive in the existant migration.

