### PR TITLE
General nih tables exporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: docker compose build web
       - uses: ./.github/actions/gems-cache
 
   unit:
@@ -73,6 +74,7 @@ jobs:
       - integration
     steps:
       - uses: actions/checkout@v3
+      - run: docker compose build web
       - uses: ./.github/actions/gems-cache
 
       - uses: actions/download-artifact@v3
@@ -81,6 +83,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: integration_tests_coverage
+
       - run: docker compose run --no-deps --rm web bundle exec rails coverage:report
 
       - uses: actions/upload-artifact@v3

--- a/app/controllers/nih_tables_controller.rb
+++ b/app/controllers/nih_tables_controller.rb
@@ -29,6 +29,7 @@ class NihTablesController < ApplicationController
     end
     zip_file
   end
+
   def add_general_samples_table(samples_report, zip_file)
     csv_file = Tempfile.new("#{samples_report.name}_samples.csv")
     csv_data = []

--- a/app/controllers/nih_tables_controller.rb
+++ b/app/controllers/nih_tables_controller.rb
@@ -1,17 +1,11 @@
+require 'csv'
+
 class NihTablesController < ApplicationController
   def show
     samples_report = SamplesReport.find(params[:id])
     return unless authorize_resource(samples_report, READ_SAMPLES_REPORT)
     
-    purpose = samples_report.samples[0].box.purpose
-    zip_file = create_zip_file(samples_report.name)
-  
-    if purpose == "LOD"
-    add_lod_table(zip_file)
-    elsif purpose == "Challenge"
-    add_challenge_table(zip_file)
-    end
-  
+    zip_file = create_zip_file(samples_report)
     zip_file.close
   
     send_zip_file(zip_file, samples_report.name)
@@ -19,19 +13,122 @@ class NihTablesController < ApplicationController
   
   private
   
-  def create_zip_file(filename)
-    zip_file = Tempfile.new("#{filename}_nih_tables.zip")
+  def create_zip_file(samples_report)
+    purpose = samples_report.samples[0].box.purpose
+    zip_file = Tempfile.new("#{samples_report.name}_nih_tables.zip")
     Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip|
-    zip.add("Instructions.txt", Rails.root.join('public/templates/Instructions.txt'))
+      zip.add("Instructions.txt", Rails.root.join('public/templates/Instructions.txt'))
+      add_general_samples_table(samples_report, zip)
+      add_general_results_table(samples_report, zip)
+
+      if purpose == "LOD"
+        add_lod_table(samples_report, zip_file)
+      elsif purpose == "Challenge"
+        add_challenge_table(samples_report, zip_file)
+      end
     end
     zip_file
   end
+  def add_general_samples_table(samples_report, zip_file)
+    csv_file = Tempfile.new("#{samples_report.name}_samples.csv")
+    csv_data = []
   
-  def add_lod_table(zip_file)
+    csv_data << [
+      'sample_id',
+      'vqa_box_id',
+      'sample_group',
+      'sample_media',
+      'sample_media_id',
+      'sample_media_source',
+      'sample_media_source_url',
+      'sample_concentration',
+      'sample_concentration_unit',
+      'sample_concentration_reference_gene',
+      'virus_sample_id',
+      'virus_batch_number',
+      'target_analyte_type',
+      'target_organism_name',
+      'target_organism_taxonomy_id',
+      'pango_lineage',
+      'who_label',
+      'virus_sample_inactivation_method'
+    ]
+  
+    samples_report.samples.each do |sample|
+      batch = Batch.find_by(batch_number: sample.batch_number)
+      csv_data << [
+        sample.id,
+        sample.box.uuid,
+        "#{sample.box.purpose}-panel",
+        nil,
+        nil,
+        nil,
+        nil,
+        sample.concentration,
+        'copies/ml',
+        batch.reference_gene,
+        sample.id,
+        sample.batch_number,
+        'inactivated virus',
+        'SARS-CoV-2',
+        batch.target_organism_taxonomy_id,
+        batch.pango_lineage,
+        batch.who_label,
+        sample.inactivation_method
+      ]
+    end
+  
+    CSV.open(csv_file.path, 'w') do |csv|
+      csv_data.each do |row|
+        csv << row
+      end
+    end
+  
+    zip_file.add("#{samples_report.name}_samples.csv", csv_file.path)
+  end
+  
+  def add_general_results_table(samples_report, zip_file)
+    csv_file = Tempfile.new("#{samples_report.name}_results.csv")
+    csv_data = []
+  
+    csv_data << [
+      'sample_id',
+      'vqa_box_id',
+      'sample_group',
+      'protocol_id',
+      'technology_platform',
+      'assay_readout',
+      'assay_readout_unit',
+      'assay_readout_description'
+    ]
+  
+    samples_report.samples.each do |sample|
+      csv_data << [
+        sample.id,
+        sample.box.uuid,
+        "#{sample.box.purpose}-panel",
+        nil,
+        nil,
+        sample.measured_signal,
+        nil,
+        nil
+      ]
+    end
+  
+    CSV.open(csv_file.path, 'w') do |csv|
+      csv_data.each do |row|
+        csv << row
+      end
+    end
+  
+    zip_file.add("#{samples_report.name}_results.csv", csv_file.path)
+  end
+
+  def add_lod_table(samples_report, zip_file)
     # TODO: Add the LOD table to the zip file
   end
   
-  def add_challenge_table(zip_file)
+  def add_challenge_table(samples_report, zip_file)
     # TODO: Add the Challenge table to the zip file
   end
   

--- a/app/controllers/nih_tables_controller.rb
+++ b/app/controllers/nih_tables_controller.rb
@@ -1,45 +1,44 @@
 class NihTablesController < ApplicationController
   def show
-    samples_report = SamplesReport.find(params[:id])
-    return unless authorize_resource(samples_report, READ_SAMPLES_REPORT)
+    @samples_report = SamplesReport.find(params[:id])
+    return unless authorize_resource(@samples_report, READ_SAMPLES_REPORT)
     
-    zip_file = create_zip_file(samples_report)
+    zip_file = create_zip_file
     zip_file.close
   
-    send_zip_file(zip_file, samples_report.name)
+    send_zip_file(zip_file)
   end
   
   private
   
-  def create_zip_file(samples_report)
-    purpose = samples_report.samples[0].box.purpose
-    zip_file = Tempfile.new("#{samples_report.name}_nih_tables.zip")
+  def create_zip_file
+    purpose = @samples_report.samples[0].box.purpose
+    zip_file = Tempfile.new("#{@samples_report.name}_nih_tables.zip")
     Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip|
       zip.add("Instructions.txt", Rails.root.join('public/templates/Instructions.txt'))
-      add_nih_table(samples_report, 'samples', zip)
-      add_nih_table(samples_report, 'results', zip)
+      add_nih_table('samples', zip)
+      add_nih_table('results', zip)
 
       if purpose == "LOD"
-        #add_nih_table(samples_report, 'lod', zip)
+        #add_nih_table('lod', zip)
       elsif purpose == "Challenge"
-        #add_nih_table(samples_report, 'challenge', zip)
+        #add_nih_table('challenge', zip)
       end
     end
     zip_file
   end
 
-  def add_nih_table(samples_report, table_name, zip_file)
-    csv_file = Tempfile.new("#{samples_report.name}_#{table_name}.csv")
+  def add_nih_table(table_name, zip_file)
+    csv_file = Tempfile.new("#{@samples_report.name}_#{table_name}.csv")
     
     csv_file.write(
-      render_to_string(:file => 'samples_reports/nih_'+table_name+'.csv.csvbuilder', :locals => { :samples_report => samples_report })
+      render_to_string('samples_reports/nih_'+table_name, formats: :csv)
     )
     csv_file.close
-
-    zip_file.add("#{samples_report.name}_#{table_name}.csv", csv_file.path)
+    zip_file.add("#{@samples_report.name}_#{table_name}.csv", csv_file.path)
   end
   
-  def send_zip_file(zip_file, filename)
-    send_file zip_file.path, type: 'application/zip', filename: "#{filename}_nih_tables.zip"
+  def send_zip_file(zip_file)
+    send_file zip_file.path, type: 'application/zip', filename: "#{@samples_report.name}_nih_tables.zip"
   end
 end

--- a/app/controllers/nih_tables_controller.rb
+++ b/app/controllers/nih_tables_controller.rb
@@ -3,42 +3,35 @@ class NihTablesController < ApplicationController
     @samples_report = SamplesReport.find(params[:id])
     return unless authorize_resource(@samples_report, READ_SAMPLES_REPORT)
     
-    zip_file = create_zip_file
-    zip_file.close
-  
-    send_zip_file(zip_file)
+    zip_data = create_zip_file
+    send_data zip_data.read, type: 'application/zip', filename: "#{@samples_report.name}_nih_tables.zip"
   end
   
   private
   
   def create_zip_file
     purpose = @samples_report.samples[0].box.purpose
-    zip_file = Tempfile.new("#{@samples_report.name}_nih_tables.zip")
-    Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip|
-      zip.add("Instructions.txt", Rails.root.join('public/templates/Instructions.txt'))
-      add_nih_table('samples', zip)
-      add_nih_table('results', zip)
+
+    zip_stream = Zip::OutputStream.write_buffer do |stream|
+      # Read public/templates/Instructions.txt contents and write to zip
+      stream.put_next_entry('Instructions.txt')
+      stream.write(File.read(Rails.root.join('public/templates/Instructions.txt')))
+
+      add_nih_table('samples', stream)
+      add_nih_table('results', stream)
 
       if purpose == "LOD"
-        #add_nih_table('lod', zip)
+        #add_nih_table('lod', stream)
       elsif purpose == "Challenge"
-        #add_nih_table('challenge', zip)
+        #add_nih_table('challenge', stream)
       end
     end
-    zip_file
+    zip_stream.rewind
+    zip_stream
   end
 
-  def add_nih_table(table_name, zip_file)
-    csv_file = Tempfile.new("#{@samples_report.name}_#{table_name}.csv")
-    
-    csv_file.write(
-      render_to_string('samples_reports/nih_'+table_name, formats: :csv)
-    )
-    csv_file.close
-    zip_file.add("#{@samples_report.name}_#{table_name}.csv", csv_file.path)
-  end
-  
-  def send_zip_file(zip_file)
-    send_file zip_file.path, type: 'application/zip', filename: "#{@samples_report.name}_nih_tables.zip"
+  def add_nih_table(table_name, stream)
+    stream.put_next_entry("#{@samples_report.name}_#{table_name}.csv")
+    stream.write(render_to_string('samples_reports/nih_'+table_name, formats: :csv))
   end
 end

--- a/app/views/samples_reports/nih_results.csv.csvbuilder
+++ b/app/views/samples_reports/nih_results.csv.csvbuilder
@@ -9,7 +9,7 @@ csv << [
   'assay_readout_description'
 ]
 
-samples_report.samples.each do |sample|
+@samples_report.samples.each do |sample|
   csv << [
     sample.id,
     sample.box.uuid,

--- a/app/views/samples_reports/nih_results.csv.csvbuilder
+++ b/app/views/samples_reports/nih_results.csv.csvbuilder
@@ -1,0 +1,23 @@
+csv << [
+  'sample_id',
+  'vqa_box_id',
+  'sample_group',
+  'protocol_id',
+  'technology_platform',
+  'assay_readout',
+  'assay_readout_unit',
+  'assay_readout_description'
+]
+
+samples_report.samples.each do |sample|
+  csv << [
+    sample.id,
+    sample.box.uuid,
+    "#{sample.box.purpose}-panel",
+    nil,
+    nil,
+    sample.measured_signal,
+    nil,
+    nil
+  ]
+end

--- a/app/views/samples_reports/nih_samples.csv.csvbuilder
+++ b/app/views/samples_reports/nih_samples.csv.csvbuilder
@@ -1,0 +1,44 @@
+csv << [
+  'sample_id',
+  'vqa_box_id',
+  'sample_group',
+  'sample_media',
+  'sample_media_id',
+  'sample_media_source',
+  'sample_media_source_url',
+  'sample_concentration',
+  'sample_concentration_unit',
+  'sample_concentration_reference_gene',
+  'virus_sample_id',
+  'virus_batch_number',
+  'target_analyte_type',
+  'target_organism_name',
+  'target_organism_taxonomy_id',
+  'pango_lineage',
+  'who_label',
+  'virus_sample_inactivation_method'
+]
+
+samples_report.samples.each do |sample|
+  batch = Batch.find_by(batch_number: sample.batch_number)
+  csv << [
+    sample.id,
+    sample.box.uuid,
+    "#{sample.box.purpose}-panel",
+    nil,
+    nil,
+    nil,
+    nil,
+    sample.concentration,
+    'copies/ml',
+    batch.reference_gene,
+    sample.id,
+    sample.batch_number,
+    'inactivated virus',
+    'SARS-CoV-2',
+    batch.target_organism_taxonomy_id,
+    batch.pango_lineage,
+    batch.who_label,
+    sample.inactivation_method
+  ]
+end

--- a/app/views/samples_reports/nih_samples.csv.csvbuilder
+++ b/app/views/samples_reports/nih_samples.csv.csvbuilder
@@ -19,7 +19,7 @@ csv << [
   'virus_sample_inactivation_method'
 ]
 
-samples_report.samples.each do |sample|
+@samples_report.samples.each do |sample|
   batch = Batch.find_by(batch_number: sample.batch_number)
   csv << [
     sample.id,

--- a/spec/controllers/nih_tables_controller_spec.rb
+++ b/spec/controllers/nih_tables_controller_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe NihTablesController, type: :controller do
     it "should download a zip file on show" do
       get :show, params: { id: @samples_report.id } 
     
-      #expect sent file to be a zip file
       expect(response.headers["Content-Type"]).to eq("application/zip")
       expect(response.headers["Content-Disposition"]).to eq("attachment; filename=\"Test_nih_tables.zip\"")
     end
@@ -34,7 +33,6 @@ RSpec.describe NihTablesController, type: :controller do
     it "should contain the Instructions.txt file" do
       get :show, params: { id: @samples_report.id }
       
-      #expect the zip file to contain the Instructions.txt file
       expect(Zip::File.open_buffer(response.body).entries.map(&:name)).to include("Instructions.txt")
     end
 
@@ -50,10 +48,8 @@ RSpec.describe NihTablesController, type: :controller do
 
       samples_table = CSV.parse(Zip::File.open_buffer(response.body).entries.find{|e| e.name == "Test_samples.csv"}.get_input_stream.read, headers: true)
       
-      #expect the samples table to contain the same number of rows as the samples report
       expect(samples_table.count).to eq(@samples_report.samples_report_samples.count)
 
-      #expect the id columns to contain the proper samples
       expect(samples_table["sample_id"]).to eq(@samples_report.samples_report_samples.map{|srs| srs.sample.id.to_s})
     end
 
@@ -62,10 +58,8 @@ RSpec.describe NihTablesController, type: :controller do
 
       samples_table = CSV.parse(Zip::File.open_buffer(response.body).entries.find{|e| e.name == "Test_results.csv"}.get_input_stream.read, headers: true)
       
-      #expect the samples table to contain the same number of rows as the samples report
       expect(samples_table.count).to eq(@samples_report.samples_report_samples.count)
 
-      #expect the id columns to contain the proper samples
       expect(samples_table["sample_id"]).to eq(@samples_report.samples_report_samples.map{|srs| srs.sample.id.to_s})
     end
 


### PR DESCRIPTION
Closes #1905.

The two general tables (samples & results) specified in the issue are generated as described in the text of the issue and added to the zip file downloaded when the user selects `Download NIH files`. 

The only commentary for the code I think is that the following line

`batch = Batch.find_by(batch_number: sample.batch_number)`

is used to load the batch instead of using `sample.batch` to allow loading fields for deleted batched.

