### PR TITLE
Feature/1877 validate samples when creating boxes

### DIFF
--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -113,7 +113,7 @@ class BoxesController < ApplicationController
     samples = if @box.blinded? && !params[:unblind]
       samples.scrambled
     else
-      samples.sort_by{ |sample|  [ sample.batch_number , sample.concentration , sample.replicate ] }
+      samples.sort_by{ |sample|  [ sample.batch_number ? sample.batch_number : "" , sample.concentration , sample.replicate ] }
     end
     SamplePresenter.map(samples, request.format, unblind: params[:unblind])
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -235,6 +235,8 @@ class SamplesController < ApplicationController
       :concentration,
       :replicate,
       :media,
+      :distractor,
+      :instruction,
       :measured_signal,
       assay_attachments_attributes: [:id, :loinc_code_id, :result, :assay_file_id, :_destroy],
       notes_attributes: [:id, :description, :updated_at, :user_id, :_destroy],

--- a/spec/features/boxes_spec.rb
+++ b/spec/features/boxes_spec.rb
@@ -267,10 +267,14 @@ describe "boxes" do
     end
 
     describe "add_samples" do
+      let(:v_1) { Batch.make!(institution: institution, batch_number: "VIRUS-1") }
+      let(:v_2) { Batch.make!(institution: institution, batch_number: "VIRUS-2") }
+      let(:d_1) { Batch.make!(institution: institution, batch_number: "DISTRACTOR-1") }
+
       let(:purpose) { Box.purposes.sample }
-      let(:sample_1) { Sample.make!(:filled, institution: institution, batch: Batch.make!(institution: institution, batch_number: "VIRUS-1") ) }
-      let(:sample_2) { Sample.make!(:filled, institution: institution, batch: Batch.make!(institution: institution, batch_number: "VIRUS-2") ) }
-      let(:sample_3) { Sample.make!(:filled, institution: institution, distractor: true) }
+      let(:sample_1) { Sample.make!(:filled, institution: institution, batch: v_1) }
+      let(:sample_2) { Sample.make!(:filled, institution: institution, batch: v_2) }
+      let(:sample_3) { Sample.make!(:filled, institution: institution, batch: d_1, distractor: true) }
       let(:sample_qc) { Sample.make!(:filled, institution: institution, specimen_role: "q") }
       
       it "adds and removes samples" do

--- a/spec/features/boxes_spec.rb
+++ b/spec/features/boxes_spec.rb
@@ -267,14 +267,10 @@ describe "boxes" do
     end
 
     describe "add_samples" do
-      let(:v_1) { Batch.make!(institution: institution, batch_number: "VIRUS-1") }
-      let(:v_2) { Batch.make!(institution: institution, batch_number: "VIRUS-2") }
-      let(:d_1) { Batch.make!(institution: institution, batch_number: "DISTRACTOR-1") }
-
       let(:purpose) { Box.purposes.sample }
-      let(:sample_1) { Sample.make!(:filled, institution: institution, batch: v_1) }
-      let(:sample_2) { Sample.make!(:filled, institution: institution, batch: v_2) }
-      let(:sample_3) { Sample.make!(:filled, institution: institution, batch: d_1, distractor: true) }
+      let(:sample_1) { Sample.make!(:filled, institution: institution, batch: Batch.make!(institution: institution, batch_number: "VIRUS-1") ) }
+      let(:sample_2) { Sample.make!(:filled, institution: institution, batch: Batch.make!(institution: institution, batch_number: "VIRUS-2") ) }
+      let(:sample_3) { Sample.make!(:filled, institution: institution, distractor: true) }
       let(:sample_qc) { Sample.make!(:filled, institution: institution, specimen_role: "q") }
       
       it "adds and removes samples" do

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -177,6 +177,7 @@ Sample.blueprint(:filled) do
   specimen_role { "p" }
   date_produced { Faker::Time.backward }
   measured_signal { 10.0 }
+  batch { object.encounter.try(:batch) || Batch.make! }
 end
 
 Sample.blueprint(:batch) do


### PR DESCRIPTION
Closes #1877.

Before the PR itself, two small fixes: 
- In Samples form, both `distractor` and `instruction` properties were not saved if modified because they were not included in the `samples_controller` as attributes.
- In `boxes_controller`, on the `add_samples` scenario, the samples could not belong to any batch, making the `sort_by` for the samples list to fail. 

For the PR: 
- Added validations for the box as described in the issue.
- Added new specs to validate this behavior. 
