### PR TITLE
Truncating institution name on box label

### DIFF
--- a/app/views/boxes/barcode.pdf.haml
+++ b/app/views/boxes/barcode.pdf.haml
@@ -8,7 +8,7 @@
     .code
       Box: #{box.samples.count} samples
     .code
-      Institution: #{box.institution.name}
+      Institution: #{(box.institution.name).truncate(9)}
     .code
       Purpose: #{box.purpose}
     .logo

--- a/app/views/boxes/barcode.pdf.haml
+++ b/app/views/boxes/barcode.pdf.haml
@@ -6,11 +6,9 @@
       .uuid
         #{box.uuid}
     .code
-      Box: #{box.samples.count} samples
+      #{(box.institution.name).truncate(22)}
     .code
-      Institution: #{(box.institution.name).truncate(9)}
-    .code
-      Purpose: #{box.purpose}
+      #{box.purpose} (#{box.samples.count} samples)
     .logo
       = image_tag wicked_pdf_asset_base64('cdx-logo-bw.png')
       .label https://cdx.io


### PR DESCRIPTION
Closes #1816 

Institution name is now truncated for institution name to avoid a new line that broke the label.

Before:

![image](https://user-images.githubusercontent.com/13782680/206133485-f6ee986c-56ee-47ad-be41-dab21e9ff2c9.png)

Now:

![image](https://user-images.githubusercontent.com/13782680/206133591-04d85ead-e6b8-4929-83e2-1e9f13d480ea.png)

Given that an ellipsis is used for truncating, there are only 6 characters displayed when the institution name exceeds the 9 characters, which is relatively short, maybe `Institution` can be shortened? (cc @diegoliberman) 


