### PR TITLE
Blinding new fields for samples on blind box creation

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -66,6 +66,11 @@ label {
     padding-top: 10px;
   }
 }
+
+.blinded { 
+  line-height: 2.6em;
+}
+
 .blinded, .blinded i {
   color: $gray2;
 }

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -89,7 +89,7 @@ class Box < ApplicationRecord
 
   # Returns the full list of sample attributes that can be blinded.
   def self.blind_attribute_names
-    %i[batch_number concentration replicate virus_lineage isolate_name]
+    %i[batch_number concentration replicate virus_lineage isolate_name reference_gene target_organism_taxonomy_id pango_lineage who_label]
   end
 
   # Returns true if a sample attribute should be blinded for the current box.

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -66,16 +66,20 @@
           .span.unit (μl)
 
       = f.form_field :reference_gene do
-        = autocomplete_field(f, "sample[reference_gene]", :reference_gene, @navigation_context.institution, class: "input-x-large")
+        - @sample_form.blinded_attribute(:reference_gene) do
+          = autocomplete_field(f, "sample[reference_gene]", :reference_gene, @navigation_context.institution, class: "input-x-large")
 
       = f.form_field :target_organism_taxonomy_id do
-        = autocomplete_field(f, "sample[target_organism_taxonomy_id]", :target_organism_taxonomy_id, @navigation_context.institution, class: "input-x-large")
+        - @sample_form.blinded_attribute(:target_organism_taxonomy_id) do
+          = autocomplete_field(f, "sample[target_organism_taxonomy_id]", :target_organism_taxonomy_id, @navigation_context.institution, class: "input-x-large")
 
       = f.form_field :pango_lineage do
-        = autocomplete_field(f, "sample[pango_lineage]", :pango_lineage, @navigation_context.institution, class: "input-x-large")
+        - @sample_form.blinded_attribute(:pango_lineage) do
+          = autocomplete_field(f, "sample[pango_lineage]", :pango_lineage, @navigation_context.institution, class: "input-x-large")
 
       = f.form_field :who_label do
-        = autocomplete_field(f, "sample[who_label]", :who_label, @navigation_context.institution, class: "input-x-large")
+        - @sample_form.blinded_attribute(:who_label) do
+          = autocomplete_field(f, "sample[who_label]", :who_label, @navigation_context.institution, class: "input-x-large")
 
       = f.form_field :concentration do
         - @sample_form.blinded_attribute(:concentration) do

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -193,6 +193,10 @@ RSpec.describe SamplesController, type: :controller do
         assert_select "input[name='sample[replicate]']", count: 0
         assert_select "input[name='sample[virus_lineage]']", count: 0
         assert_select "input[name='sample[isolate_name]']", count: 0
+        assert_select "input[name='sample[reference_gene]']", count: 0
+        assert_select "input[name='sample[target_organism_taxonomy_id]']", count: 0
+        assert_select "input[name='sample[pango_lineage]']", count: 0
+        assert_select "input[name='sample[who_label]']", count: 0
       end
     end
   end


### PR DESCRIPTION
Closes #1976.

New fields added for samples are blindable now.

 As an extra, the alignment of the blinded fields was corrected in the form, since it was incorrect. Now, in staging and production looks like this:

![image](https://github.com/instedd/cdx/assets/13782680/433a8f54-2042-45e5-9bf8-9438510b5a2e)

And now it looks like this:
![image](https://github.com/instedd/cdx/assets/13782680/ab3c1b1f-1a65-4b42-bc1b-b7c8bb62c9db)
