### PR TITLE
Speed up login for feature specs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,4 +262,8 @@ Rails.application.routes.draw do
   end
 
   get 'nndd' => 'application#nndd' if Rails.env.test?
+
+  if Rails.env.test?
+    get "/tests/user_token_authentication", to: "tests#user_token_authentication"
+  end
 end

--- a/spec/features/performance_spec.rb
+++ b/spec/features/performance_spec.rb
@@ -11,27 +11,28 @@ describe "performance", elasticsearch: true do
   before(:each) {
     device_spec_helper.import_sample_json device, 'genexpert_sample.json'
     device_spec_helper.import_sample_json device, 'genexpert_sample_qc.json'
-    sign_in(user)
+    # FIXME: for some reason tests will start failing if we don't go through the
+    #        login form to authenticate the user (?!)
+    sign_in(user, login_form: true)
   }
-
-  after(:each) { Timecop.return }
 
   it "should have 2 test results" do
     expect(device.test_results.count).to eq(2)
   end
 
   it "dashboard charts should hide qc tests" do
-    Timecop.travel(Time.utc(2015, 9, 1))
-    goto_page DashboardPage do |page|
-      expect(page.tests_run.pie_chart.total.text).to eq("1")
+    Timecop.travel(Time.utc(2015, 9, 1)) do
+      goto_page DashboardPage do |page|
+        expect(page.tests_run.pie_chart.total.text).to eq("1")
+      end
     end
   end
 
   it "device charts should hide qc tests" do
-    Timecop.travel(Time.utc(2015, 9, 1))
-    goto_page DevicePage, id: device.id do |page|
-      page.tab_header.performance.click # FIXME: this click shouldn't be needed
-      expect(page.tests_run.pie_chart.total.text).to eq("1")
+    Timecop.travel(Time.utc(2015, 9, 1)) do
+      goto_page DevicePage, id: device.id do |page|
+        expect(page.tests_run.pie_chart.total.text).to eq("1")
+      end
     end
   end
 end

--- a/spec/support/feature_spec_helpers.rb
+++ b/spec/support/feature_spec_helpers.rb
@@ -68,7 +68,7 @@ module FeatureSpecHelpers
 
   def goto_page(klass, args = {})
     page = klass.new
-    load_page_with_retries(page, args)
+    load_page_with_retries(page, args, attempts: 3)
     yield page if block_given?
   end
 
@@ -86,16 +86,16 @@ module FeatureSpecHelpers
 
   private
 
-  def load_page_with_retries(page, args, attempts: 0)
+  def load_page_with_retries(page, args, attempts: 3)
     begin
       page.load(args)
     rescue Net::ReadTimeout
       # Selenium and/or the browser may not be ready yet (especially on CI) so
       # let's retry a few times...
-      if (attempts += 1) == 3
-        retry
-      else
+      if (attempts -= 1) < 0
         raise
+      else
+        retry
       end
     end
   end

--- a/spec/support/feature_spec_helpers.rb
+++ b/spec/support/feature_spec_helpers.rb
@@ -1,3 +1,27 @@
+class TestsController < ActionController::Base
+  @@tokens = {}
+
+  def self.create_token_for(user)
+    token = SecureRandom.uuid
+    @@tokens[token] = user
+    token
+  end
+
+  def user_token_authentication
+    if user = @@tokens.delete(params.fetch(:token))
+      sign_in(user)
+      head :ok
+    else
+      handle_unverified_request
+      head :unauthorized
+    end
+  end
+end
+
+class UserTokenAuthenticationPage < SitePrism::Page
+  set_url "/tests/user_token_authentication{?query*}"
+end
+
 module FeatureSpecHelpers
   extend ActiveSupport::Concern
 
@@ -16,41 +40,35 @@ module FeatureSpecHelpers
     dm.test_results.first
   end
 
-  def sign_in(user)
-    if user.password.nil?
-      # change password of user
-      user.password = 'password'
-      user.password_confirmation = 'password'
-      user.save!
-    end
-
-    goto_page HomePage do |page|
-      unless page.has_form?
-        page.user_menu.icon.click
-        page.user_menu.logout.click
+  def sign_in(user, login_form: false)
+    if login_form
+      # slow: load the login form, fill the form, submit, get redirected to the
+      # dashboard page, wait for the page to be loaded...
+      if user.password.nil?
+        # change password of user
+        user.password = 'password'
+        user.password_confirmation = 'password'
+        user.save!
       end
-      page.form.user_name.set user.email
-      page.form.password.set user.password
-      page.form.login.click
+
+      goto_page HomePage do |page|
+        unless page.has_form?
+          page.user_menu.icon.click
+          page.user_menu.logout.click
+        end
+        page.form.user_name.set user.email
+        page.form.password.set user.password
+        page.form.login.click
+      end
+    else
+      # fast: single token request to immediately sign the user in:
+      goto_page(UserTokenAuthenticationPage, { query: { token: TestsController.create_token_for(user) } })
     end
   end
 
   def goto_page(klass, args = {})
     page = klass.new
-
-    attempts = 0
-    begin
-      page.load args
-    rescue Net::ReadTimeout
-      # Selenium and/or the browser may not be ready yet (especially on CI) so
-      # let's retry a few times...
-      if (attempts += 1) == 3
-        retry
-      else
-        raise
-      end
-    end
-
+    load_page_with_retries(page, args)
     yield page if block_given?
   end
 
@@ -64,6 +82,22 @@ module FeatureSpecHelpers
 
   def snapshot
     screenshot_and_open_image
+  end
+
+  private
+
+  def load_page_with_retries(page, args, attempts: 0)
+    begin
+      page.load(args)
+    rescue Net::ReadTimeout
+      # Selenium and/or the browser may not be ready yet (especially on CI) so
+      # let's retry a few times...
+      if (attempts += 1) == 3
+        retry
+      else
+        raise
+      end
+    end
   end
 end
 


### PR DESCRIPTION
I got bored with how slow each integration is to start, and spend half a hour to implement a dirty token authentication for users, only available to the test environment.

Instead of loading the login page, fill the form, submit, be redirected to the dashboard, just to eventually open _another page_... it now authenticates in a single request, returning a mere 200 OK with a blank page.

Tests now start almost instantly, and the integration test suite is now ~25% faster on my local!