### PR TITLE
Fix/1883 wrong alignment upload sample results

### DIFF
--- a/app/views/samples/_upload_results_js.haml
+++ b/app/views/samples/_upload_results_js.haml
@@ -82,23 +82,23 @@
                 var fragment = template.cloneNode(true);
 
                 fragment.querySelector(`.uploaded-samples-count`).textContent = `${samples.length} Samples ` ;
+                fragment.querySelector(`.file-name`).textContent = `${f.name}`;
+                
                 if (found.length != samples.length){
                     fragment.querySelector(`.uploaded-samples-count`).innerHTML += `(<span class="dashed-underline">${(not_found.length)} sample UUID${(not_found.length>1?'s':'')}</span> not found) `
                     fragment.querySelector(`.upload-icon`).classList.add(`icon-alert`,`icon-red`)
                     fragment.querySelector(`.items-row-action`).classList.add(`ttip`,`input-required`)
-                }
-                else {
-                    fragment.querySelector(`.upload-icon`).classList.add(`icon-check`)
-                    fragment.querySelector(`.ttext`).classList.remove(`not-found-uuids`)
-                }
-                fragment.querySelector(`.file-name`).textContent = `${f.name}`;
-                // if samples were not found add mouse behaviour to display tooltip
-                if (found.length != samples.length) {
+
+                    // Add mouse behaviour to display tooltip
                     var ttext = fragment.querySelector(".ttext")
                     ttext.innerHTML = not_found.slice(0,5).join("<br>")
                     // Modify classList here won't work because of class order
                     fragment.querySelector(".not_found_message").tooltip = ttext
                     fragment.querySelector(".not_found_message").addEventListener('click', showToolTip, false )
+                }
+                else {
+                    fragment.querySelector(`.upload-icon`).classList.add(`icon-check`)
+                    fragment.querySelector(`.ttext`).remove()
                 }
                 
                 // Bind click event to remove button


### PR DESCRIPTION
Closes #1883.

Small fix to restore the proper alignment when uploading files with sample results. Now it looks like this:

![image](https://user-images.githubusercontent.com/13782680/216086334-7c8fa2d2-a45a-4667-bd69-56807cc0c692.png)

Also, some code reorganization to avoid repeating the same condition.

