### PR TITLE
Warning about duplicated uuids on sample results upload

### DIFF
--- a/app/views/samples/_upload_results_js.haml
+++ b/app/views/samples/_upload_results_js.haml
@@ -58,10 +58,11 @@
                 var samples = [] // samples uuids
                 var duplicates = false
                 lines.forEach(function(line) { 
-                    if (line != '' && isUUID(line.split(',')[0])){
-                        if (samples.indexOf(line.split(',')[0]) == -1){
-                            samples_param.push( 'uuids[]=' + line.split(',')[0] );
-                            samples.push( line.split(',')[0] );
+                    var row = line.split(',');
+                    if (line != '' && isUUID(row[0])){
+                        if (samples.indexOf(row[0]) == -1){
+                            samples_param.push( 'uuids[]=' + row[0] );
+                            samples.push( row[0] );
                         }
                         else {
                             duplicates = true;

--- a/app/views/samples/_upload_results_js.haml
+++ b/app/views/samples/_upload_results_js.haml
@@ -56,11 +56,16 @@
                 var lines = text.split(/\r\n|\r|\n/); // tolerate both Windows and Unix linebreaks
                 var samples_param = [] // params for GET call
                 var samples = [] // samples uuids
-
+                var duplicates = false
                 lines.forEach(function(line) { 
                     if (line != '' && isUUID(line.split(',')[0])){
-                        samples_param.push( 'uuids[]=' + line.split(',')[0] );
-                        samples.push( line.split(',')[0] );
+                        if (samples.indexOf(line.split(',')[0]) == -1){
+                            samples_param.push( 'uuids[]=' + line.split(',')[0] );
+                            samples.push( line.split(',')[0] );
+                        }
+                        else {
+                            duplicates = true;
+                        }
                     } 
                 });
                 
@@ -111,7 +116,7 @@
                 fragment.querySelector(".remove_file").addEventListener('click', removeFileRow, false)
 
                 // If some samples were not found, show a warning modal
-                if (not_found.length > 0) {
+                if (not_found.length > 0 || duplicates) {
                     document.querySelector(`.results-upload-error-modal-container`).style.visibility = 'visible';
                     confirmFunc = function() {
                         document.querySelector(`.results-upload-error-modal-container`).style.visibility = 'hidden';

--- a/app/views/samples/upload_results.haml
+++ b/app/views/samples/upload_results.haml
@@ -58,8 +58,8 @@
                       confirmFunction: "confirmFunc", 
                       id: "my-confirmation-modal", 
                       colorClass: "red", 
-                      confirmMessage: "Skip invalid IDs", 
+                      confirmMessage: "Skip invalid/duplicated IDs", 
                       title: "Results Upload Error", 
-                      message: "Some IDs found on this CSV don't exist, please remove those rows and try again. ")
+                      message: "Some IDs found on this CSV are duplicated or don't exist, please remove those rows and try again. ")
 
 = render 'upload_results_js'


### PR DESCRIPTION
Closes #1891.

Upon uploading results files for samples, if there were duplicated uuids, there was a wrong behavior on the count of found and not found uuids.
As was discussed in the text of the issue, now, if there are invalid or duplicated sample uuids, this modal is shown:

![image](https://user-images.githubusercontent.com/13782680/216608567-f67437ef-a926-41f8-8b58-3687feaed24c.png)

And then, inform invalid uuids (nonexistent within CDx user), the warning is shown just as before:

![image](https://user-images.githubusercontent.com/13782680/216608598-fbdce629-d9da-4fee-9dda-98c0525feb90.png)

But for valid duplicated samples, the system now just ignores its second appearance, as in this file that contains twice the same sample:

![image](https://user-images.githubusercontent.com/13782680/216608621-86b52f41-90e7-4362-a2a6-95b4eecbca1c.png)
