### PR TITLE
Button allowing to copy uuid for each sample in box detail

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -229,4 +229,9 @@
   &:hover {
     border: 1px solid #999;
   }
+
+  &.v-aligned-box-detail{
+    position: absolute;
+    left: 300px;
+  }
 }

--- a/app/views/boxes/show.haml
+++ b/app/views/boxes/show.haml
@@ -60,7 +60,7 @@
               .items-item
                 .copy-content
                   = sample.uuid
-                %button.btn-copy.ttip.left
+                %button.btn-copy.ttip.v-aligned-box-detail
                   = icon_tag "copy", class: "btn-icon"
               - unless sample.blinded_attribute?(:batch_number)
                 .sample-row-action= sample.batch_number

--- a/app/views/boxes/show.haml
+++ b/app/views/boxes/show.haml
@@ -57,7 +57,11 @@
         - @samples.each do |sample|
           .col.pe-7.list-items.box-sample-row
             .items-row
-              .items-item= sample.uuid
+              .items-item
+                .copy-content
+                  = sample.uuid
+                %button.btn-copy.ttip.left
+                  = icon_tag "copy", class: "btn-icon"
               - unless sample.blinded_attribute?(:batch_number)
                 .sample-row-action= sample.batch_number
 


### PR DESCRIPTION
Closes #1967 

Now, in the box detail, there is a button allowing the copy for each sample uuid composing the box.

![image](https://github.com/instedd/cdx/assets/13782680/8cc311fd-2cab-45c9-8a19-8e656fefeb49)
