### PR TITLE
Reduce blank space in modals

### DIFF
--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -17,7 +17,6 @@
   .modal {
     background: $white;
     min-width: 500px;
-    min-height: 400px;
     padding: 0px 50px 100px 50px;
     box-shadow: 0px 1px 15px 0px rgba(0, 0, 0, 0.6);
     margin-top: -5%;
@@ -56,6 +55,10 @@
     .item-search {
       width: 100%;
       position:relative;
+    }
+
+    .modal-content {
+      padding-bottom: 30px;
     }
 
     .modal-footer {


### PR DESCRIPTION
Closes #1851. 

All modals along CDx now adapt their height to the contents displayed. This applies to the new custom modals:

![image](https://user-images.githubusercontent.com/13782680/214273892-d1bb675c-4e68-46cd-8514-8cef575cf872.png)

but also for the old confirmation modals:

![image](https://user-images.githubusercontent.com/13782680/214274880-fb7153bf-0d35-4d7c-a45f-cf5cb17decf4.png)
