### PR TITLE
Fix: ensure that samples' measured signals are floats

### DIFF
--- a/db/migrate/20230731140544_fix_samples_measured_signals.rb
+++ b/db/migrate/20230731140544_fix_samples_measured_signals.rb
@@ -1,0 +1,17 @@
+class FixSamplesMeasuredSignals < ActiveRecord::Migration[5.0]
+  def up
+    # make sure measured signals are always a float (the entity framework
+    # deletes the attribute from the core_fields when it's nil):
+    Sample
+      .where("core_fields LIKE '%measured_signal%'")
+      .preload(:sample_identifiers)
+      .find_each do |sample|
+        sample.measured_signal = sample.measured_signal.presence&.to_f
+        sample.save(validate: false)
+      end
+  end
+
+  def down
+    # nothing to do
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20221223203602) do
+ActiveRecord::Schema.define(version: 20230731140544) do
 
   create_table "alert_condition_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci" do |t|
     t.string  "result"


### PR DESCRIPTION
I believe normalizing the value should fix samples reports related issues in staging, and it won't hurt to run them in production, to make sure that the values, when present, are floats, not a blank string or a float string.

closes #1966 
closes #1968 