### PR TITLE
Improve batch selection in box form

### DIFF
--- a/app/assets/javascripts/components/box_batches_form.js.jsx
+++ b/app/assets/javascripts/components/box_batches_form.js.jsx
@@ -56,6 +56,7 @@ var BoxBatchesForm = React.createClass({
             prepareOptions={this.prepareOptions}
             autoselect={true}
             onSelect={this.selectBatch}
+            autoselect={true}
           />
         </div>
       </div>


### PR DESCRIPTION
Close #1944 

Following @ysbaddaden comment on the issue and testing it locally, this small fix does what is needed, now batches are autoselected if the entered text is a perfect match with an existing batch. It has the expected behavior if the batch does not exist also. 

