### PR TITLE
Change samples source empty selector component in box creation

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -18,12 +18,6 @@ function cdx_select_on_change(name, callback) {
   });
 }
 
-$(document).on("change", ".radiotoggle input", function(){
-  $(".radiotoggle input").each(function(i, field) {
-    $("#" + field.value).hide().attr("disabled", true);
-  });
-  $("#" + this.value).removeAttr("disabled").show();
-});
 /*
 This is kind of a exception solution. Because input date's behavior are different.
 Consider this points:

--- a/app/assets/javascripts/components/batches_selector.js.jsx
+++ b/app/assets/javascripts/components/batches_selector.js.jsx
@@ -10,7 +10,7 @@ var BatchesSelector = React.createClass({
       list: [],
     };
   },
-  reset : function() {
+  reset: function() {
     this.setState({
       batches: [],
       samples: this.props.samples,
@@ -23,7 +23,6 @@ var BatchesSelector = React.createClass({
   },
   render: function () {
     let button;
-    let clearButton = <a className="clear-batches" href="#" onClick={this.reset}></a>;
     if (this.state.batches.length > 0) {
       button = '';
     } else {
@@ -36,7 +35,7 @@ var BatchesSelector = React.createClass({
     }
 
     return (<div className="batches-selector">
-      {clearButton}
+      <a className="clear-batches" href="#" onClick={this.reset}></a>
       <div className="items-count">
         <div className="title">{this.state.list.length}&nbsp;{this.state.list.length == 1 ? "batch" : "batches"}</div>
       </div>

--- a/app/assets/javascripts/components/batches_selector.js.jsx
+++ b/app/assets/javascripts/components/batches_selector.js.jsx
@@ -10,9 +10,20 @@ var BatchesSelector = React.createClass({
       list: [],
     };
   },
-
+  reset : function() {
+    this.setState({
+      batches: [],
+      samples: this.props.samples,
+      concentration: null,
+      replicate: null,
+      distractor: null,
+      instruction: null,
+      list: [],
+    });
+  },
   render: function () {
     let button;
+    let clearButton = <a className="clear-batches" href="#" onClick={this.reset}></a>;
     if (this.state.batches.length > 0) {
       button = '';
     } else {
@@ -25,6 +36,7 @@ var BatchesSelector = React.createClass({
     }
 
     return (<div className="batches-selector">
+      {clearButton}
       <div className="items-count">
         <div className="title">{this.state.list.length}&nbsp;{this.state.list.length == 1 ? "batch" : "batches"}</div>
       </div>

--- a/app/assets/javascripts/components/samples_selector.js.jsx
+++ b/app/assets/javascripts/components/samples_selector.js.jsx
@@ -4,14 +4,12 @@ var SamplesSelector = React.createClass({
       samples: this.props.samples,
     };
   },
-  reset : function() {
+  reset: function() {
     this.setState({ samples: [] });
   },
   render: function () {
-    let clearButton = <a className="clear-samples" href="#" onClick={this.reset}></a>;
-    
     return (<div className="samples-selector">
-      {clearButton}
+      <a className="clear-samples" href="#" onClick={this.reset}></a>
       {this.renderTitle()}
       {this.state.samples.map(this.renderSample)}
 

--- a/app/assets/javascripts/components/samples_selector.js.jsx
+++ b/app/assets/javascripts/components/samples_selector.js.jsx
@@ -4,9 +4,14 @@ var SamplesSelector = React.createClass({
       samples: this.props.samples,
     };
   },
-
+  reset : function() {
+    this.setState({ samples: [] });
+  },
   render: function () {
+    let clearButton = <a className="clear-samples" href="#" onClick={this.reset}></a>;
+    
     return (<div className="samples-selector">
+      {clearButton}
       {this.renderTitle()}
       {this.state.samples.map(this.renderSample)}
 

--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -57,50 +57,52 @@
 
 :javascript
   
-  var confirmSampleSourceChange = function() {}
-  var cancelSampleSourceChange = function() {}
-
   var sourcesRadio = document.querySelectorAll(".radiotoggle input");
   var oldSource = null;
+  var confirmSampleSourceChange;
 
   var applySampleSourceChange = function (displayField) {
     // Hide all the fields and disable them
     sourcesRadio.forEach(function(otherRadio) {
-      document.querySelector(`#${otherRadio.value}`).style.display = 'none';
-      document.querySelector(`#${otherRadio.value}`).setAttribute("disabled", true);
+      document.getElementById(otherRadio.value).style.display = 'none';
+      document.getElementById(otherRadio.value).setAttribute("disabled", true);
     });
     // Show the selected field and enable it
-    document.querySelector(`#${displayField.value}`).style.display = 'block';
-    document.querySelector(`#${displayField.value}`).removeAttribute("disabled");
+    document.getElementById(displayField.value).style.display = 'block';
+    document.getElementById(displayField.value).removeAttribute("disabled");
     // Clear the selectors contents
     document.querySelector(".clear-batches").click()
     document.querySelector(".clear-samples").click()
   }
 
+  function showConfirmModal() {
+    document.querySelector(`.sample-source-change-modal-container`).style.visibility = 'visible';
+  }
+
+  function hideConfirmModal() {
+    document.querySelector(`.sample-source-change-modal-container`).style.visibility = 'hidden';
+  }
+
+  function confirmSampleSourceChangeFn() {
+    applySampleSourceChange(this);
+    hideConfirmModal();
+    // Update the old source only if the user confirmed the change
+    oldSource = this;
+  }
+  function cancelSampleSourceChange() {
+    hideConfirmModal();
+    // Check back the old source since it was not changed
+    oldSource.checked = true;
+  }  
+
   sourcesRadio.forEach(function(radio) {
     radio.addEventListener("change", function(evt) {
-      var thisField = this;
-
-      confirmSampleSourceChange = function() {
-        applySampleSourceChange(thisField);
-        document.querySelector(`.sample-source-change-modal-container`).style.visibility = 'hidden';
-        // Update the old source only if the user confirmed the change
-        oldSource = thisField;
-      }
-      
-      cancelSampleSourceChange = function() {
-        document.querySelector(`.sample-source-change-modal-container`).style.visibility = 'hidden';
-        // Check back the old source since it was not changed
-        oldSource.checked = true;
-      }
-
       if (oldSource) {
-        // If the user changed the source, show the modal
-        document.querySelector(`.sample-source-change-modal-container`).style.visibility = 'visible';
+        confirmSampleSourceChange = confirmSampleSourceChangeFn.bind(this)
+        showConfirmModal();
       } else {
         // For the first time, simulate that the user clicked on the confirm button
-        confirmSampleSourceChange();
+        confirmSampleSourceChangeFn.call(this);
       }
     });
   });
-

--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -43,3 +43,64 @@
   = f.form_actions do
     = f.submit 'Save', class: 'btn-primary', id: 'btn-save'
     = link_to 'Cancel', boxes_path, class: 'btn-link'
+
+.sample-source-change-modal-container.hidden
+  = react_component("ConfirmationModal", 
+                      deletion: true,
+                      cancelFunction: "cancelSampleSourceChange",
+                      confirmFunction: "confirmSampleSourceChange", 
+                      id: "sample-source-confirmation-modal", 
+                      colorClass: "red", 
+                      confirmMessage: "Continue", 
+                      title: "Warning", 
+                      message: "If you change the sample source, the box contents will be emptied. ")
+
+:javascript
+  
+  var confirmSampleSourceChange = function() {}
+  var cancelSampleSourceChange = function() {}
+
+  var sourcesRadio = document.querySelectorAll(".radiotoggle input");
+  var oldSource = null;
+
+  var applySampleSourceChange = function (displayField) {
+    // Hide all the fields and disable them
+    sourcesRadio.forEach(function(otherRadio) {
+      document.querySelector(`#${otherRadio.value}`).style.display = 'none';
+      document.querySelector(`#${otherRadio.value}`).setAttribute("disabled", true);
+    });
+    // Show the selected field and enable it
+    document.querySelector(`#${displayField.value}`).style.display = 'block';
+    document.querySelector(`#${displayField.value}`).removeAttribute("disabled");
+    // Clear the selectors contents
+    document.querySelector(".clear-batches").click()
+    document.querySelector(".clear-samples").click()
+  }
+
+  sourcesRadio.forEach(function(radio) {
+    radio.addEventListener("change", function(evt) {
+      var thisField = this;
+
+      confirmSampleSourceChange = function() {
+        applySampleSourceChange(thisField);
+        document.querySelector(`.sample-source-change-modal-container`).style.visibility = 'hidden';
+        // Update the old source only if the user confirmed the change
+        oldSource = thisField;
+      }
+      
+      cancelSampleSourceChange = function() {
+        document.querySelector(`.sample-source-change-modal-container`).style.visibility = 'hidden';
+        // Check back the old source since it was not changed
+        oldSource.checked = true;
+      }
+
+      if (oldSource) {
+        // If the user changed the source, show the modal
+        document.querySelector(`.sample-source-change-modal-container`).style.visibility = 'visible';
+      } else {
+        // For the first time, simulate that the user clicked on the confirm button
+        confirmSampleSourceChange();
+      }
+    });
+  });
+


### PR DESCRIPTION
Closes #1778.

When the source of samples in box creation is changed, a warning message is shown:

![image](https://user-images.githubusercontent.com/13782680/213431118-dd1f6918-f3f0-4635-9d6b-d247af3bb9cd.png)

To accomplish this, react selector components reset to empty state by clicking a hidden `<a>`. It's the best way I found to apply changes within React components from plain javascript. Not sure it's the best way. 

The javascript is commented because it has some complexity (should I put it in a separate file? don't know if it's a rule to do it or not). At least, some jquery is gone :) 
