### PR TITLE
Added column replicates in CSV box creation

### DIFF
--- a/app/assets/javascripts/components/upload_csv_box.js.jsx
+++ b/app/assets/javascripts/components/upload_csv_box.js.jsx
@@ -93,16 +93,16 @@ var UploadCsvBox = React.createClass({
 
   const rowContent = errorMessage ?
     <div className="uploaded-samples-count">
-      {uploadedSamplesCount} {samplesText}
-      {batchesNotFound > 0 && (
-        <span className="dashed-underline">
-          {" ("}{batchesNotFound} {batchesText} not found{")"}
-        </span>
-      )}
-    </div> :
-    <div className="uploaded-samples-count">
       {errorMessage}
-    </div>;
+    </div>:
+    <div className="uploaded-samples-count">
+     {uploadedSamplesCount} {samplesText}
+     {batchesNotFound > 0 && (
+       <span className="dashed-underline">
+         {" ("}{batchesNotFound} {batchesText} not found{")"}
+       </span>
+     )}
+   </div>;
 
   return (
     <div className="items-row" key={filename}>

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -80,7 +80,6 @@ class BoxesController < ApplicationController
 
     @found_batches = @navigation_context.institution.batches.where(batch_number: batch_numbers.to_a).pluck(:batch_number)
     @not_found_batches = (batch_numbers - @found_batches)
-
   end
 
   def create

--- a/app/models/box_form.rb
+++ b/app/models/box_form.rb
@@ -217,7 +217,7 @@ class BoxForm
           instruction: row["Instructions"],
           concentrations: {
             "0" => {
-              replicate: 1,
+              replicate: row["Replicates"],
               concentration: Integer(Float(row["Concentration"]&.strip)),
             },
           },

--- a/app/models/box_form.rb
+++ b/app/models/box_form.rb
@@ -217,7 +217,7 @@ class BoxForm
           instruction: row["Instructions"],
           concentrations: {
             "0" => {
-              replicate: row["Replicates"],
+              replicate: row["Replicates"].to_i,
               concentration: Integer(Float(row["Concentration"]&.strip)),
             },
           },

--- a/public/templates/upload_box.csv
+++ b/public/templates/upload_box.csv
@@ -1,9 +1,5 @@
-Batch,Concentration,Distractor,Instructions
-batch1,100,no,Add 175 ml of media
-batch1,100,no,Add 175 ml of media
-batch1,1000,no,Add 175 ml of media
-batch1,1000,no,Add 175 ml of media
-batch2,2,yes,Add 250 ml of media
-batch2,2,yes,Add 250 ml of media
-batch2,200,yes,Add 100 ml of media
-batch2,200,yes,Add 100 ml of media
+Batch,Concentration,Distractor,Instructions,Replicates
+borrar,100,no,Add 175 ml of media,2
+borrar,1000,no,Add 175 ml of media,2
+Blank,2,yes,Add 250 ml of media,4
+Blank,200,yes,Add 100 ml of media,4

--- a/spec/controllers/boxes_controller_spec.rb
+++ b/spec/controllers/boxes_controller_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe BoxesController, type: :controller do
     end
 
     it "validates CSV headers" do
-      csv_file = fixture_file_upload(Rails.root.join("spec/fixtures/csvs/samples_results_1.csv"), "text/csv")
+      csv_file = fixture_file_upload(Rails.root.join("spec/fixtures/csvs/csv_box_no_headers.csv"), "text/csv")
 
       expect do
         post :validate, params: { csv_box: csv_file }, format: "json"
@@ -292,7 +292,7 @@ RSpec.describe BoxesController, type: :controller do
       expect(JSON.parse(response.body)).to eq({
         "found_batches" => ["DISTRACTOR"],
         "not_found_batches" => [],
-        "samples_count" => 3,
+        "samples_count" => 4,
       })
     end
 
@@ -307,7 +307,7 @@ RSpec.describe BoxesController, type: :controller do
       expect(JSON.parse(response.body)).to eq({
         "found_batches" => ["DISTRACTOR"],
         "not_found_batches" => ["VIRUS"],
-        "samples_count" => 5,
+        "samples_count" => 6,
       })
     end
   end

--- a/spec/fixtures/csvs/csv_box_1.csv
+++ b/spec/fixtures/csvs/csv_box_1.csv
@@ -1,5 +1,3 @@
-Batch,Concentration,Distractor,Instructions
-DISTRACTOR,10,no,Add 10ml
-DISTRACTOR,10,no,Add 10ml
-DISTRACTOR,20,no,Add 10ml
-DISTRACTOR,20,no,Add 10ml
+Batch,Concentration,Distractor,Instructions,Replicates
+DISTRACTOR,10,no,Add 10ml,2
+DISTRACTOR,20,no,Add 10ml,2

--- a/spec/fixtures/csvs/csv_box_no_headers.csv
+++ b/spec/fixtures/csvs/csv_box_no_headers.csv
@@ -1,4 +1,3 @@
-Batch,Concentration,Distractor,Instructions,Replicates
 VIRUS,10,no,Add 10ml,2
 DISTRACTOR,10,yes,Add 10ml,2
 DISTRACTOR,20,yes,Add 10ml,2


### PR DESCRIPTION
Closes #1972.

When creating a box from a CSV file, a new column asking for the number of `Replicates` was added, and the samples will be created with the according replicate number (before all the samples had `replicate=1`).

Two errors were fixed: 

- Error messages were not correctly shown in the `rowContent`, this was reported by Muhammad but not corrected, not sure why but no issue was created. It was due to an inversed condition. 
- The first row of the uploaded CSV was always ignored. The specs were written but the number of expected samples was one less than the ones in the CSV files used for testing.
