### PR TITLE
Automatic unblinding for samples with uploaded measurements

### DIFF
--- a/app/presenters/sample_presenter.rb
+++ b/app/presenters/sample_presenter.rb
@@ -33,7 +33,7 @@ class SamplePresenter
 
   def blinded_attribute?(attr_name)
     if box = @sample.box
-      box.blinded? && !!box.blind_attribute?(attr_name)
+      (box.blinded? && !!box.blind_attribute?(attr_name)) && !@sample.measured_signal
     else
       false
     end

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -82,6 +82,10 @@
         - else
           = f.text_field :media, readonly: true
 
+      - if @sample_form.measured_signal
+        = f.form_field :measured_signal do
+          = f.text_field :measured_signal, readonly: true
+
   .col
     = render (@can_update ? 'form_assays' : 'show_assays'), f: f
 


### PR DESCRIPTION
Closes #1735 .

Sample data is unblinded when `measured_signal` field is defined. Also, is shown as read-only in the sample's form when it is displayed.

![image](https://user-images.githubusercontent.com/13782680/208087098-5e0d94d4-b97c-4c9c-b37c-854febcf6228.png)

With respect to the issue specification: unblind action was not removed since it applies for boxes and this implementation applies for individual samples. **Small consistency issue: theoretically, if almost all results are uploaded for samples of a box, the rest could be "inferred" if the contents of how the box are made are known, while I don't think this is really an issue to take care of, I mention it**. (cc @diegoliberman).

