### PR TITLE
Removing references to wicked_pdf in BoxReports PDF export

### DIFF
--- a/app/views/samples_reports/_pdf_report.haml
+++ b/app/views/samples_reports/_pdf_report.haml
@@ -7,7 +7,7 @@
   .samples-report{id:'samples-report'}
     .report-content 
       .report-header
-        = image_tag wicked_pdf_asset_base64('cdx-logo-bw.png')
+        = image_tag "cdx-logo-bw-.png"
         %span
           Box Report: #{@samples_report.name}
           %br
@@ -52,10 +52,8 @@
       %br
       = render 'confusion_matrix'
 
-      .pdf-page-break
-
       .report-header
-        = image_tag wicked_pdf_asset_base64('cdx-logo-bw.png')
+        = image_tag "cdx-logo-bw.png"
         %span
           Box Report: #{@samples_report.name}
           %br
@@ -77,7 +75,7 @@
       - if @purpose == "LOD"
         .pdf-page-break
         .report-header
-          = image_tag wicked_pdf_asset_base64('cdx-logo-bw.png')
+          = image_tag "cdx-logo-bw.png"
           %span
             Box Report: #{@samples_report.name}
             %br
@@ -99,7 +97,7 @@
       - if @purpose == "Challenge"
         .pdf-page-break
         .report-header
-          = image_tag wicked_pdf_asset_base64('cdx-logo-bw.png')
+          = image_tag "cdx-logo-bw.png"
           %span
             Box Report: #{@samples_report.name}
             %br


### PR DESCRIPTION
Closes #1873.

Removed the dependency to wicked_pdf library, not needed in the new ruby version.

Also: small bugfix removing an extra page break.