### PR TITLE
Feature/1807 custom confirm modal

### DIFF
--- a/app/assets/javascripts/components/confirmation_modal.js.jsx
+++ b/app/assets/javascripts/components/confirmation_modal.js.jsx
@@ -51,8 +51,8 @@ var ConfirmationModal = React.createClass({
     return this.props.deletion ? "btn-primary btn-danger" : "btn-primary";
   },
   
-  titleClass: function() {
-    return this.props.titleClass ? this.props.titleClass : "";
+  colorClass: function() {
+    return this.props.colorClass ? this.props.colorClass : "";
   },
   
   showCancelButton: function() {
@@ -66,8 +66,8 @@ var ConfirmationModal = React.createClass({
     }
     return (
       <Modal ref="confirmationModal" show="true">
-        <h1 className={this.titleClass()}>{this.modalTitle()}</h1>
-        <div className="modal-content" dangerouslySetInnerHTML={this.message()}>
+        <h1 className={this.colorClass()}>{this.modalTitle()}</h1>
+        <div className={this.colorClass()+ " modal-content"} dangerouslySetInnerHTML={this.message()}>
         </div>
         <div className="modal-footer button-actions">
           <button type="button" className={this.confirmButtonClass()} onClick={this.onConfirm}>{this.confirmMessage()}</button>

--- a/app/assets/javascripts/components/confirmation_modal.js.jsx
+++ b/app/assets/javascripts/components/confirmation_modal.js.jsx
@@ -66,13 +66,13 @@ var ConfirmationModal = React.createClass({
     }
     return (
       <Modal ref="confirmationModal" show="true">
-      <h1 className={this.titleClass()}>{this.modalTitle()}</h1>
-      <div className="modal-content" dangerouslySetInnerHTML={this.message()}>
-      </div>
-      <div className="modal-footer button-actions">
-      <button type="button" className={this.confirmButtonClass()} onClick={this.onConfirm}>{this.confirmMessage()}</button>
-      { cancelButton }
-      </div>
+        <h1 className={this.titleClass()}>{this.modalTitle()}</h1>
+        <div className="modal-content" dangerouslySetInnerHTML={this.message()}>
+        </div>
+        <div className="modal-footer button-actions">
+          <button type="button" className={this.confirmButtonClass()} onClick={this.onConfirm}>{this.confirmMessage()}</button>
+          { cancelButton }
+        </div>
       </Modal>
       );
     }

--- a/app/assets/javascripts/components/confirmation_modal.js.jsx
+++ b/app/assets/javascripts/components/confirmation_modal.js.jsx
@@ -1,50 +1,64 @@
 var ConfirmationModal = React.createClass({
-
+  
   modalTitle: function() {
     return this.props.title || (this.props.deletion ? "Delete confirmation" : "Confirmation");
   },
-
+  
   cancelMessage: function() {
     return this.props.cancelMessage || "Cancel";
   },
-
+  
   confirmMessage: function() {
     return this.props.confirmMessage || (this.props.deletion ? "Delete" : "Confirm");
   },
-
+  
   componentDidMount: function() {
     this.refs.confirmationModal.show();
   },
-
+  
   onCancel: function() {
-    this.refs.confirmationModal.hide();
-		if (this.props.target instanceof Function ) {
-		this.props.cancel_target();	
-	}
-
+    if (this.props.cancelFunction) {
+      window[this.props.cancelFunction]();
+    }
+    else{
+      this.refs.confirmationModal.hide();
+      if (this.props.target instanceof Function ) {
+        this.props.cancel_target();	
+      }
+    }    
   },
-
+  
   onConfirm: function() {
-		if (this.props.target instanceof Function ) {
-	  this.props.target();	
-	} else {
-    window[this.props.target]();
-  }
-    this.refs.confirmationModal.hide();
+    if (this.props.confirmFunction) {
+      window[this.props.confirmFunction]();
+    }
+    else
+    { 
+      if (this.props.target instanceof Function ) {
+        this.props.target();	
+      } else {
+        window[this.props.target]();
+      }
+      this.refs.confirmationModal.hide();
+    }
   },
-
+  
   message: function() {
     return {__html: this.props.message};
   },
-
+  
   confirmButtonClass: function() {
     return this.props.deletion ? "btn-primary btn-danger" : "btn-primary";
   },
-
+  
+  titleClass: function() {
+    return this.props.titleClass ? this.props.titleClass : "";
+  },
+  
   showCancelButton: function() {
     return this.props.hideCancel != true;
   },
-
+  
   render: function() {
     var cancelButton = null;
     if (this.showCancelButton()) {
@@ -52,14 +66,15 @@ var ConfirmationModal = React.createClass({
     }
     return (
       <Modal ref="confirmationModal" show="true">
-        <h1>{this.modalTitle()}</h1>
-        <div className="modal-content" dangerouslySetInnerHTML={this.message()}>
-        </div>
-        <div className="modal-footer button-actions">
-          <button type="button" className={this.confirmButtonClass()} onClick={this.onConfirm}>{this.confirmMessage()}</button>
-          { cancelButton }
-        </div>
+      <h1 className={this.titleClass()}>{this.modalTitle()}</h1>
+      <div className="modal-content" dangerouslySetInnerHTML={this.message()}>
+      </div>
+      <div className="modal-footer button-actions">
+      <button type="button" className={this.confirmButtonClass()} onClick={this.onConfirm}>{this.confirmMessage()}</button>
+      { cancelButton }
+      </div>
       </Modal>
-    );
-  }
-});
+      );
+    }
+  });
+  

--- a/app/assets/javascripts/styled_confirmation.js
+++ b/app/assets/javascripts/styled_confirmation.js
@@ -11,6 +11,7 @@ var reactConfirmationModalConfirmationAction = null;
 $.rails.showConfirmationDialog = function(link){
   var message = link.data("confirm");
   var title = link.data("confirm-title");
+  var titleClass = link.data("confirm-title-class");
   var hideCancel = link.data("confirm-hide-cancel");
   var confirmButtonMessage = link.data('confirm-button-message');
   var confirmationModalContainer = $('#confirmationModalContainer')
@@ -43,6 +44,6 @@ $.rails.showConfirmationDialog = function(link){
 
   confirmationModalContainer.append($("<div>")
     .attr('data-react-class', 'ConfirmationModal')
-    .attr('data-react-props', JSON.stringify({message: message, title: title, target: 'reactConfirmationModalConfirmationAction', deletion: link.data('method') == 'delete', hideCancel: hideCancel, confirmMessage: confirmButtonMessage })));
+    .attr('data-react-props', JSON.stringify({message: message, title: title, target: 'reactConfirmationModalConfirmationAction', deletion: link.data('method') == 'delete', hideCancel: hideCancel, confirmMessage: confirmButtonMessage, titleClass: titleClass })));
   cdx_init_components(confirmationModalContainer);
 }

--- a/app/assets/javascripts/styled_confirmation.js
+++ b/app/assets/javascripts/styled_confirmation.js
@@ -11,7 +11,7 @@ var reactConfirmationModalConfirmationAction = null;
 $.rails.showConfirmationDialog = function(link){
   var message = link.data("confirm");
   var title = link.data("confirm-title");
-  var titleClass = link.data("confirm-title-class");
+  var colorClass = link.data("color-class");
   var hideCancel = link.data("confirm-hide-cancel");
   var confirmButtonMessage = link.data('confirm-button-message');
   var confirmationModalContainer = $('#confirmationModalContainer')
@@ -44,6 +44,6 @@ $.rails.showConfirmationDialog = function(link){
 
   confirmationModalContainer.append($("<div>")
     .attr('data-react-class', 'ConfirmationModal')
-    .attr('data-react-props', JSON.stringify({message: message, title: title, target: 'reactConfirmationModalConfirmationAction', deletion: link.data('method') == 'delete', hideCancel: hideCancel, confirmMessage: confirmButtonMessage, titleClass: titleClass })));
+    .attr('data-react-props', JSON.stringify({message: message, title: title, target: 'reactConfirmationModalConfirmationAction', deletion: link.data('method') == 'delete', hideCancel: hideCancel, confirmMessage: confirmButtonMessage, colorClass: colorClass })));
   cdx_init_components(confirmationModalContainer);
 }

--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -36,9 +36,6 @@
       padding: 30px 45px;
       border-bottom: 1px solid $gray1;
 
-      &.red {
-        color: $red;
-      }
     }
 
     h2 {
@@ -73,6 +70,10 @@
     }
     &.small {
       min-width: 250px;
+    }
+
+    .red {
+      color: $red;
     }
   }
 }

--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -35,6 +35,10 @@
       margin: 0 -45px 30px;
       padding: 30px 45px;
       border-bottom: 1px solid $gray1;
+
+      &.red {
+        color: $red;
+      }
     }
 
     h2 {

--- a/app/views/samples/_upload_results_js.haml
+++ b/app/views/samples/_upload_results_js.haml
@@ -1,4 +1,7 @@
 :javascript
+    var cancelFunc = function() {}
+    var confirmFunc = function() {}
+
     var getUrlParameter = function getUrlParameter(sParam) {
         var sPageURL = window.location.search.substring(1),
             sURLVariables = sPageURL.split('&'),
@@ -65,10 +68,11 @@
                 var not_found = samples.filter(function(x) {
                     return found.indexOf(x) < 0;
                 });
-                
+
                 // Create row from template with filename and upload info
                 var template = document.getElementById(`csvFileRow`).content;
                 var fragment = template.cloneNode(true);
+
                 fragment.querySelector(`.uploaded-samples-count`).textContent = `${samples.length} Samples ` ;
                 if (found.length != samples.length){
                     fragment.querySelector(`.uploaded-samples-count`).innerHTML += `(<span class="dashed-underline">${(not_found.length)} sample UUID${(not_found.length>1?'s':'')}</span> not found) `
@@ -98,8 +102,22 @@
                 fragment.querySelector(".remove_file").upload_info = fragment.querySelector(`.upload_info`)
                 fragment.querySelector(".remove_file").addEventListener('click', removeFileRow, false)
 
+                // If some samples were not found, show a warning modal
+                if (not_found.length > 0) {
+                    document.querySelector(`.results-upload-error-modal-container`).style.visibility = 'visible';
+                    confirmFunc = function() {
+                        console.log("this continue")
+                        document.querySelector(`.results-upload-error-modal-container`).style.visibility = 'hidden';
+                    }
+                    cancelFunc = function() {
+                        var removeFileNodes = document.querySelectorAll(".remove_file")
+                        removeFileNodes[removeFileNodes.length-1].click()
+                        document.querySelector(`.results-upload-error-modal-container`).style.visibility = 'hidden';
+                    }
+                }
+
                 document.getElementById(`uploaded-files`).append(fragment)
-                
+
                 checkUploadEnabling();
             }
         })(f);

--- a/app/views/samples/_upload_results_js.haml
+++ b/app/views/samples/_upload_results_js.haml
@@ -106,7 +106,6 @@
                 if (not_found.length > 0) {
                     document.querySelector(`.results-upload-error-modal-container`).style.visibility = 'visible';
                     confirmFunc = function() {
-                        console.log("this continue")
                         document.querySelector(`.results-upload-error-modal-container`).style.visibility = 'hidden';
                     }
                     cancelFunc = function() {

--- a/app/views/samples/upload_results.haml
+++ b/app/views/samples/upload_results.haml
@@ -24,7 +24,7 @@
 
   .row
     .col
-      = button_tag id: 'bulk_process_csv', class: 'btn-primary', name: 'bulk_action', value: 'process_csv', disabled: true, data: { confirm_title_class: "red", confirm_button_message: "Continue", method: "delete", confirm_title: "Warning", confirm: "This action will unblind samples and cannot be undone. <br><br> Samples' with previously uploaded measurements won't be overwritten. <br><br> " } do
+      = button_tag id: 'bulk_process_csv', class: 'btn-primary', name: 'bulk_action', value: 'process_csv', disabled: true, data: { color_class: "red", confirm_button_message: "Continue", method: "delete", confirm_title: "Warning", confirm: "This action will unblind samples and cannot be undone. <br><br> Samples' with previously uploaded measurements won't be overwritten. <br><br> " } do
         Upload Results
       = link_to 'Cancel', samples_path, class: 'btn-link'
 
@@ -48,7 +48,7 @@
                       cancelFunction: "cancelFunc",
                       confirmFunction: "confirmFunc", 
                       id: "my-confirmation-modal", 
-                      titleClass: "red", 
+                      colorClass: "red", 
                       confirmMessage: "Skip invalid IDs", 
                       title: "Results Upload Error", 
                       message: "Some IDs found on this CSV don't exist, please remove those rows and try again. ")

--- a/app/views/samples/upload_results.haml
+++ b/app/views/samples/upload_results.haml
@@ -44,6 +44,7 @@
 
 .results-upload-error-modal-container.hidden
   = react_component("ConfirmationModal", 
+                      deletion: true,
                       cancelFunction: "cancelFunc",
                       confirmFunction: "confirmFunc", 
                       id: "my-confirmation-modal", 

--- a/app/views/samples/upload_results.haml
+++ b/app/views/samples/upload_results.haml
@@ -24,7 +24,7 @@
 
   .row
     .col
-      = button_tag id: 'bulk_process_csv', class: 'btn-primary', name: 'bulk_action', value: 'process_csv', disabled: true, data: { method: "process_csv", confirm: "This action will unblind samples and cannot be undone. <br> Samples with uploaded measurements won't be overwritten. " } do
+      = button_tag id: 'bulk_process_csv', class: 'btn-primary', name: 'bulk_action', value: 'process_csv', disabled: true, data: { confirm_title_class: "red", confirm_button_message: "Continue", method: "delete", confirm_title: "Warning", confirm: "This action will unblind samples and cannot be undone. <br><br> Samples' with previously uploaded measurements won't be overwritten. <br><br> " } do
         Upload Results
       = link_to 'Cancel', samples_path, class: 'btn-link'
 
@@ -41,5 +41,15 @@
 
 %template{:id => "csvInputFile"}
   = file_field_tag "csv_files[]", hidden: true, class: "csv_file", accept: "text/csv"
+
+.results-upload-error-modal-container.hidden
+  = react_component("ConfirmationModal", 
+                      cancelFunction: "cancelFunc",
+                      confirmFunction: "confirmFunc", 
+                      id: "my-confirmation-modal", 
+                      titleClass: "red", 
+                      confirmMessage: "Skip invalid IDs", 
+                      title: "Results Upload Error", 
+                      message: "Some IDs found on this CSV don't exist, please remove those rows and try again. ")
 
 = render 'upload_results_js'


### PR DESCRIPTION
Closes #1807 & #1808. 

When a file containing invalid IDs is uploaded a modal to confirm the upload is shown as in the [mockup](https://projects.invisionapp.com/d/main#/console/4103589/470842165/preview):

![image](https://user-images.githubusercontent.com/13782680/210346425-7a6bac8d-c8b9-40d8-9d36-da3eb8be5872.png)

Also, a warning message is shown in a modal to confirm the measurements uploading, as in [this mockup](https://projects.invisionapp.com/d/main#/console/4103589/470792646/preview)

![image](https://user-images.githubusercontent.com/13782680/210346485-6b9e417f-7d0c-409b-afdd-f00701c68a3e.png)

Some notes:
- An extra warning before uploading was added with respect to the message in the mockup.
- A unique class to color the contents of the modal was added (`red`) and this same class modify the title and the text of the modal. Maybe is better to add two separate props to the modal? The name was chosen to make explicit that modifying other than the color will make the modal look not ok since the title and the content will apply the same class.
- There were introduced two props to the `ConfirmModal` class to call callback functions and use this component as a regular modal and not just as a confirm submission one (thanks Julien <3). 
- The `confirmation_modal.js.jsx` file was really old and I removed the tabs to indent with spaces as in the rest of the project. 