### PR TITLE
Box label mismatch between PDF and UI

### DIFF
--- a/app/views/boxes/_barcode_card.haml
+++ b/app/views/boxes/_barcode_card.haml
@@ -6,18 +6,9 @@
       .uuid
         #{@box.uuid}
     .code
-      %strong
-        Box:
-      = @box.samples.count
-      samples
+      #{(@box.institution.name).truncate(35)}
     .code
-      %strong
-        Institution:
-      = @box.institution.name
-    .code
-      %strong
-        Purpose:
-      #{@box.purpose}
+      #{@box.purpose} (#{@box.samples.count} samples)
     .logo
       = image_tag 'cdx-logo-bw.png'
       .label https://cdx.io


### PR DESCRIPTION
Closes #1826.

UI box label was modified to look as in the PDF. 

![image](https://user-images.githubusercontent.com/13782680/210773903-be12f76d-0c4e-4194-886b-c5245e35dff7.png)

The truncation of the institution name is set to 35 characters instead of the 22 of the PDF, calculated on how the label displays modifying the screen width.
