### PR TITLE
Warn unconfirmed replicates/copies when adding batch to a box

### DIFF
--- a/app/assets/javascripts/components/batches_selector.js.jsx
+++ b/app/assets/javascripts/components/batches_selector.js.jsx
@@ -117,6 +117,9 @@ var BatchesSelector = React.createClass({
                 </div>
               </div>
             </div>
+            <span className="warn hidden" id="unconfirmed-copies-warning">
+              To add the batch, you must confirm the replicates & concentrations above by pressing the blue check. If you don't want to add them, please erase the fields.
+            </span>
           </div>
         </div>
         <div className="col">
@@ -204,6 +207,11 @@ var BatchesSelector = React.createClass({
   },
   addList: function (event) {
     event.preventDefault();
+
+    if (parseInt(this.state.replicate) >0 || parseInt(this.state.concentration) >0 ){
+      document.getElementById("unconfirmed-copies-warning").classList.remove("hidden");
+      return 
+    }
     var list = this.state.list;
     var batches = this.state.batches;
     batches[0].samples = batches[0].samples.map( (sample) => {

--- a/app/assets/javascripts/components/batches_selector.js.jsx
+++ b/app/assets/javascripts/components/batches_selector.js.jsx
@@ -225,6 +225,7 @@ var BatchesSelector = React.createClass({
   },
   addConcentration: function (event) {
     event.preventDefault();
+    document.getElementById("unconfirmed-copies-warning").classList.add("hidden");
     if (parseInt(this.state.replicate) >0 && parseInt(this.state.concentration) >0 ){
       this.state.batches[0].samples.push({ replicate: this.state.replicate, concentration: this.state.concentration });
       this.setState({concentration: null });


### PR DESCRIPTION
Close #1847 .

When adding a new batch to a box through the option "create new samples", if there are unconfirmed replicates/concentrations the user is warned about it:

![image](https://user-images.githubusercontent.com/13782680/214608339-62df3965-a358-4fb1-8426-8aebd8bc0112.png)

It was implemented in this and not by showing a custom modal for two reasons: 
- codewise it was complex (or required big changes in code) 
- adding the warning message there is more consistent with the "form errors" and points the user towards the place where the action is required.

