### PR TITLE
Allow to enter zero concentration in boxes creation

### DIFF
--- a/app/assets/javascripts/components/box_batches_form.js.jsx
+++ b/app/assets/javascripts/components/box_batches_form.js.jsx
@@ -301,7 +301,7 @@ var BoxBatchForm = React.createClass({
   },
 
   isValidConcentration: function (c) {
-    return (parseInt(c.replicate, 10) > 0 && parseFloat(c.concentration, 10) > 0);
+    return (parseInt(c.replicate, 10) > 0 && parseFloat(c.concentration, 10) >= 0);
   },
 
   hideForm: function (event) {

--- a/app/assets/stylesheets/_batches.scss
+++ b/app/assets/stylesheets/_batches.scss
@@ -170,13 +170,9 @@
   display: flex;
   align-items: center;
   margin-left: auto;
-  
-  .icon-check {
-    width: 24px;
-    height: 24px;
-    margin-left: 10px;
-    background-size: 100%;
-    cursor: pointer;
+
+  >input{
+    width: 80px;
   }
 }
 

--- a/spec/features/boxes_spec.rb
+++ b/spec/features/boxes_spec.rb
@@ -64,8 +64,11 @@ describe "boxes" do
 
           # validates concentration field:
           field = batch_form.concentration_fields[0]
-          field.set(0)
+          field.set(-1)
           expect(batch_form.ok.disabled?).to be(true)
+
+          field.set(0)
+          expect(batch_form.ok.disabled?).to be(false)
 
           field.set(2)
           expect(batch_form.ok.disabled?).to be(false)


### PR DESCRIPTION
Closes #1901.

Small fix to allow create new samples in the box at zero concentration. As you can see, the button is enabled:

![image](https://user-images.githubusercontent.com/13782680/217591360-f38e6e30-bc6b-4fe3-b188-ffce87bf45b0.png)

Also, marked as a bonus, the width of the concentration field was increased to 80px, which allows more comfortable visualization of scientific notation: 

![image](https://user-images.githubusercontent.com/13782680/217591734-0f91fab4-0dde-4fe7-98e8-ee053bd89c84.png)

Also, some dead code css was removed.

