### PR TITLE
GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,28 @@
 {
-  "dockerComposeFile": "../docker-compose.yml",
-  "service": "web",
-  "runServices": ["web", "db", "elasticsearch", "redis", "sidekiq", "selenium"],
-
-  "settings": {
-    "terminal.integrated.shell.linux": "/bin/bash"
-  },
-
+	"name": "Docker in Docker",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
   "features": {
+    "ghcr.io/devcontainers/features/common-utils": {
+      "installZsh": false,
+      "installOhMyZsh": false,
+      "uid": 1000,
+      "gid": 1000,
+      "nonFreePackages": true
+    },
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "dockerDashComposeVersion": "v2"
+    }
   }
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "docker --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
-  "onCreateCommand": "docker compose build && docker compose pull && docker compose run --rm --no-deps web bundle install",
+  "onCreateCommand": "docker compose build web sidekiq selenium && docker compose pull db elasticsearch redis && docker compose run --rm --no-deps web bundle install",
   "postCreateCommand": "docker compose run --rm web bin/rails db:setup elasticsearch:setup"
 
   // Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
-  "onCreateCommand": "docker compose pull --ignore-pull-failures; docker compose build; docker compose run --rm --no-deps web bundle install",
+  "onCreateCommand": "docker compose pull --ignore-pull-failures; docker compose build; docker compose run --rm web bundle install",
   "postCreateCommand": "docker compose run --rm web bin/rails db:setup elasticsearch:setup"
 
   // Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
-  "onCreateCommand": "docker compose build web sidekiq selenium; docker compose pull db elasticsearch redis; docker compose run --rm --no-deps web bundle install",
+  "onCreateCommand": "docker compose build; docker compose pull; docker compose run --rm --no-deps web bundle install",
   "postCreateCommand": "docker compose run --rm web bin/rails db:setup elasticsearch:setup"
 
   // Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "web",
+
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+
+  "features": {
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
-  "onCreateCommand": "docker compose build web sidekiq selenium && docker compose pull db elasticsearch redis && docker compose run --rm --no-deps web bundle install",
+  "onCreateCommand": "docker compose build web sidekiq selenium; docker compose pull db elasticsearch redis; docker compose run --rm --no-deps web bundle install",
   "postCreateCommand": "docker compose run --rm web bin/rails db:setup elasticsearch:setup"
 
   // Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,17 +17,8 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
-  "onCreateCommand": [
-    "docker compose build",
-    "docker compose pull",
-    "docker compose run --rm --no-deps web bundle install"
-  ],
-
-  "postCreateCommand": [
-    "docker compose run --rm web bin/rails db:setup",
-    "docker compose run --rm web bin/rails db:test:prepare",
-    "docker compose run --rm web bin/rails elasticsearch:setup"
-  ]
+  "onCreateCommand": "docker compose build && docker compose pull && docker compose run --rm --no-deps web bundle install",
+  "postCreateCommand": "docker compose run --rm web bin/rails db:setup elasticsearch:setup"
 
   // Configure tool-specific properties.
   // "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "dockerComposeFile": "docker-compose.yml",
+  "dockerComposeFile": "../docker-compose.yml",
   "service": "web",
 
   "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
-	"name": "Docker in Docker",
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+  "name": "Docker in Docker",
+  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
   "features": {
     "ghcr.io/devcontainers/features/common-utils": {
       "installZsh": false,
@@ -9,20 +9,20 @@
       "gid": 1000,
       "nonFreePackages": true
     },
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "dockerDashComposeVersion": "v2"
     }
   }
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "docker --version",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "docker --version",
 
-	// Configure tool-specific properties.
-	// "customizations": {},
+  // Configure tool-specific properties.
+  // "customizations": {},
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
-  "onCreateCommand": "docker compose build; docker compose pull; docker compose run --rm --no-deps web bundle install",
+  "onCreateCommand": "docker compose pull --ignore-pull-failures; docker compose build; docker compose run --rm --no-deps web bundle install",
   "postCreateCommand": "docker compose run --rm web bin/rails db:setup elasticsearch:setup"
 
   // Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "dockerComposeFile": "../docker-compose.yml",
   "service": "web",
+  "runServices": ["web", "db", "elasticsearch", "redis", "sidekiq", "selenium"],
 
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,13 +12,22 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "dockerDashComposeVersion": "v2"
     }
-  }
+  },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
-  // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "docker --version",
+  "onCreateCommand": [
+    "docker compose build",
+    "docker compose pull",
+    "docker compose run --rm --no-deps web bundle install"
+  ],
+
+  "postCreateCommand": [
+    "docker compose run --rm web bin/rails db:setup",
+    "docker compose run --rm web bin/rails db:test:prepare",
+    "docker compose run --rm web bin/rails elasticsearch:setup"
+  ]
 
   // Configure tool-specific properties.
   // "customizations": {},


### PR DESCRIPTION
Creates the basic devcontainer configuration for GitHub Codespaces.

It starts a devcontainer (required by codespaces) with docker in docker and compose support. Once started it pulls and builds the docker images required by CDx, and runs a few commands to setup the dev environment (i.e. ruby dependencies, db setup).

Once the codespace is started, you can run `docker compose up web` on a VScode terminal, and port 3000 should automatically be exposed.

TODO: we should use a [browserless image](https://hub.docker.com/r/browserless/chrome) that exposes a webpage with a VNC server (or something like that) instead of the custom `selenium` images, that is only useful for CI / running system tests quickly, but bad for writing tests (you can't see what's happening). For local dev, we redirect to a geckodriver/chromedriver running on the host, but we can't do that in a codespace, which runs remotely.

NOTE: VScode web is _very_ sluggish (at least in Firefox). Be it the code editor, the Git or Terminal panes, everything is slow. It probably fares better when running in a local VScode desktop with the GitHub codespaces extension.