### PR TITLE
Fixes over distractor samples values on report creation

### DIFF
--- a/app/models/samples_report.rb
+++ b/app/models/samples_report.rb
@@ -76,7 +76,7 @@ class SamplesReport < ApplicationRecord
 
   # Returns any sample that isn't a distractor.
   def target_sample
-    target_sample = samples.where("distractor IS NULL or distractor = ?", false).take
+    target_sample = samples.find_by("distractor IS NULL or distractor = ?", false)
     target_sample ||= samples.take
   end
 

--- a/app/models/samples_report.rb
+++ b/app/models/samples_report.rb
@@ -76,7 +76,8 @@ class SamplesReport < ApplicationRecord
 
   # Returns any sample that isn't a distractor.
   def target_sample
-    samples.where.not(distractor: true).take!
+    target_sample = samples.where("distractor IS NULL or distractor = ?", false).take
+    target_sample ||= samples.take
   end
 
   private


### PR DESCRIPTION
Unfortunately, as Julien found, mysql translates != 1 to = !1 to = 0 and this makes the query for `sample.distractor` field not equal to 1 to don't work if the distractor field is equal to NULL, and this happens when boxes are created from the option `Create new samples`. 

This was fixed. 

Also, now we consider the edge case when all the samples are distractors in the box used to generate the report. This is not a use case that is expected but nothing blocks the user to do that. 

