### PR TITLE
GHA: speed up overall time

### DIFF
--- a/.github/actions/docker-cache/action.yml
+++ b/.github/actions/docker-cache/action.yml
@@ -1,11 +1,11 @@
-name: Docker cache
+name: Docker Compose cache
 
 inputs:
   docker-images:
     default: ""
 
   version:
-    default: "v0"
+    default: "v1"
 
 outputs:
   cache-hit:
@@ -32,6 +32,6 @@ runs:
     - name: Build Docker image
       if: steps.docker-cache.outputs.cache-hit != 'true'
       run: |
-        docker-compose build --build-arg TARGETARCH=amd64
+        docker compose build
         docker save ${{ inputs.docker-images }} > tmp/docker/docker_images.tar
       shell: bash

--- a/.github/actions/docker-cache/action.yml
+++ b/.github/actions/docker-cache/action.yml
@@ -1,37 +1,32 @@
-name: Docker Compose cache
+name: Docker cache
 
 inputs:
-  docker-images:
-    default: ""
+  context:
+    default: .
+
+  dockerfile:
+    default: Dockerfile
+
+  image:
+    type: string
+
+  tag:
+    default: latest
 
   version:
-    default: "v1"
-
-outputs:
-  cache-hit:
-    value: ${{ steps.docker-cache.outputs.cache-hit }}
+    default: v2
 
 runs:
   using: composite
 
   steps:
-    - uses: actions/cache@v3
-      id: docker-cache
+    - uses: docker/setup-buildx-action@v2
+
+    - uses: docker/build-push-action@v3
       with:
-        path: tmp/docker
-        key: Docker-${{ inputs.version }}-${{ hashFiles('Dockerfile*', 'docker-compose*') }}
-        restore-keys: |
-          Docker-${{ inputs.version }}-
-
-    - name: Load Docker image
-      if: steps.docker-cache.outputs.cache-hit == 'true'
-      run: |
-        docker load < tmp/docker/docker_images.tar
-      shell: bash
-
-    - name: Build Docker image
-      if: steps.docker-cache.outputs.cache-hit != 'true'
-      run: |
-        docker compose build
-        docker save ${{ inputs.docker-images }} > tmp/docker/docker_images.tar
-      shell: bash
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ inputs.image }}:${{ inputs.tag }}
+        cache-from: type=gha,scope=docker-${{ inputs.version }}-${{ hashFiles('Dockerfile*') }} \
+        cache-to: type=gha,mode=max,scope=docker-${{ inputs.version }}-${{ hashFiles('Dockerfile*') }}
+        load: true # export the image from buildx cache & load into docker (sloooooooow)

--- a/.github/actions/gems-cache/action.yml
+++ b/.github/actions/gems-cache/action.yml
@@ -23,7 +23,6 @@ runs:
     - name: Install gems
       if: steps.gems-cache.outputs.cache-hit != 'true'
       run: |
-        docker compose create sshd
         docker compose run --rm --no-deps -e BUNDLE_GEMFILE $COMPOSE_DEFAULT_SERVICE bash -c "bundle install --jobs 4 --retry 3 && bundle clean --force"
         sudo chown -R "$(id -u):$(id -g)" vendor/bundle
       shell: bash

--- a/.github/actions/gems-cache/action.yml
+++ b/.github/actions/gems-cache/action.yml
@@ -23,6 +23,7 @@ runs:
     - name: Install gems
       if: steps.gems-cache.outputs.cache-hit != 'true'
       run: |
-        docker-compose run --rm --no-deps -e BUNDLE_GEMFILE $COMPOSE_DEFAULT_SERVICE bash -c "bundle install --jobs 4 --retry 3 && bundle clean --force"
+        docker compose create sshd
+        docker compose run --rm --no-deps -e BUNDLE_GEMFILE $COMPOSE_DEFAULT_SERVICE bash -c "bundle install --jobs 4 --retry 3 && bundle clean --force"
         sudo chown -R "$(id -u):$(id -g)" vendor/bundle
       shell: bash

--- a/.github/actions/setup-databases/action.yml
+++ b/.github/actions/setup-databases/action.yml
@@ -1,0 +1,17 @@
+name: Setup databases
+
+runs:
+  using: composite
+
+  steps:
+    # pull, create and start services
+    - run: docker compose up -d db elasticsearch redis
+      shell: bash
+
+    # wait for MySQL to have started
+    - run: timeout 60s sh -c "while ! nc -z $(docker inspect cdx-db-1 | jq -r '.[0].NetworkSettings.Networks.cdx_default.IPAddress') 3306; do sleep 1; done"
+      shell: bash
+
+    # create the databases
+    - run: docker compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
+      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ env:
   COMPOSE_DEFAULT_SERVICE: web
   BUNDLE_GEMFILE: ${{ inputs.gemfile }}
   BUNDLE_LOCKFILE: ${{ inputs.gemfile }}.lock
-  SELENIUM_URL: http://cdx_selenium_%{test_env_number}:4444/ # dealing with docker-compose v1 name (https://github.com/instedd/cdx/pull/1644)
 
 jobs:
   setup:
@@ -21,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/docker-cache
         with:
-          docker-images: cdx_web cdx_selenium
+          docker_images: cdx_web cdx_selenium
       - uses: ./.github/actions/gems-cache
 
   unit:
@@ -34,11 +33,11 @@ jobs:
 
       - name: Setup databases
         run: |
-          docker-compose up -d db elasticsearch redis
-          docker-compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
+          docker compose up -d db elasticsearch redis
+          docker compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
 
       - name: Run specs
-        run: docker-compose run --rm -e RAILS_ENV=test -e COVERAGE=true web bundle exec rspec
+        run: docker compose run --rm -e RAILS_ENV=test -e COVERAGE=true web bundle exec rspec
 
       - run: cp coverage/.resultset.json resultset.unit_tests.json
 
@@ -58,17 +57,17 @@ jobs:
 
       - name: Setup databases
         run: |
-          docker-compose up -d db elasticsearch redis
-          docker-compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
+          docker compose up -d db elasticsearch redis
+          docker compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
 
       - name: Start services (Selenium)
-        run: docker-compose up -d selenium
+        run: docker compose up -d selenium
 
       - name: Run specs (capybara)
-        run: docker-compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e FEATURES=true -e SELENIUM_URL web bundle exec rspec
+        run: docker compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e FEATURES=true -e SELENIUM_URL web bundle exec rspec
 
       - name: Run specs (cucumber)
-        run: docker-compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e SELENIUM_URL web bundle exec cucumber
+        run: docker compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e SELENIUM_URL web bundle exec cucumber
 
       - run: cp coverage/.resultset.json resultset.integration_tests.json
 
@@ -94,7 +93,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: integration_tests_coverage
-      - run: docker-compose run --no-deps --rm web bundle exec rails coverage:report
+      - run: docker compose run --no-deps --rm web bundle exec rails coverage:report
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
         type: string
 
 env:
+  DOCKER_BUILDKIT: "1"
+  COMPOSE_DOCKER_CLI_BUILD: "1"
   COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml
   COMPOSE_DEFAULT_SERVICE: web
   BUNDLE_GEMFILE: ${{ inputs.gemfile }}
@@ -18,9 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/docker-cache
-        with:
-          docker_images: cdx_web cdx_selenium
       - uses: ./.github/actions/gems-cache
 
   unit:
@@ -28,13 +27,9 @@ jobs:
     needs: setup
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/docker-cache
+      - run: docker compose build web
       - uses: ./.github/actions/gems-cache
-
-      - name: Setup databases
-        run: |
-          docker compose up -d db elasticsearch redis
-          docker compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
+      - uses: ./.github/actions/setup-databases
 
       - name: Run specs
         run: docker compose run --rm -e RAILS_ENV=test -e COVERAGE=true web bundle exec rspec
@@ -52,16 +47,10 @@ jobs:
     needs: setup
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/docker-cache
+      - run: docker compose build web
       - uses: ./.github/actions/gems-cache
-
-      - name: Setup databases
-        run: |
-          docker compose up -d db elasticsearch redis
-          docker compose run --rm -e RAILS_ENV=test web bundle exec rake db:setup db:test:prepare elasticsearch:setup
-
-      - name: Start services (Selenium)
-        run: docker compose up -d selenium
+      - uses: ./.github/actions/setup-databases
+      - run: docker compose up -d selenium
 
       - name: Run specs (capybara)
         run: docker compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e FEATURES=true -e SELENIUM_URL web bundle exec rspec
@@ -84,7 +73,6 @@ jobs:
       - integration
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/docker-cache
       - uses: ./.github/actions/gems-cache
 
       - uses: actions/download-artifact@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,14 @@ services:
     volumes:
       - .:/src
       - bundle:/usr/local/bundle
+      - ./tmp/keys:/etc/ssh/keys
+      - ./tmp/.ssh:/home/cdx-sync/.ssh
+      - ./tmp/sync:/home/cdx-sync/tmp/sync
     command: /bin/true
 
   web:
     <<: *base
     pid: host
-    volumes_from:
-      - sshd
     # tty: true
     ports:
       - "3000:3000"
@@ -63,11 +64,13 @@ services:
     image: instedd/cdx-sync-sshd
     environment:
       SYNC_UID: 9999
+    volumes:
+      - ./tmp/keys:/etc/ssh/keys
+      - ./tmp/.ssh:/home/cdx-sync/.ssh
+      - ./tmp/sync:/home/cdx-sync/tmp/sync
 
   csv_watch:
     <<: *base
-    volumes_from:
-      - sshd
     command: /bin/sh -c 'rake csv:watch'
 
   ftp_monitor:


### PR DESCRIPTION
- Enables BuildKit for slightly faster builds.
- Disables GHA cache of dev Docker images (`docker save` & `docker load` are slow);
- Implements but disables the `buildx` with GHA cache (again because `docker load` is slow);
- Let's Compose build the image it needs when it needs (or will need them).

The `docker save` and `docker load` commands are so slow that they ruin all benefit of using the GHA cache. It's faster to build the image (~30s) than exporting the image from the buildx cache and loading the image into docker (~40s) despite the image being fully cached (~8s) :shrug: 

Note: using an Alpine based image might help to build smaller images? The eventual production image build might benefit from GHA?