### PR TITLE
Same order for inventory and label printing for boxes

### DIFF
--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -37,7 +37,9 @@ class BoxesController < ApplicationController
   def print
     return unless authorize_resource(@box, READ_BOX)
 
-    send_data BoxLabelPdf.render(@box, @box.samples.preload(:batch, :sample_identifiers)),
+    @samples = load_box_samples
+
+    send_data BoxLabelPdf.render(@box, @samples),
       filename: "cdx_box_#{@box.uuid}",
       type: "application/pdf",
       disposition: "inline"


### PR DESCRIPTION
Close #1948.

Since the method `load_box_samples` already made the `.preload(:batch, :sample_identifiers)` for the samples, this fix ensures that the printing of labels will be in the same order than the inventory. 

Since the awardee will not have the option of printing the labels, the "scrambled" part of this function will be never applied in the label printing. 
