### PR TITLE
Blinding date_produced for samples and keeping samples order for send…

### DIFF
--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -143,7 +143,7 @@ class BoxesController < ApplicationController
 
   def load_box_samples
     samples = @box.samples.preload(:batch, :sample_identifiers)
-    samples = if @box.blinded? && !params[:unblind]
+    samples = if @box.blinded? && !params[:unblind] && @box.transferred?
       samples.scrambled
     else
       samples.order(:id)

--- a/app/documents/label_pdf.rb
+++ b/app/documents/label_pdf.rb
@@ -41,7 +41,7 @@ class LabelPdf < BasePdf
     text_lines [
       "I.N. #{sample.isolate_name}".truncate(22),
       "I.M. #{sample.inactivation_method}".truncate(22),
-      "P.D. #{sample.date_produced == "Blinded" ? "Blinded" : sample.date_produced.strftime("%m/%d/%Y")}",
+      "P.D. #{sample.blinded_attribute?(:date_produced) ? sample.date_produced : sample.date_produced.strftime("%m/%d/%Y")}",
     ], leading: -0.5
   end
 

--- a/app/documents/label_pdf.rb
+++ b/app/documents/label_pdf.rb
@@ -41,7 +41,7 @@ class LabelPdf < BasePdf
     text_lines [
       "I.N. #{sample.isolate_name}".truncate(22),
       "I.M. #{sample.inactivation_method}".truncate(22),
-      "P.D. #{sample.date_produced.strftime("%m/%d/%Y")}",
+      "P.D. #{sample.date_produced == "Blinded" ? "Blinded" : sample.date_produced.strftime("%m/%d/%Y")}",
     ], leading: -0.5
   end
 

--- a/app/documents/label_pdf.rb
+++ b/app/documents/label_pdf.rb
@@ -41,7 +41,7 @@ class LabelPdf < BasePdf
     text_lines [
       "I.N. #{sample.isolate_name}".truncate(22),
       "I.M. #{sample.inactivation_method}".truncate(22),
-      "P.D. #{sample.blinded_attribute?(:date_produced) ? sample.date_produced : sample.date_produced.strftime("%m/%d/%Y")}",
+      "P.D. #{sample.blinded_attribute(:date_produced) { sample.date_produced.strftime("%m/%d/%Y") }}",
     ], leading: -0.5
   end
 

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -89,7 +89,7 @@ class Box < ApplicationRecord
 
   # Returns the full list of sample attributes that can be blinded.
   def self.blind_attribute_names
-    %i[batch_number concentration replicate virus_lineage isolate_name]
+    %i[batch_number concentration replicate virus_lineage isolate_name date_produced]
   end
 
   # Returns true if a sample attribute should be blinded for the current box.

--- a/app/views/boxes/inventory.csv.csvbuilder
+++ b/app/views/boxes/inventory.csv.csvbuilder
@@ -20,7 +20,7 @@ csv << [
     sample.virus_lineage,
     sample.replicate,
     sample.concentration,
-    sample.date_produced == "Blinded" ? "Blinded" : sample.date_produced.to_date,
+    sample.blinded_attribute?(:date_produced) ? sample.date_produced : sample.date_produced.to_date,
     sample.inactivation_method,
     sample.media,
   ]

--- a/app/views/boxes/inventory.csv.csvbuilder
+++ b/app/views/boxes/inventory.csv.csvbuilder
@@ -20,7 +20,7 @@ csv << [
     sample.virus_lineage,
     sample.replicate,
     sample.concentration,
-    sample.blinded_attribute?(:date_produced) ? sample.date_produced : sample.date_produced.to_date,
+    sample.blinded_attribute(:date_produced) { sample.date_produced.to_date },
     sample.inactivation_method,
     sample.media,
   ]

--- a/app/views/boxes/inventory.csv.csvbuilder
+++ b/app/views/boxes/inventory.csv.csvbuilder
@@ -20,7 +20,7 @@ csv << [
     sample.virus_lineage,
     sample.replicate,
     sample.concentration,
-    sample.date_produced.to_date,
+    sample.date_produced == "Blinded" ? "Blinded" : sample.date_produced.to_date,
     sample.inactivation_method,
     sample.media,
   ]

--- a/app/views/samples/_barcode_card.haml
+++ b/app/views/samples/_barcode_card.haml
@@ -19,7 +19,7 @@
     .code
       %strong
         Production Date:
-      #{@sample_form.date_produced.try{ strftime("%m/%d/%Y")}}
+      #{@sample_form ? @sample_form.date_produced : @sample_form.date_produced.try{ strftime("%m/%d/%Y")}}
     .logo
       = image_tag 'cdx-logo-bw.png'
       .label https://cdx.io

--- a/app/views/samples/_barcode_card.haml
+++ b/app/views/samples/_barcode_card.haml
@@ -19,7 +19,7 @@
     .code
       %strong
         Production Date:
-      #{@sample_form ? @sample_form.date_produced : @sample_form.date_produced.try{ strftime("%m/%d/%Y")}}
+      #{@sample_form.blinded_attribute(:date_produced){ @sample_form.date_produced.try { strftime("%m/%d/%Y") } } }
     .logo
       = image_tag 'cdx-logo-bw.png'
       .label https://cdx.io

--- a/app/views/samples/_form.haml
+++ b/app/views/samples/_form.haml
@@ -33,7 +33,8 @@
   .row
     .col
       = f.form_field :date_produced do
-        = f.date_field :date_produced, readonly: !@can_update
+        - @sample_form.blinded_attribute(:date_produced) do
+          = f.date_field :date_produced, readonly: !@can_update
 
       = f.form_field :lab_technician do
         = f.text_field :lab_technician, :class => 'input-x-large', readonly: !@can_update


### PR DESCRIPTION
As requested by the client: Blinding date_produced for samples and keeping samples order for sender institution.

Note: for the date field, in order to make things work when blinded, I had to compare to "Blinded" string, which does not feel like the best solution possible.

