### PR TITLE
Fix: CI can't run the analysis step (docker error)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: docker compose build web
       - uses: ./.github/actions/gems-cache
 
   unit:
@@ -73,6 +74,7 @@ jobs:
       - integration
     steps:
       - uses: actions/checkout@v3
+      - run: docker compose build web
       - uses: ./.github/actions/gems-cache
 
       - uses: actions/download-artifact@v3
@@ -81,6 +83,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: integration_tests_coverage
+
       - run: docker compose run --no-deps --rm web bundle exec rails coverage:report
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
This is a bug introduced in docker compose v2.19.0: https://github.com/docker/compose/issues/10751