### PR TITLE
Don't allow to create Box Report without sample with results

### DIFF
--- a/app/models/samples_report.rb
+++ b/app/models/samples_report.rb
@@ -46,8 +46,8 @@ class SamplesReport < ApplicationRecord
   private
 
   def there_are_samples
-    samples_with_results = samples_report_samples.select { |srs| !srs.sample.measured_signal.nil? }
-    errors.add(:base, "Please select a box containing samples with results") if samples_with_results.empty?
+    samples_with_measurements = samples_report_samples.select { |srs| !srs.sample.measured_signal.nil? }
+    errors.add(:base, "The selected box should contain samples with uploaded measurements") if samples_with_measurements.empty?
   end
 
 end

--- a/app/models/samples_report.rb
+++ b/app/models/samples_report.rb
@@ -46,7 +46,8 @@ class SamplesReport < ApplicationRecord
   private
 
   def there_are_samples
-    errors.add(:base, "Please select a box containing samples with results") if samples_report_samples.empty?
+    samples_with_results = samples_report_samples.select { |srs| !srs.sample.measured_signal.nil? }
+    errors.add(:base, "Please select a box containing samples with results") if samples_with_results.empty?
   end
 
 end

--- a/app/views/samples_reports/_form.haml
+++ b/app/views/samples_reports/_form.haml
@@ -11,7 +11,7 @@
           maxBoxes: 1,
           caller: "samples_reports",
           boxes: boxes_data(@boxes))
-        = f.field_errors :"samples_report_samples"
+        = f.field_errors :samples_report_samples
 
   = f.form_actions do
     = f.submit 'Generate Report', class: 'btn-primary'

--- a/app/views/samples_reports/_form.haml
+++ b/app/views/samples_reports/_form.haml
@@ -11,7 +11,7 @@
           maxBoxes: 1,
           caller: "samples_reports",
           boxes: boxes_data(@boxes))
-        = f.field_errors :"samples_report_samples "
+        = f.field_errors :"samples_report_samples"
 
   = f.form_actions do
     = f.submit 'Generate Report', class: 'btn-primary'

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe BoxesController, type: :controller do
     end
 
     it "blinds columns for Samples" do
-      box = Box.make! :filled, institution: institution, blinded: true
+      box = Box.make! :filled_without_measurements, institution: institution, blinded: true
 
       get :inventory, params: { id: box.id, format: "csv" }
       expect(response).to have_http_status(:ok)
@@ -205,6 +205,20 @@ RSpec.describe BoxesController, type: :controller do
         expect(row[4]).to eq("Blinded")
         expect(row[5]).to eq("Blinded")
         expect(row[6]).to eq("Blinded")
+      end
+    end
+
+    it "don't blind columns columns for samples with uploaded measurements" do
+      box = Box.make! :filled, institution: institution, blinded: true
+
+      get :inventory, params: { id: box.id, format: "csv" }
+      expect(response).to have_http_status(:ok)
+
+      CSV.parse(response.body).tap(&:shift).each do |row|
+        expect(row[3]).not_to eq("Blinded")
+        expect(row[4]).not_to eq("Blinded")
+        expect(row[5]).not_to eq("Blinded")
+        expect(row[6]).not_to eq("Blinded")
       end
     end
 

--- a/spec/controllers/samples_reports_controller_spec.rb
+++ b/spec/controllers/samples_reports_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SamplesReportsController, type: :controller do
 
     @box = Box.make!(:overfilled, institution: @institution, purpose: "LOD")
     @box2 = Box.make!(:filled, institution: @institution, purpose: "Challenge")
-    @box_without_measurements = Box.make!(:without_measurements, institution: @institution, purpose: "LOD")
+    @box_without_measurements = Box.make!(:filled_without_measurements, institution: @institution, purpose: "LOD")
 
     @samples_report = SamplesReport.create(institution: @institution, samples_report_samples: @box.samples.map{|s| SamplesReportSample.new(sample: s)}, name: "Test")
     @samples_report2 = SamplesReport.create(institution: @institution, samples_report_samples: @box2.samples.map{|s| SamplesReportSample.new(sample: s)}, name: "Test2")

--- a/spec/controllers/samples_reports_controller_spec.rb
+++ b/spec/controllers/samples_reports_controller_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe SamplesReportsController, type: :controller do
     @other_institution = Institution.make! user: @other_user
 
     @box = Box.make!(:overfilled, institution: @institution, purpose: "LOD")
-    @samples_report = SamplesReport.create(institution: @institution, samples_report_samples: @box.samples.map{|s| SamplesReportSample.new(sample: s)}, name: "Test")
     @box2 = Box.make!(:filled, institution: @institution, purpose: "Challenge")
+    @box_without_measurements = Box.make!(:without_measurements, institution: @institution, purpose: "LOD")
+
+    @samples_report = SamplesReport.create(institution: @institution, samples_report_samples: @box.samples.map{|s| SamplesReportSample.new(sample: s)}, name: "Test")
     @samples_report2 = SamplesReport.create(institution: @institution, samples_report_samples: @box2.samples.map{|s| SamplesReportSample.new(sample: s)}, name: "Test2")
 
     grant @user, @other_user, @institution, READ_INSTITUTION
@@ -95,6 +97,17 @@ RSpec.describe SamplesReportsController, type: :controller do
         expect(response).to have_http_status(:forbidden)
       end.to change(institution.samples_reports, :count).by(0)
     end
+
+    it "should not create samples report if there is no measurements" do
+      sign_in other_user
+      
+      expect do
+        post :create, params: { samples_report: { name: "TestWithoutMeasurements", samples_report_samples_attributes: @box_without_measurements.samples.map{|s| {sample_id: s.id}} } }
+        expect(response).to have_http_status(:forbidden)
+      end.to change(institution.samples_reports, :count).by(0)
+    end
+
+    
   end
   
   describe "index" do

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -259,7 +259,7 @@ Box.blueprint(:filled) do
   ] }
 end
 
-Box.blueprint(:without_measurements) do
+Box.blueprint(:filled_without_measurements) do
   samples { [
     Sample.make(:filled, box: object, institution: object.institution, site: object.site, measured_signal: nil),
     Sample.make(:filled, box: object, institution: object.institution, site: object.site, measured_signal: nil),

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -176,6 +176,7 @@ Sample.blueprint(:filled) do
   isolate_name { Faker::Name.name }
   specimen_role { "p" }
   date_produced { Faker::Time.backward }
+  measured_signal { 10.0 }
 end
 
 Sample.blueprint(:batch) do
@@ -255,6 +256,13 @@ Box.blueprint(:filled) do
   samples { [
     Sample.make(:filled, box: object, institution: object.institution, site: object.site),
     Sample.make(:filled, box: object, institution: object.institution, site: object.site),
+  ] }
+end
+
+Box.blueprint(:without_measurements) do
+  samples { [
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, measured_signal: nil),
+    Sample.make(:filled, box: object, institution: object.institution, site: object.site, measured_signal: nil),
   ] }
 end
 


### PR DESCRIPTION
Closes #1870.

Don't allow creating box reports if there isn't at least one sample with results on it. 
Is a fix to a validation implemented incorrectly, without it, plots won't work ok. 