### PR TITLE
Ignoring blank lines when uploading sample results csvs

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -208,7 +208,7 @@ class SamplesController < ApplicationController
       CSV.open(csv_file.path) do |csv_stream|
         csv_stream.each do |row|
           sample_id, measured_signal = row[0], row[1]
-          next if !sample_id.match(uuid_regex) # non uuids are ignored
+          next if !sample_id || !sample_id.match(uuid_regex) # non uuids are ignored
           sample = Sample.find_by_uuid(sample_id)
           unless sample.nil?
             sample.measured_signal ||= Float(measured_signal) if measured_signal.present?

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -208,7 +208,7 @@ class SamplesController < ApplicationController
       CSV.open(csv_file.path) do |csv_stream|
         csv_stream.each do |row|
           sample_id, measured_signal = row[0], row[1]
-          next if !sample_id || !sample_id.match(uuid_regex) # non uuids are ignored
+          next unless sample_id&.match(uuid_regex) # non uuids are ignored
           sample = Sample.find_by_uuid(sample_id)
           unless sample.nil?
             sample.measured_signal ||= Float(measured_signal) if measured_signal.present?


### PR DESCRIPTION
Close #1874 

When the uploaded CSV for sample results have blank lines, they produce an error since there are no fields to be matched with the `uuid` regex. Now, if a blank line is present it is ignored.

