### PR TITLE
Small fix properly blind production date

### DIFF
--- a/app/views/boxes/inventory.csv.csvbuilder
+++ b/app/views/boxes/inventory.csv.csvbuilder
@@ -20,7 +20,7 @@ csv << [
     sample.virus_lineage,
     sample.replicate,
     sample.concentration,
-    sample.blinded_attribute(:date_produced) { sample.date_produced.to_date },
+    params[:unblind] ? sample.date_produced.to_date : sample.blinded_attribute(:date_produced) { sample.date_produced.to_date },
     sample.inactivation_method,
     sample.media,
   ]


### PR DESCRIPTION
Small fix to properly blind production date, that needs a conversion to_date. It was shown as blinded on the unblinded inventory downloading.