### PR TITLE
Space added between lines in not found sample uuids tooltip

### DIFF
--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -490,6 +490,12 @@ ul.samples {
 
 }
 
+.not-found-uuids {
+  line-height: 2 !important;
+  color: #EB2122 !important; 
+  width: 300px !important;
+}
+
 .ttip {
   position: relative;
   display: inline-block;

--- a/app/views/samples/_upload_results_js.haml
+++ b/app/views/samples/_upload_results_js.haml
@@ -96,7 +96,6 @@
                     var ttext = fragment.querySelector(".ttext")
                     ttext.innerHTML = not_found.slice(0,5).join("<br>")
                     // Modify classList here won't work because of class order
-                    ttext.style = `color: #EB2122; width: 300px;`
                     fragment.querySelector(".not_found_message").tooltip = ttext
                     fragment.querySelector(".not_found_message").addEventListener('click', showToolTip, false )
                 }

--- a/app/views/samples/upload_results.haml
+++ b/app/views/samples/upload_results.haml
@@ -46,7 +46,7 @@
       .items-row-action.gap-5.not_found_message
         .uploaded-samples-count
         .upload-icon.bigger
-        .ttext.hidden
+        .ttext.not-found-uuids.hidden
 
 %template{:id => "csvInputFile"}
   = file_field_tag "csv_files[]", hidden: true, class: "csv_file", accept: "text/csv"


### PR DESCRIPTION
Closes #1852.

Now, the tooltip of not founded UUIDs in the upload sample results respects the [mockup](https://projects.invisionapp.com/d/main#/console/4103589/470792645/preview) separation between lines.

How it looks
![image](https://user-images.githubusercontent.com/13782680/214336599-9a036ada-d246-4c27-9a2f-e2750a768aac.png)

Before I was setting the styles inline in the javascript because they were overwritten, I changed this into a new class and set the properties to `!important`. 