### PR TITLE
Linked CSV download to 'Create CSV' option

### DIFF
--- a/app/views/boxes/_form.haml
+++ b/app/views/boxes/_form.haml
@@ -46,10 +46,6 @@
                 %span.btn-upload
                   = file_field_tag "box[csv_box]", class: "csv_file", accept: "text/csv"
             .row
-              #validating-spinner.hidden
-                .spinner
-          .spinner
-            .row
               =link_to '/templates/upload_box.csv', class: 'btn-link', target: "_blank" do
                 .icon-download.icon-gray
                 %span.btn-download


### PR DESCRIPTION
This pull request introduces changes to enhance the user experience by only displaying the CSV template download button when the 'Create from CSV file' option is selected in the form. 