### PR TITLE
Feature/1814 upload csv with new box

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -180,10 +180,12 @@
 
 .btn-upload {
   color: $blue;
+  font-weight: 300;
 }
 
 .btn-download {
   color: $gray-medium;
+  font-weight: 300;
 }
 
 .pager {

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -28,6 +28,11 @@ class BatchesController < ApplicationController
     @batches = check_access(batches, READ_BATCH).pluck(:uuid, :batch_number)
   end
 
+  def existing_batch_number
+    uuids = Batch.where(institution: @navigation_context.institution, batch_number: params[:batch_number]).pluck(:uuid)
+    render json: { status: :ok, message: uuids }
+  end
+
   def edit_or_show
     batch = Batch.find(params[:id])
 

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -133,14 +133,14 @@ class BoxesController < ApplicationController
 
   def box_params
     if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 0
-      params.require(:box).permit(:purpose, :media, :blinded, :option).tap do |allowed|
+      params.require(:box).permit(:purpose, :media, :blinded, :option, :csv_box).tap do |allowed|
         allowed[:batches] = params[:box][:batches].try(&:permit!)
         allowed[:sample_uuids] = params[:box][:sample_uuids].try(&:permit!)
         allowed[:concentrations] = params[:box][:concentrations].try(&:permit!)
       end
     else
       params.require(:box)
-        .permit(:purpose, :media, :blinded, :option, sample_uuids: [], batches: [
+        .permit(:purpose, :media, :blinded, :option, :csv_box, sample_uuids: [], batches: [
           :batch_uuid, :distractor, :instruction, concentrations: [:replicate, :concentration]
         ])
     end

--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -1,4 +1,4 @@
-= cdx_form_for(@box_form) do |f|
+= cdx_form_for(@box_form, html: { multipart: true }) do |f|
   .row
     .col
       .row.form-field
@@ -20,6 +20,8 @@
           = f.label :option, "Create new samples", value: "add_batches"
           = f.radio_button :option, "add_samples"
           = f.label :option, "Select samples from inventory", value: "add_samples"
+          = f.radio_button :option, "add_csv"
+          = f.label :option, "Create from CSV file", value: "add_csv"
 
       .row.form-field
         .col.form-field__label
@@ -33,7 +35,25 @@
             = react_component "SamplesSelector", { url: autocomplete_samples_path(format: "json", context: params[:context], qc: 0),
               name: "box[sample_uuids]", placeholder: "Enter sample id", className: "input-block",
               samples: @box_form.samples_data }
+          
+          %fieldset#add_csv{ :disabled => @box_form.option != "add_csv", :style => (@box_form.option == "add_csv" ? "" : "display: none") }
+            #uploaded-files
 
+            .row
+              = button_tag id: 'add-box-file', class: 'btn-link', type: "button" do
+                .icon-circle-plus.icon-blue.icon-margin
+                %span.btn-upload
+                  Add file
+            .row
+              =link_to '/templates/upload_box.csv', class: 'btn-link', target: "_blank" do
+                .icon-download.icon-gray
+                %span.btn-download
+                  CSV template
+            .row.errors.hidden#csv-file-error
+              No samples were found in the CSV file or it has an invalid format. 
+              %br
+              Please check the template and try again.
+              
   .row
     .col
       = f.check_box :blinded
@@ -54,6 +74,8 @@
                       title: "Warning",
                       message: "If you change the sample source, the box contents will be emptied. ")
 
+= render 'upload_csv_box'
+
 :javascript
   var sourcesRadio = document.querySelectorAll(".radiotoggle input");
   var oldSource = null;
@@ -73,6 +95,9 @@
     // Clear the selectors contents
     document.querySelector(".clear-batches").click()
     document.querySelector(".clear-samples").click()
+    // Clear the CSV file and re-enable the add button
+    document.getElementById("uploaded-files").innerHTML = "";
+    document.getElementById(`add-box-file`).style.display = 'block';
   }
 
   function showConfirmModal() {

--- a/app/views/boxes/_upload_csv_box.haml
+++ b/app/views/boxes/_upload_csv_box.haml
@@ -1,0 +1,146 @@
+
+%template{:id => "csvFileRow"}
+  .list-items.upload_info
+    .items-row
+      .items-item.gap-5
+        .icon-circle-minus.icon-gray.remove_file
+        .file-name
+      .items-row-action.gap-5.not_found_message
+        .uploaded-samples-count
+        .upload-icon.bigger
+        .ttext.not-found-uuids.hidden
+        
+%template{:id => "csvInputFile"}
+  = file_field_tag "box[csv_box]", hidden: true, class: "csv_file", accept: "text/csv"
+
+:javascript
+  var getUrlParameter = function getUrlParameter(sParam) {
+      var sPageURL = window.location.search.substring(1),
+          sURLVariables = sPageURL.split('&'),
+          sParameterName,
+          i;
+
+      for (i = 0; i < sURLVariables.length; i++) {
+          sParameterName = sURLVariables[i].split('=');
+
+          if (sParameterName[0] === sParam) {
+              return sParameterName[1] === undefined ? true : decodeURIComponent(sParameterName[1]);
+          }
+      }
+      return false;
+  };
+
+  var context = getUrlParameter('context');
+  var isUUID = function(str) {
+    const regexExp = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+    return regexExp.test(str);
+  };
+
+  var showToolTip = function(evt) {
+    var tooltip = evt.currentTarget.tooltip
+    if (tooltip.classList.contains("hidden")) {
+        tooltip.classList.remove("hidden")
+        setTimeout(() => tooltip.classList.add("hidden"), 5000)
+    }
+    else {
+        tooltip.classList.toggle("hidden")
+    }
+  }
+
+  // Add file button behaviour
+  function handleFileSelect(change_event) {
+    // We use the 1st file from the FileList list
+    let f = change_event.target.files[0];
+    let reader = new FileReader();
+
+    // Closure to capture the file information.
+    reader.onload = (function(f) {
+      return async(load_event) => {
+        // Parse the input file
+        var text =  load_event.target.result
+        var lines = text.split(/\r\n|\r|\n/); // tolerate both Windows and Unix linebreaks
+        
+        var fieldNames = ['Batch','Concentration','Distractor','Instructions']
+        var samples = []
+        var startParsing = false;
+        
+        var found_batches = new Set()
+        var not_found_batches = new Set()
+        
+        for (const line of lines) {
+          var fields = line.split(',')
+          if (startParsing && fields.length >= fieldNames.length) {
+            var sample = {}
+            fieldNames.forEach( async field => { sample[field] = fieldNames.indexOf(field) })
+            if (!found_batches.has(fields[0])) {
+              // Check if the batch number exists
+              var found = await fetch('/batches/existing_batch_number?context='+context+"&batch_number="+fields[0])
+                .then((response) => response.json())
+                .then((r) => { return r.message; })
+              
+              found.length > 0 ? found_batches.add(fields[0]) : not_found_batches.add(fields[0])
+            }
+            if (not_found_batches.has(fields[0])) continue;
+            samples.push(sample);
+          }
+          if ( !startParsing && _.isEqual(fields, fieldNames) ) startParsing = true;
+        }
+        
+        if (samples.length == 0) {
+          document.getElementById(`csv-file-error`).classList.remove(`hidden`);
+        } 
+        else {
+          // Create row from template with filename and upload info
+          var template = document.getElementById(`csvFileRow`).content;
+          var fragment = template.cloneNode(true);
+
+          fragment.querySelector(`.uploaded-samples-count`).textContent = `${samples.length} Samples ` ;
+          fragment.querySelector(`.upload-icon`).classList.add(`icon-checkmark`)
+          fragment.querySelector(`.file-name`).textContent = `${f.name}`;
+          
+          // Bind click event to remove button
+          var removeFileRow = function(evt) {
+              evt.currentTarget.upload_info.remove();
+              change_event.target.remove();
+              document.getElementById(`add-box-file`).style.display = 'block';
+          }
+          fragment.querySelector(".remove_file").upload_info = fragment.querySelector(`.upload_info`)
+          fragment.querySelector(".remove_file").addEventListener('click', removeFileRow, false)
+
+          // Add tooltip to display not found batches
+          if (not_found_batches.size > 0) {
+            fragment.querySelector(`.uploaded-samples-count`).innerHTML += `(<span class="dashed-underline">${(not_found_batches.size)} batch${(not_found_batches.size>1?'es':'')}</span> not found) `
+            fragment.querySelector(`.upload-icon`).classList.add(`icon-alert`,`icon-red`)
+            fragment.querySelector(`.items-row-action`).classList.add(`ttip`,`input-required`)
+
+            // Add mouse behaviour to display tooltip
+            var ttext = fragment.querySelector(".ttext")
+            ttext.innerHTML = Array.from(not_found_batches).slice(0,5).join("<br>")
+
+            fragment.querySelector(".not_found_message").tooltip = ttext
+            fragment.querySelector(".not_found_message").addEventListener('click', showToolTip, false )
+          } else {
+            fragment.querySelector(`.upload-icon`).classList.add(`icon-check`)
+            fragment.querySelector(`.ttext`).remove()
+          }
+
+          document.getElementById(`uploaded-files`).append(fragment);
+          document.getElementById(`add-box-file`).style.display = 'none';
+          document.getElementById(`csv-file-error`).classList.add(`hidden`);
+        }
+        
+      }
+    })(f);
+    reader.readAsText(f);
+  }
+
+  // Upon pressing the "Add file" button we will create a file input and click it
+  document.getElementById(`add-box-file`).addEventListener('click', function (e) {
+    var template = document.getElementById(`csvInputFile`).content;
+    var fragment = template.cloneNode(true);
+    var fileInput = fragment.querySelector('.csv_file');
+    document.getElementById(`uploaded-files`).append(fragment)
+    
+    fileInput.addEventListener('change', handleFileSelect, false);
+    fileInput.click();
+  })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,7 @@ Rails.application.routes.draw do
     end
     collection do
       get 'autocomplete'
+      get 'existing_batch_number'
       post 'bulk_action', constraints: lambda { |request| request.params[:bulk_action] == 'destroy' }, action: :bulk_destroy
     end
   end

--- a/features/support/page_objects/new_box_page.rb
+++ b/features/support/page_objects/new_box_page.rb
@@ -45,6 +45,11 @@ class NewBoxPage < CdxPageBase
   section :search_sample, CdxSelect, ".samples-selector .Select"
   sections :sample_summaries, SampleSummary, ".sample-summary"
 
+  element :add_csv, "label[for='box_option_add_csv']"
+  element :add_csv_button, ".add-link", text: "ADD CSV"
+  element :add_file_button, ".btn-upload", text: "ADD FILE"
+  element :csv_box, ".csv_file", visible: false
+
   element :submit_button, :button, "Save"
 
   def fill(purpose: nil, media: nil, option: nil)
@@ -58,6 +63,9 @@ class NewBoxPage < CdxPageBase
     when "add_samples"
       add_samples.click
       wait_until_samples_selector_visible
+    when "add_csv"
+      add_csv.click
+      wait_until_add_file_button_visible
     end
   end
 
@@ -81,6 +89,12 @@ class NewBoxPage < CdxPageBase
   def add_sample(sample)
     add_sample_button.click unless has_search_sample?(wait: 0)
     search_sample.paste(sample.uuid)
+  end
+
+  def add_csv_file(csv_path)
+    add_file_button.click 
+    wait_until_csv_box_visible
+    attach_file(csv_box, File.absolute_path(csv_path)) unless has_csv_box?(wait: 0)
   end
 
   def submit

--- a/public/templates/upload_box.csv
+++ b/public/templates/upload_box.csv
@@ -1,0 +1,9 @@
+Batch,Concentration,Distractor,Instructions
+batch1,100,no,Add 175 ml of media
+batch1,100,no,Add 175 ml of media
+batch1,1000,no,Add 175 ml of media
+batch1,1000,no,Add 175 ml of media
+batch2,2,yes,Add 250 ml of media
+batch2,2,yes,Add 250 ml of media
+batch2,200,yes,Add 100 ml of media
+batch2,200,yes,Add 100 ml of media

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -442,6 +442,98 @@ RSpec.describe BoxesController, type: :controller do
         end.to change(institution.boxes, :count).by(0)
       end
     end
+
+    describe "from csv file" do
+      it "create box from csv file" do
+        Batch.make!(institution: institution, site: site, batch_number: "DISTRACTOR")
+        file_path = File.join(Rails.root, 'spec', 'fixtures', 'csvs', 'csv_box_1.csv')
+        file = fixture_file_upload(file_path, 'text/csv')
+        expect do
+          post :create, params: { box: { purpose: "LOD", 
+                                       media: "Saliva", 
+                                       option: "add_csv", 
+                                       csv_box: file,
+                                       blinded: false } }
+        
+          expect(response).to redirect_to boxes_path
+        end.to change(institution.boxes, :count).by(1)
+        expect(Box.last.samples.count).to eq(4)
+      end
+
+      it "don't create box if invalid csv file" do
+        file_path = File.join(Rails.root, 'spec', 'fixtures', 'csvs', 'samples_results_1.csv')
+        file = fixture_file_upload(file_path, 'text/csv')
+        expect do
+          post :create, params: { box: { purpose: "LOD", 
+                                       media: "Saliva", 
+                                       option: "add_csv", 
+                                       csv_box: file,
+                                       blinded: false } }
+        
+          expect(response).to have_http_status(:unprocessable_entity)
+        end.to change(institution.boxes, :count).by(0)
+      end
+
+      it "create Challenge box if distractors and virus samples are present" do
+        Batch.make!(institution: institution, site: site, batch_number: "VIRUS")
+        Batch.make!(institution: institution, site: site, batch_number: "DISTRACTOR")
+        file_path = File.join(Rails.root, 'spec', 'fixtures', 'csvs', 'csv_box_2.csv')
+        file = fixture_file_upload(file_path, 'text/csv')
+        expect do
+          post :create, params: { box: { purpose: "Challenge", 
+                                       media: "Saliva", 
+                                       option: "add_csv", 
+                                       csv_box: file,
+                                       blinded: false } }
+        end.to change(institution.boxes, :count).by(1)
+        expect(Box.last.samples.count).to eq(6)
+      end
+
+      it "don't create Challenge box if no distractors are present" do
+        Batch.make!(institution: institution, site: site, batch_number: "DISTRACTOR")
+        file_path = File.join(Rails.root, 'spec', 'fixtures', 'csvs', 'csv_box_1.csv')
+        file = fixture_file_upload(file_path, 'text/csv')
+        expect do
+          post :create, params: { box: { purpose: "Challenge", 
+                                       media: "Saliva", 
+                                       option: "add_csv", 
+                                       csv_box: file,
+                                       blinded: false } }
+        
+          expect(response).to have_http_status(:unprocessable_entity)
+        end.to change(institution.boxes, :count).by(0)
+      end
+
+      it "create Variants box if samples from two batches are present" do
+        Batch.make!(institution: institution, site: site, batch_number: "VIRUS")
+        Batch.make!(institution: institution, site: site, batch_number: "DISTRACTOR")
+        file_path = File.join(Rails.root, 'spec', 'fixtures', 'csvs', 'csv_box_2.csv')
+        file = fixture_file_upload(file_path, 'text/csv')
+        expect do
+          post :create, params: { box: { purpose: "Variants", 
+                                       media: "Saliva", 
+                                       option: "add_csv", 
+                                       csv_box: file,
+                                       blinded: false } }
+        end.to change(institution.boxes, :count).by(1)
+        expect(Box.last.samples.count).to eq(6)
+      end
+
+      it "don't create Variants box if samples from two batches aren't present" do
+        Batch.make!(institution: institution, site: site, batch_number: "DISTRACTOR")
+        file_path = File.join(Rails.root, 'spec', 'fixtures', 'csvs', 'csv_box_1.csv')
+        file = fixture_file_upload(file_path, 'text/csv')
+        expect do
+          post :create, params: { box: { purpose: "Variants", 
+                                       media: "Saliva", 
+                                       option: "add_csv", 
+                                       csv_box: file,
+                                       blinded: false } }
+        
+          expect(response).to have_http_status(:unprocessable_entity)
+        end.to change(institution.boxes, :count).by(0)
+      end
+    end
   end
 
   describe "destroy" do

--- a/spec/features/boxes_spec.rb
+++ b/spec/features/boxes_spec.rb
@@ -379,6 +379,27 @@ describe "boxes" do
           expect(form.media_field.value).to eq(media)
         end
       end
+
+      let(:distractor) { Batch.make!(institution: institution, batch_number: "DISTRACTOR") }
+
+      it "can create a from a CSV file" do
+        goto_page NewBoxPage do |form|
+          form.fill(purpose: "LOD", media: media, option: "add_csv")
+          form.add_csv_file('/src/spec/fixtures/csvs/csv_box_1.csv')
+          form.submit
+          puts form.errors.text
+        end
+
+        expect_page ListBoxesPage do |page|
+          expect(page.entries.size).to eq(1)
+          page.entries.last.uuid.click
+        end
+
+        expect_page ShowBoxPage do |page|
+          expect(page.samples.size).to eq(1)
+          expect(page.samples[0]).to have_text(sample_1.uuid)
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/csvs/csv_box_1.csv
+++ b/spec/fixtures/csvs/csv_box_1.csv
@@ -1,0 +1,5 @@
+Batch,Concentration,Distractor,Instructions
+DISTRACTOR,10,no,Add 10ml
+DISTRACTOR,10,no,Add 10ml
+DISTRACTOR,20,no,Add 10ml
+DISTRACTOR,20,no,Add 10ml

--- a/spec/fixtures/csvs/csv_box_2.csv
+++ b/spec/fixtures/csvs/csv_box_2.csv
@@ -1,0 +1,7 @@
+Batch,Concentration,Distractor,Instructions
+VIRUS,10,no,Add 10ml
+VIRUS,10,no,Add 10ml
+DISTRACTOR,10,yes,Add 10ml
+DISTRACTOR,10,yes,Add 10ml
+DISTRACTOR,20,yes,Add 10ml
+DISTRACTOR,20,yes,Add 10ml


### PR DESCRIPTION
Closes #1814 

Now a box can be created from a CSV file. To agree with the excel files that they use in order to define box samples concentrations, they should look like this.

![image](https://user-images.githubusercontent.com/13782680/217325106-c796127f-b859-4c4a-9967-95999d9a74a9.png)

This is the file that you can download as a template file when you choose the new option in the boxes form:

![image](https://user-images.githubusercontent.com/13782680/217325898-7b1b4d7d-2bda-41ad-909b-05d232b3b20f.png)

If the file is correct, it will respect the mockups done for the sample's upload results page:

![image](https://user-images.githubusercontent.com/13782680/217326353-f0aae269-7934-425e-9c7b-1a99687a967a.png)

If, within the file, some rows have inexistent batches, they will be informed:

![image](https://user-images.githubusercontent.com/13782680/217326725-94becdb3-7641-476b-8ca5-e17040ad7592.png)

While this message will be shown if no samples have been parsed (because they are not, or because the file has a wrong file format, etc):

![image](https://user-images.githubusercontent.com/13782680/217326988-06e2cb81-a9fd-40d8-8a5b-12fa848c41e0.png)

Comments on the code:
- The way the upload works is, within `box_form`, the file is parsed and the same parameters as if the user has chosen the option `Create new samples` options are fulfilled and saved (`initialize_csv_box` method)
-  The upload CSV is done with templates and plain JS, as for the upload samples results. Should be good to generalize, or, maybe better, create a React component that does this.
- On Capybara, only the creation of boxes is tested, while the functioning of the validations for this new `add_csv` option is tested on the controller (as previously discussed).
