### PR TITLE
Fix: remove concentrations button in box form

### DIFF
--- a/app/assets/javascripts/random_key.js
+++ b/app/assets/javascripts/random_key.js
@@ -1,0 +1,19 @@
+function cdxGenRandomKey(items) {
+  var keys;
+  var key;
+
+  if (items) {
+    keys = items.map(function (item) { return item.key });
+  } else {
+    keys = [];
+  }
+
+  do {
+    key = "xxxxxxxxxxxxxxxx".replace(/[x]/g, function (c) {
+      const r = Math.floor(Math.random() * 16);
+      return r.toString(16);
+    });
+  } while (keys.indexOf(key) != -1);
+
+  return key;
+}

--- a/app/assets/javascripts/random_key.js
+++ b/app/assets/javascripts/random_key.js
@@ -1,12 +1,6 @@
 function cdxGenRandomKey(items) {
-  var keys;
+  var keys = (items || []).map(function (item) { return item.key; });
   var key;
-
-  if (items) {
-    keys = items.map(function (item) { return item.key });
-  } else {
-    keys = [];
-  }
 
   do {
     key = "xxxxxxxxxxxxxxxx".replace(/[x]/g, function (c) {

--- a/spec/features/boxes_spec.rb
+++ b/spec/features/boxes_spec.rb
@@ -47,6 +47,12 @@ describe "boxes" do
           batch_form.remove_concentrations[1].click
           expect(batch_form.remove_concentrations.size).to eq(2)
 
+          # it kept the first & last concentrations:
+          expect(batch_form.replicate_fields[0].value).to eq("2")
+          expect(batch_form.concentration_fields[0].value).to eq("10")
+          expect(batch_form.replicate_fields[1].value).to eq("4")
+          expect(batch_form.concentration_fields[1].value).to eq("1000")
+
           # validates replicate field:
           field = batch_form.replicate_fields[0]
           field.set(0)


### PR DESCRIPTION
We can't use the array index to identify as a react key when the array is dynamic.

fixes #1885 