### PR TITLE
GHA: cancel previous workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - "**:**"
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -11,6 +11,10 @@ name: CI (next)
 #    branches:
 #      - "**:**"
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml


### PR DESCRIPTION
This avoids race conditions when merging multiple pull requests in a row, where the action from a previous run would finish *after* the action from the last merge, and thus push a docker image that isn't the latest (but still acts as the latest).

It also avoids building & pushing multiple docker images when only the last one is interesting and ought to be pushed.

We also don't need to keep running previous tests in a branch when we push a new commit.