### PR TITLE
Rename box reports as reports

### DIFF
--- a/app/assets/javascripts/components/samples_reports_bar_chart.js.jsx
+++ b/app/assets/javascripts/components/samples_reports_bar_chart.js.jsx
@@ -1,4 +1,4 @@
-var BoxReportsBarChart = React.createClass({
+var SamplesReportsBarChart = React.createClass({
   getDefaultProps: function() {
     return {
       margin: {top: 20, right: 20, bottom: 50, left: 50},

--- a/app/assets/javascripts/components/samples_reports_line_chart.js.jsx
+++ b/app/assets/javascripts/components/samples_reports_line_chart.js.jsx
@@ -1,4 +1,4 @@
-var BoxReportsLineChart = React.createClass({
+var SamplesReportsLineChart = React.createClass({
     getDefaultProps: function() {
       return {
         margin: {top: 0, right: 50, bottom: 50, left: 50},

--- a/app/assets/javascripts/components/samples_reports_roc_chart.js.jsx
+++ b/app/assets/javascripts/components/samples_reports_roc_chart.js.jsx
@@ -1,4 +1,4 @@
-var BoxReportsRocChart = React.createClass({
+var SamplesReportsRocChart = React.createClass({
     getDefaultProps: function() {
       return {
         margin: {top: 50, right: 50, bottom: 50, left: 50},

--- a/app/controllers/samples_reports_controller.rb
+++ b/app/controllers/samples_reports_controller.rb
@@ -58,7 +58,7 @@ class SamplesReportsController < ApplicationController
     @samples_report.samples_report_samples = samples_report_samples
 
     if @samples_report.save
-      redirect_to samples_reports_path, notice: 'Box report was successfully created.'
+      redirect_to samples_reports_path, notice: 'Report was successfully created.'
     else
       render action: 'new'
     end
@@ -92,14 +92,14 @@ class SamplesReportsController < ApplicationController
   
     @samples_report.destroy
     
-    redirect_to samples_reports_path, notice: 'Box report was successfully deleted.'
+    redirect_to samples_reports_path, notice: 'Report was successfully deleted.'
   end
   
   def bulk_destroy
     samples_reports_ids = params[:samples_report_ids]
   
     if samples_reports_ids.blank?
-      redirect_to samples_reports_path, notice: 'Select at least one box report to destroy.'
+      redirect_to samples_reports_path, notice: 'Select at least one report to destroy.'
       return
     end
   
@@ -108,7 +108,7 @@ class SamplesReportsController < ApplicationController
   
     samples_reports.destroy_all
   
-    redirect_to samples_reports_path, notice: 'Box reports were successfully deleted.'
+    redirect_to samples_reports_path, notice: 'Reports were successfully deleted.'
   end
 
   def find_box

--- a/app/views/samples_reports/_filters.haml
+++ b/app/views/samples_reports/_filters.haml
@@ -6,7 +6,7 @@
           %h1
             - if @can_create
               = link_to "+", new_samples_report_path, class: 'btn-add side-link fix', title: 'Add Report'
-            Reports
+            Samples Reports
 
       %form#filters-form{action: samples_reports_path, "data-auto-submit" => true}
         %input{type: "hidden", name: "page_size", value: @page_size}

--- a/app/views/samples_reports/_filters.haml
+++ b/app/views/samples_reports/_filters.haml
@@ -5,8 +5,8 @@
         .col
           %h1
             - if @can_create
-              = link_to "+", new_samples_report_path, class: 'btn-add side-link fix', title: 'Add Box Report'
-            Box Reports
+              = link_to "+", new_samples_report_path, class: 'btn-add side-link fix', title: 'Add Report'
+            Reports
 
       %form#filters-form{action: samples_reports_path, "data-auto-submit" => true}
         %input{type: "hidden", name: "page_size", value: @page_size}

--- a/app/views/samples_reports/_pdf_report.haml
+++ b/app/views/samples_reports/_pdf_report.haml
@@ -9,7 +9,7 @@
       .report-header
         = image_tag "cdx-logo-bw-.png"
         %span
-          Box Report: #{@samples_report.name}
+          Report: #{@samples_report.name}
           %br
           Created at #{@samples_report.created_at.strftime(I18n.t('date.input_format.pattern'))}
       %br
@@ -55,7 +55,7 @@
       .report-header
         = image_tag "cdx-logo-bw.png"
         %span
-          Box Report: #{@samples_report.name}
+          Report: #{@samples_report.name}
           %br
           Created at #{@samples_report.created_at.strftime(I18n.t('date.input_format.pattern'))}
       .title
@@ -64,7 +64,7 @@
       %br
       %br
       %div
-        = react_component('BoxReportsBarChart', 
+        = react_component('SamplesReportsBarChart', 
                     data: @reports_data, 
                     height: 300, 
                     barVariable: "average",
@@ -77,7 +77,7 @@
         .report-header
           = image_tag "cdx-logo-bw.png"
           %span
-            Box Report: #{@samples_report.name}
+            Report: #{@samples_report.name}
             %br
             Created at #{@samples_report.created_at.strftime(I18n.t('date.input_format.pattern'))}
         
@@ -87,7 +87,7 @@
         %br
         %br
         %div
-          = react_component('BoxReportsLineChart', 
+          = react_component('SamplesReportsLineChart', 
                       data: @reports_data, 
                       height: 400, 
                       width: 600, 
@@ -99,7 +99,7 @@
         .report-header
           = image_tag "cdx-logo-bw.png"
           %span
-            Box Report: #{@samples_report.name}
+            Report: #{@samples_report.name}
             %br
             Created at #{@samples_report.created_at.strftime(I18n.t('date.input_format.pattern'))}
         
@@ -109,7 +109,7 @@
         %br
         %br
         %div
-        = react_component('BoxReportsRocChart',
+        = react_component('SamplesReportsRocChart',
           data: roc_curve(@samples_report))
 
 :javascript

--- a/app/views/samples_reports/index.haml
+++ b/app/views/samples_reports/index.haml
@@ -9,7 +9,7 @@
           %p Use reports to analize sample results
     - else
       =form_tag bulk_action_samples_reports_path, :id => 'samples_report_form' , :method => :post do
-        = cdx_table title: pluralize(@total, "box report") do |t|
+        = cdx_table title: pluralize(@total, "report") do |t|
           - t.actions do
             -if @can_delete
               =button_tag id: 'bulk_destroy', class: 'btn-link', name: 'bulk_action', value: 'destroy', data: { method: "delete", confirm: "You're about to permanently delete the selected reports. This action CANNOT be undone. Are you sure you want to proceed?" } do

--- a/app/views/samples_reports/new.haml
+++ b/app/views/samples_reports/new.haml
@@ -6,6 +6,6 @@
           %h2
             = link_to samples_reports_path, class: 'side-link', title: 'Back' do
               = image_tag "arrow-left-white.png"
-            New Box Report
+            New Report
 
 = render 'form'

--- a/app/views/samples_reports/show.haml
+++ b/app/views/samples_reports/show.haml
@@ -52,7 +52,7 @@
 
         - if @can_delete
           .report-summary-after
-            =link_to delete_samples_report_path, id: @samples_report.id, data: { method: "delete", confirm: "You're about to permanently delete this box report. This action CANNOT be undone. Are you sure you want to proceed?" } do
+            =link_to delete_samples_report_path, id: @samples_report.id, data: { method: "delete", confirm: "You're about to permanently delete this report. This action CANNOT be undone. Are you sure you want to proceed?" } do
               .subtitle
                 = icon_tag "trash", class: "btn-icon icon-text-color"
                 Delete Report
@@ -80,7 +80,7 @@
             .separation 
             .title
               Measured signal
-            = react_component('BoxReportsBarChart', 
+            = react_component('SamplesReportsBarChart', 
                         data: @reports_data, 
                         height: 300, 
                         barVariable: "average",
@@ -92,7 +92,7 @@
               .separation 
               .title
                 Limit of detection
-              = react_component('BoxReportsLineChart', 
+              = react_component('SamplesReportsLineChart', 
                           data: @reports_data, 
                           height: 300, 
                           dotsVariable: "measurements",
@@ -103,7 +103,7 @@
               .separation 
               .title
                 ROC Curve
-              = react_component('BoxReportsRocChart',
+              = react_component('SamplesReportsRocChart',
                 data: roc_curve(@samples_report))
 
 :javascript

--- a/app/views/shared/_header_nav.haml
+++ b/app/views/shared/_header_nav.haml
@@ -32,7 +32,7 @@
               %li{:class => params[:controller] == "transfer_packages" && "active"}
                 = link_to "Transfers", transfer_packages_path
               %li{:class => params[:controller] == "samples_reports" && "active"}
-                = link_to "Box Reports", samples_reports_path
+                = link_to "Reports", samples_reports_path
         - if has_access_to_test_results_index?
           %li{:class => ["test_results", "encounters"].include?(params[:controller]) && "active"}
             = link_to "Tests", test_results_path


### PR DESCRIPTION
Closes #1860.

Following the last comments on the issue, `Box reports` labels on the site were changed to `Reports.

Regarding the comment

> I would also change the page title to "Sample reports"

The index view doesn't have a specific title but is `Connected Diagnostics Platform` then I didn't do anything regarding this (or I need further clarification).

Also, to enhance the naming clarity along the project, the `box_reports_*` d3 charts where renamed to `samples_reports_*`. 
