### PR TITLE
use bundle exec for rake command so it doesn't fail on a version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Reference implementation for the Connected Diagnostics API (http://dxapi.org/)
 
 4. Setup development db, test db and elasticsearch index template:
 	```
-	$ docker-compose run --rm web rake db:setup db:test:prepare elasticsearch:setup
+	$ docker-compose run --rm web bundle exec rake db:setup db:test:prepare elasticsearch:setup
 	```
 
 ### Additionally setup for importing Loinc Codes


### PR DESCRIPTION
This is a very small patch to the instructions so that the db rake tasks succeed. When I tried this step, it failed with a rake version mismatch and the error message indicated to prefix the command with `bundle exec`. Other than this, the instructions worked great to set up a working dev env.